### PR TITLE
feat(secmaster): new resource to manage shipper

### DIFF
--- a/docs/resources/secmaster_siem_shipper.md
+++ b/docs/resources/secmaster_siem_shipper.md
@@ -1,0 +1,185 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_siem_shipper"
+description: |-
+  Manages a SIEM shipper resource within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_siem_shipper
+
+Manages a SIEM shipper resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "shipper_name" {}
+
+resource "huaweicloud_secmaster_siem_shipper" "test" {
+  consumption_type = 0
+  dataspace_id     = "xxx"
+  dataspace_name   = "xxx"
+  domain_id        = "xxx"
+  pipe_id          = "xxx"
+  pipe_name        = "xxx"
+  project_id       = "xxx"
+  region           = "cn-north-4"
+  shipper_name     = var.shipper_name
+  version          = "v1"
+  workspace_id     = var.workspace_id
+  workspace_name   = "xxx"
+
+  shipper_destination {
+    data_param                 = jsonencode({})
+    destination_dataspace      = "xxx"
+    destination_dataspace_name = "xxx"
+    destination_identity_role  = "pipe-strategy"
+    destination_pipe           = "xxx"
+    destination_pipe_name      = "xxx"
+    destination_region         = "cn-north-4"
+    destination_shipper_type   = 0
+    destination_workspace      = "xxx"
+    destination_workspace_name = "xxx"
+  }
+
+  shipper_source {
+    region                = "cn-north-4"
+    source_dataspace      = "xxx"
+    source_dataspace_name = "xxx"
+    source_identity_role  = "pipe-strategy"
+    source_pipe           = "xxx"
+    source_pipe_name      = "xxx"
+    source_type           = 0
+    source_workspace      = "xxx"
+    source_workspace_name = "xxx"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the SIEM shipper belongs.
+
+* `shipper_name` - (Required, String, NonUpdatable) Specifies the name of the SIEM shipper.
+
+* `consumption_type` - (Optional, Int, NonUpdatable) Specifies the consumption type.
+  **0** means real-time, **1** means scheduled.
+
+* `dataspace_id` - (Optional, String, NonUpdatable) Specifies the data space ID.
+
+* `dataspace_name` - (Optional, String, NonUpdatable) Specifies the data space name.
+
+* `domain_id` - (Optional, String, NonUpdatable) Specifies the domain ID.
+
+* `pipe_id` - (Optional, String, NonUpdatable) Specifies the pipe ID.
+
+* `pipe_name` - (Optional, String, NonUpdatable) Specifies the pipe name.
+
+* `project_id` - (Optional, String, NonUpdatable) Specifies the project ID.
+
+* `shipper_destination` - (Optional, List, NonUpdatable) Specifies the shipper destination configuration.
+  The [shipper_destination](#shipper_destination_block) structure is documented below.
+
+* `shipper_source` - (Optional, List, NonUpdatable) Specifies the shipper source configuration.
+  The [shipper_source](#shipper_source_block) structure is documented below.
+
+* `version` - (Optional, String, NonUpdatable) Specifies the version information.
+
+* `workspace_name` - (Optional, String, NonUpdatable) Specifies the workspace name.
+
+* `action` - (Optional, String) Specifies the operation to perform on the SIEM shipper. Valid values are:
+  + **pause**: Permitted only when the delivery status is "in delivery".
+  + **resume**: Permitted only when the delivery status is "Pending".
+  + **retry**: Resubmission is only possible when the authorization status is "Cancelled".
+
+<a name="shipper_destination_block"></a>
+The `shipper_destination` block supports:
+
+* `data_param` - (Optional, String, NonUpdatable) Specifies the data parameter, usually in JSON format.
+
+* `destination_dataspace` - (Optional, String, NonUpdatable) Specifies the destination data space ID.
+
+* `destination_dataspace_name` - (Optional, String, NonUpdatable) Specifies the destination data space name.
+
+* `destination_identity_role` - (Optional, String, NonUpdatable) Specifies the destination identity role.
+
+* `destination_pipe` - (Optional, String, NonUpdatable) Specifies the destination pipe ID.
+
+* `destination_pipe_name` - (Optional, String, NonUpdatable) Specifies the destination pipe name.
+
+* `destination_region` - (Optional, String, NonUpdatable) Specifies the destination region.
+
+* `destination_shipper_type` - (Optional, Int, NonUpdatable) Specifies the destination shipper type.
+
+* `destination_workspace` - (Optional, String, NonUpdatable) Specifies the destination workspace ID.
+
+* `destination_workspace_name` - (Optional, String, NonUpdatable) Specifies the destination workspace name.
+
+<a name="shipper_source_block"></a>
+The `shipper_source` block supports:
+
+* `region` - (Optional, String, NonUpdatable) Specifies the source region.
+
+* `source_dataspace` - (Optional, String, NonUpdatable) Specifies the source data space ID.
+
+* `source_dataspace_name` - (Optional, String, NonUpdatable) Specifies the source data space name.
+
+* `source_identity_role` - (Optional, String, NonUpdatable) Specifies the source identity role.
+
+* `source_pipe` - (Optional, String, NonUpdatable) Specifies the source pipe ID.
+
+* `source_pipe_name` - (Optional, String, NonUpdatable) Specifies the source pipe name.
+
+* `source_type` - (Optional, Int, NonUpdatable) Specifies the source type.
+
+* `source_workspace` - (Optional, String, NonUpdatable) Specifies the source workspace ID.
+
+* `source_workspace_name` - (Optional, String, NonUpdatable) Specifies the source workspace name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the shipper name.
+
+* `shipper_id` - The shipper ID.
+
+* `status` - The status of the SIEM shipper.
+
+* `create_time` - The creation time, in milliseconds.
+
+* `update_time` - The update time, in milliseconds.
+
+## Import
+
+The SIEM shipper can be imported using the `workspace_id` and the `shipper_name`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_secmaster_siem_shipper.test <workspace_id>/<shipper_name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `workspace_name`, `action`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource,
+or the resource definition should be updated to align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_secmaster_siem_shipper" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      workspace_name,
+      action,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4506,6 +4506,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_layout_wizard":               secmaster.ResourceLayoutWizard(),
 			"huaweicloud_secmaster_layout_field":                secmaster.ResourceLayoutField(),
 			"huaweicloud_secmaster_metric":                      secmaster.ResourceMetric(),
+			"huaweicloud_secmaster_siem_shipper":                secmaster.ResourceSiemShipper(),
 			"huaweicloud_secmaster_module":                      secmaster.ResourceModule(),
 			"huaweicloud_secmaster_node_expansion":              secmaster.ResourceNodeExpansion(),
 			"huaweicloud_secmaster_operation_connection":        secmaster.ResourceOperationConnection(),

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_siem_shipper_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_siem_shipper_test.go
@@ -1,0 +1,96 @@
+package secmaster
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster"
+)
+
+func getResourceSiemShipperFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("secmaster", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	return secmaster.GetSiemShipperInfo(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+func TestAccResourceSiemShipper_basic(t *testing.T) {
+	var (
+		rName       = "huaweicloud_secmaster_siem_shipper.test"
+		shipperName = acceptance.RandomAccResourceName()
+
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourceSiemShipperFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceSiemShipper_basic(shipperName),
+				ExpectError: regexp.MustCompile(`空间ID不存在`),
+			},
+		},
+	})
+}
+
+func testAccResourceSiemShipper_basic(shipperName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_siem_shipper" "test" {
+  consumption_type = 0
+  dataspace_id     = "xxx"
+  dataspace_name   = "xxx"
+  domain_id        = "xxx"
+  pipe_id          = "xxx"
+  pipe_name        = "xxx"
+  project_id       = "xxx"
+  region           = "cn-north-4"
+  shipper_name     = "%[1]s"
+  version          = "v1"
+  workspace_id     = "%[2]s"
+  workspace_name   = "xxx"
+
+  shipper_destination {
+    data_param                 = jsonencode({})
+    destination_dataspace      = "xxx"
+    destination_dataspace_name = "xxx"
+    destination_identity_role  = "pipe-strategy"
+    destination_pipe           = "xxx"
+    destination_pipe_name      = "xxx"
+    destination_region         = "cn-north-4"
+    destination_shipper_type   = 0
+    destination_workspace      = "xxx"
+    destination_workspace_name = "xxx"
+  }
+
+  shipper_source {
+    region                = "cn-north-4"
+    source_dataspace      = "xxx"
+    source_dataspace_name = "xxx"
+    source_identity_role  = "pipe-strategy"
+    source_pipe           = "xxx"
+    source_pipe_name      = "xxx"
+    source_type           = 0
+    source_workspace      = "xxx"
+    source_workspace_name = "xxx"
+  }
+}
+`, shipperName, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_siem_shipper.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_siem_shipper.go
@@ -1,0 +1,598 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableParamsSiemShipper = []string{
+	"workspace_id",
+	"shipper_name",
+	"consumption_type",
+	"dataspace_id",
+	"dataspace_name",
+	"domain_id",
+	"pipe_id",
+	"pipe_name",
+	"project_id",
+	"shipper_destination.*.data_param",
+	"shipper_destination.*.destination_dataspace",
+	"shipper_destination.*.destination_dataspace_name",
+	"shipper_destination.*.destination_identity_role",
+	"shipper_destination.*.destination_pipe",
+	"shipper_destination.*.destination_pipe_name",
+	"shipper_destination.*.destination_region",
+	"shipper_destination.*.destination_shipper_type",
+	"shipper_destination.*.destination_workspace",
+	"shipper_destination.*.destination_workspace_name",
+	"shipper_source.*.region",
+	"shipper_source.*.source_dataspace",
+	"shipper_source.*.source_dataspace_name",
+	"shipper_source.*.source_identity_role",
+	"shipper_source.*.source_pipe",
+	"shipper_source.*.source_pipe_name",
+	"shipper_source.*.source_type",
+	"shipper_source.*.source_workspace",
+	"shipper_source.*.source_workspace_name",
+	"version",
+	"workspace_name",
+}
+
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/siem/shippers
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/siem/shippers
+// @API SecMaster DELETE /v1/{project_id}/workspaces/{workspace_id}/siem/shippers
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/siem/shippers/{shipper_id}/pause
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/siem/shippers/{shipper_id}/resume
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/siem/shippers/{shipper_id}/retry
+func ResourceSiemShipper() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSiemShipperCreate,
+		ReadContext:   resourceSiemShipperRead,
+		UpdateContext: resourceSiemShipperUpdate,
+		DeleteContext: resourceSiemShipperDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSiemShipperImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableParamsSiemShipper),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"shipper_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"consumption_type": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"dataspace_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"dataspace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"pipe_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"pipe_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"shipper_destination": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem:     buildShipperDestinationSchema(),
+			},
+			"shipper_source": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem:     buildShipperSourceSchema(),
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// `workspace_name` is not returned in the response.
+			"workspace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// Custom field, no return value.
+			"action": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"pause", "resume", "retry"}, false),
+			},
+			"shipper_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildShipperDestinationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"data_param": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_dataspace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_dataspace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_identity_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_pipe": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_pipe_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_shipper_type": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_workspace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"destination_workspace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildShipperSourceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_dataspace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_dataspace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_identity_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_pipe": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_pipe_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_type": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"source_workspace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_workspace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildShipperDestinationBodyParams(rawList []interface{}) interface{} {
+	if len(rawList) == 0 {
+		return nil
+	}
+
+	item, ok := rawList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"data_param":                 utils.ValueIgnoreEmpty(item["data_param"]),
+		"destination_dataspace":      utils.ValueIgnoreEmpty(item["destination_dataspace"]),
+		"destination_dataspace_name": utils.ValueIgnoreEmpty(item["destination_dataspace_name"]),
+		"destination_identity_role":  utils.ValueIgnoreEmpty(item["destination_identity_role"]),
+		"destination_pipe":           utils.ValueIgnoreEmpty(item["destination_pipe"]),
+		"destination_pipe_name":      utils.ValueIgnoreEmpty(item["destination_pipe_name"]),
+		"destination_region":         utils.ValueIgnoreEmpty(item["destination_region"]),
+		"destination_shipper_type":   item["destination_shipper_type"],
+		"destination_workspace":      utils.ValueIgnoreEmpty(item["destination_workspace"]),
+		"destination_workspace_name": utils.ValueIgnoreEmpty(item["destination_workspace_name"]),
+	}
+}
+
+func buildShipperSourceBodyParams(rawList []interface{}) interface{} {
+	if len(rawList) == 0 {
+		return nil
+	}
+
+	item, ok := rawList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"region":                utils.ValueIgnoreEmpty(item["region"]),
+		"source_dataspace":      utils.ValueIgnoreEmpty(item["source_dataspace"]),
+		"source_dataspace_name": utils.ValueIgnoreEmpty(item["source_dataspace_name"]),
+		"source_identity_role":  utils.ValueIgnoreEmpty(item["source_identity_role"]),
+		"source_pipe":           utils.ValueIgnoreEmpty(item["source_pipe"]),
+		"source_pipe_name":      utils.ValueIgnoreEmpty(item["source_pipe_name"]),
+		"source_type":           item["source_type"],
+		"source_workspace":      utils.ValueIgnoreEmpty(item["source_workspace"]),
+		"source_workspace_name": utils.ValueIgnoreEmpty(item["source_workspace_name"]),
+	}
+}
+
+func buildCreateSiemShipperBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"shipper_name":        d.Get("shipper_name"),
+		"consumption_type":    d.Get("consumption_type"),
+		"dataspace_id":        utils.ValueIgnoreEmpty(d.Get("dataspace_id")),
+		"dataspace_name":      utils.ValueIgnoreEmpty(d.Get("dataspace_name")),
+		"domain_id":           utils.ValueIgnoreEmpty(d.Get("domain_id")),
+		"pipe_id":             utils.ValueIgnoreEmpty(d.Get("pipe_id")),
+		"pipe_name":           utils.ValueIgnoreEmpty(d.Get("pipe_name")),
+		"project_id":          utils.ValueIgnoreEmpty(d.Get("project_id")),
+		"shipper_destination": buildShipperDestinationBodyParams(d.Get("shipper_destination").([]interface{})),
+		"shipper_source":      buildShipperSourceBodyParams(d.Get("shipper_source").([]interface{})),
+		"version":             utils.ValueIgnoreEmpty(d.Get("version")),
+		"workspace_id":        d.Get("workspace_id"),
+		"workspace_name":      utils.ValueIgnoreEmpty(d.Get("workspace_name")),
+	}
+
+	return bodyParams
+}
+
+func resourceSiemShipperCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		workspaceId   = d.Get("workspace_id").(string)
+		createHttpUrl = "v1/{project_id}/workspaces/{workspace_id}/siem/shippers"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", workspaceId)
+
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateSiemShipperBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster SIEM shipper: %s", err)
+	}
+
+	d.SetId(d.Get("shipper_name").(string))
+
+	if action := d.Get("action").(string); action != "" {
+		if err := operationShipper(client, d, action); err != nil {
+			return diag.Errorf("error operating SecMaster shipper (%s): %s", action, err)
+		}
+	}
+
+	return resourceSiemShipperRead(ctx, d, meta)
+}
+
+func GetSiemShipperInfo(client *golangsdk.ServiceClient, workspaceId, shipperName string) (interface{}, error) {
+	getPath := client.Endpoint + "v1/{project_id}/workspaces/{workspace_id}/siem/shippers"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{workspace_id}", workspaceId)
+	getPath += fmt.Sprintf("?shipper_name=%s&limit=10&offset=0", shipperName)
+
+	getOpts := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	shipperInfo := utils.PathSearch("data.data[0]", respBody, nil)
+	if shipperInfo == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return shipperInfo, nil
+}
+
+func flattenShipperDestinationFromList(respBody interface{}) []map[string]interface{} {
+	destinationRaw := utils.PathSearch("shipper_destination", respBody, nil)
+	if destinationRaw == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"data_param":                 utils.PathSearch("data_param", destinationRaw, nil),
+			"destination_dataspace":      utils.PathSearch("dataspace", destinationRaw, nil),
+			"destination_dataspace_name": utils.PathSearch("dataspace_name", destinationRaw, nil),
+			"destination_identity_role":  utils.PathSearch("identity", destinationRaw, nil),
+			"destination_pipe":           utils.PathSearch("pipe", destinationRaw, nil),
+			"destination_pipe_name":      utils.PathSearch("pipe_name", destinationRaw, nil),
+			"destination_region":         utils.PathSearch("region", destinationRaw, nil),
+			"destination_shipper_type":   utils.PathSearch("data_type", destinationRaw, nil),
+			"destination_workspace":      utils.PathSearch("workspace", destinationRaw, nil),
+			"destination_workspace_name": utils.PathSearch("workspace_name", destinationRaw, nil),
+		},
+	}
+}
+
+func flattenShipperSourceFromList(respBody interface{}) []map[string]interface{} {
+	sourceRaw := utils.PathSearch("shipper_source", respBody, nil)
+	if sourceRaw == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"region":                utils.PathSearch("region", sourceRaw, nil),
+			"source_dataspace":      utils.PathSearch("dataspace", sourceRaw, nil),
+			"source_dataspace_name": utils.PathSearch("dataspace_name", sourceRaw, nil),
+			"source_identity_role":  utils.PathSearch("identity", sourceRaw, nil),
+			"source_pipe":           utils.PathSearch("pipe", sourceRaw, nil),
+			"source_pipe_name":      utils.PathSearch("pipe_name", sourceRaw, nil),
+			"source_type":           utils.PathSearch("data_type", sourceRaw, nil),
+			"source_workspace":      utils.PathSearch("workspace", sourceRaw, nil),
+			"source_workspace_name": utils.PathSearch("workspace_name", sourceRaw, nil),
+		},
+	}
+}
+
+func resourceSiemShipperRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	respBody, err := GetSiemShipperInfo(client, workspaceId, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			err,
+			"error retrieving SecMaster SIEM shipper",
+		)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("shipper_name", utils.PathSearch("shipper_name", respBody, nil)),
+		d.Set("shipper_id", utils.PathSearch("shipper_id", respBody, nil)),
+		d.Set("consumption_type", utils.PathSearch("consumption_type", respBody, nil)),
+		d.Set("dataspace_id", utils.PathSearch("dataspace_id", respBody, nil)),
+		d.Set("dataspace_name", utils.PathSearch("dataspace_name", respBody, nil)),
+		d.Set("domain_id", utils.PathSearch("domain_id", respBody, nil)),
+		d.Set("pipe_id", utils.PathSearch("pipe_id", respBody, nil)),
+		d.Set("pipe_name", utils.PathSearch("pipe_name", respBody, nil)),
+		d.Set("project_id", utils.PathSearch("project_id", respBody, nil)),
+		d.Set("shipper_destination", flattenShipperDestinationFromList(respBody)),
+		d.Set("shipper_source", flattenShipperSourceFromList(respBody)),
+		d.Set("version", utils.PathSearch("version", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", respBody, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func operationShipper(client *golangsdk.ServiceClient, d *schema.ResourceData, operateType string) error {
+	var (
+		workspaceId = d.Get("workspace_id").(string)
+		shipperId   = d.Get("shipper_id").(string)
+		httpUrl     = fmt.Sprintf("v1/{project_id}/workspaces/{workspace_id}/siem/shippers/{shipper_id}/%s", operateType)
+	)
+
+	operatePath := client.Endpoint + httpUrl
+	operatePath = strings.ReplaceAll(operatePath, "{project_id}", client.ProjectID)
+	operatePath = strings.ReplaceAll(operatePath, "{workspace_id}", workspaceId)
+	operatePath = strings.ReplaceAll(operatePath, "{shipper_id}", shipperId)
+
+	operateOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("POST", operatePath, &operateOpt)
+	return err
+}
+
+func resourceSiemShipperUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		action = d.Get("action").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	if d.HasChange("action") && action != "" {
+		if err := operationShipper(client, d, action); err != nil {
+			return diag.Errorf("error operating SecMaster SIEM shipper (%s): %s", action, err)
+		}
+	}
+
+	return resourceSiemShipperRead(ctx, d, meta)
+}
+
+func resourceSiemShipperDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/siem/shippers"
+		shipperId   = d.Get("shipper_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{workspace_id}", workspaceId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+		JSONBody:         map[string]interface{}{"ids": []string{shipperId}},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting SecMaster SIEM shipper: %s", err)
+	}
+
+	return nil
+}
+
+func resourceSiemShipperImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<shipper_name>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[1])
+
+	mErr := multierror.Append(nil,
+		d.Set("workspace_id", parts[0]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage shipper

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Due to the extensive prerequisites for resource preparation, the test cases covered only a single failure scenario. The scenarios actually tested are as follows:
<img width="753" height="215" alt="image" src="https://github.com/user-attachments/assets/28c0d25d-d1fc-4ca6-9bdd-16b75147b306" />
<img width="928" height="169" alt="image" src="https://github.com/user-attachments/assets/da690774-c8c7-4dcf-abb9-eb25f66af9e7" />
<img width="744" height="204" alt="image" src="https://github.com/user-attachments/assets/6f944cdb-5ab8-4dbd-92bb-4feb6653c2e7" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccResourceSiemShipper_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccResourceSiemShipper_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceSiemShipper_basic
=== PAUSE TestAccResourceSiemShipper_basic
=== CONT  TestAccResourceSiemShipper_basic
--- PASS: TestAccResourceSiemShipper_basic (5.98s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 6.093s  coverage: 4.0% of statements in ./huaweicloud/services/secmaster
```

* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="750" height="174" alt="image" src="https://github.com/user-attachments/assets/ea2a2397-ab77-4e69-b1e4-1ba939387912" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
