### PR TITLE
feat(gaussdb): config gaussdb instance full sqls

### DIFF
--- a/docs/resources/gaussdb_instance_full_sqls_config.md
+++ b/docs/resources/gaussdb_instance_full_sqls_config.md
@@ -1,0 +1,88 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_instance_full_sqls_config"
+description: |-
+  Manages a GaussDB instance full SQL collection configuration resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_instance_full_sqls_config
+
+Manages a GaussDB instance full SQL collection configuration resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "storage_mode" {}
+variable "is_exclude_sys_user" {}
+variable "save_days" {}
+variable "lts_config" {}
+variable "sql_type_range" {}
+
+resource "huaweicloud_gaussdb_instance_full_sqls_config" "test" {
+  instance_id         = var.instance_id
+  storage_mode        = var.storage_mode
+  save_days           = var.save_days
+  is_exclude_sys_user = var.is_exclude_sys_user
+  lts_config {
+    log_group_name  = "GROUP_GAUSSDB_APS_1"
+    log_stream_name = "STREAM_APS_FULL_SQL_1"
+  }
+  sql_type_range {
+    category = "all"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the GaussDB instance.
+
+* `storage_mode` - (Required, String, NonUpdatable) Specifies the storage mode for full SQL data.
+  Valid value is **LTS**.
+
+* `save_days` - (Required, Int) Specifies the number of days to retain full SQL data.
+  The value ranges from `1` to `30`.
+
+* `is_exclude_sys_user` - (Optional, Bool) Specifies whether to exclude system users from SQL collection.
+
+* `lts_config` - (Required, List) Specifies the LTS (Log Tank Service) configuration.
+  The [lts_config](#gaussdb_full_sqls_lts_config) structure is documented below.
+
+<a name="gaussdb_full_sqls_lts_config"></a>
+The `lts_config` block supports:
+
+* `log_group_name` - (Required, String) Specifies the name of the LTS log group.
+
+* `log_stream_name` - (Required, String) Specifies the name of the LTS log stream.
+
+* `sql_type_range` - (Optional, List) Specifies the SQL type range configuration.
+  The [sql_type_range](#gaussdb_full_sqls_sql_type_range) structure is documented below.
+
+<a name="gaussdb_full_sqls_sql_type_range"></a>
+The `sql_type_range` block supports:
+
+* `category` - (Required, String) Specifies the SQL category.
+  Valid values include **all**, **ddl**, **dml**, **dcl**, **tcl**, **dql**, **custom**.
+
+* `prefixes` - (Optional, List) Specifies the SQL statement prefixes to match.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is the same as `instance_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `update` - Default is 20 minutes.
+* `delete` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3934,6 +3934,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_instance":                          gaussdb.ResourceGaussDbInstance(),
 			"huaweicloud_gaussdb_instance_restart":                  gaussdb.ResourceGaussDbInstanceRestart(),
 			"huaweicloud_gaussdb_instance_password_reset":           gaussdb.ResourceGaussDbInstancePasswordReset(),
+			"huaweicloud_gaussdb_instance_full_sqls_config":         gaussdb.ResourceGaussDbFullSqlsConfig(),
 			"huaweicloud_gaussdb_instance_plugin":                   gaussdb.ResourceGaussDbInstancePlugin(),
 			"huaweicloud_gaussdb_instance_plugin_extensions_config": gaussdb.ResourceGaussDbInstancePluginExtensionsConfig(),
 			"huaweicloud_gaussdb_instance_plugin_license_config":    gaussdb.ResourceGaussDbPluginLicense(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_instance_full_sqls_config_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_instance_full_sqls_config_test.go
@@ -1,0 +1,99 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGaussDbFullSqlsConfig_basic(t *testing.T) {
+	var (
+		resourceName  = "huaweicloud_gaussdb_instance_full_sqls_config.test"
+		instanceID    = acceptance.HW_GAUSSDB_INSTANCE_ID
+		logGroupName  = "GROUP_GAUSSDB_APS-" + instanceID
+		logStreamName = "STREAM_APS_FULL_SQL-" + instanceID
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBInstanceId(t)
+			acceptance.TestAccPreCheckHighCostAllow(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDbFullSqlsConfig_basic(instanceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "instance_id", instanceID),
+					resource.TestCheckResourceAttr(resourceName, "storage_mode", "LTS"),
+					resource.TestCheckResourceAttr(resourceName, "save_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "lts_config.0.log_group_name", logGroupName),
+					resource.TestCheckResourceAttr(resourceName, "lts_config.0.log_stream_name", logStreamName),
+					resource.TestCheckResourceAttrSet(resourceName, "is_exclude_sys_user"),
+					resource.TestCheckResourceAttr(resourceName, "sql_type_range.0.category", "all"),
+				),
+			},
+			{
+				Config: testAccGaussDbFullSqlsConfig_update(instanceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "instance_id", instanceID),
+					resource.TestCheckResourceAttr(resourceName, "storage_mode", "LTS"),
+					resource.TestCheckResourceAttr(resourceName, "save_days", "30"),
+					resource.TestCheckResourceAttr(resourceName, "lts_config.0.log_group_name", logGroupName),
+					resource.TestCheckResourceAttr(resourceName, "lts_config.0.log_stream_name", logStreamName),
+					resource.TestCheckResourceAttr(resourceName, "is_exclude_sys_user", "false"),
+					resource.TestCheckResourceAttr(resourceName, "sql_type_range.0.category", "custom"),
+					resource.TestCheckResourceAttr(resourceName, "sql_type_range.0.prefixes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "sql_type_range.0.prefixes.0", "gaussdb"),
+					resource.TestCheckResourceAttr(resourceName, "sql_type_range.0.prefixes.1", "sql"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGaussDbFullSqlsConfig_basic(instanceID string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_instance_full_sqls_config" "test" {
+  instance_id         = "%[1]s"
+  storage_mode        = "LTS"
+  save_days           = 7
+  is_exclude_sys_user = true
+
+  lts_config {
+    log_group_name  = "GROUP_GAUSSDB_APS-%[1]s"
+    log_stream_name = "STREAM_APS_FULL_SQL-%[1]s"
+  }
+
+  sql_type_range {
+    category = "all"
+  }
+}
+`, instanceID)
+}
+
+func testAccGaussDbFullSqlsConfig_update(instanceID string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_instance_full_sqls_config" "test" {
+  instance_id         = "%[1]s"
+  storage_mode        = "LTS"
+  save_days           = 30
+  is_exclude_sys_user = false
+
+  lts_config {
+    log_group_name  = "GROUP_GAUSSDB_APS-%[1]s"
+    log_stream_name = "STREAM_APS_FULL_SQL-%[1]s"
+  }
+
+  sql_type_range {
+    category = "custom"
+    prefixes = ["gaussdb", "sql"]
+  }
+}
+`, instanceID)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_full_sqls_config.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_full_sqls_config.go
@@ -1,0 +1,298 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var gaussdbFullSqlsNonUpdatableParams = []string{"instance_id", "storage_mode"}
+
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/full-sqls/start
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/full-sqls/stop
+func ResourceGaussDbFullSqlsConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFullSqlConfigCreate,
+		ReadContext:   resourceFullSqlConfigRead,
+		UpdateContext: resourceFullSqlConfigUpdate,
+		DeleteContext: resourceFullSqlConfigDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(gaussdbFullSqlsNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"storage_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_exclude_sys_user": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"save_days": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"lts_config": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"log_group_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"log_stream_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"sql_type_range": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"category": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"prefixes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildFullSqlConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"storage_mode":        d.Get("storage_mode"),
+		"save_days":           d.Get("save_days"),
+		"is_exclude_sys_user": utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "is_exclude_sys_user"),
+		"lts_config":          buildLtsConfigBodyParams(d.Get("lts_config").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("sql_type_range"); ok {
+		params["sql_type_range"] = buildSqlTypeRangeBodyParams(v.([]interface{}))
+	}
+
+	return params
+}
+
+func buildLtsConfigBodyParams(ltsConfigs []interface{}) map[string]interface{} {
+	if len(ltsConfigs) == 0 {
+		return nil
+	}
+
+	ltsConfig, ok := ltsConfigs[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return map[string]interface{}{
+		"log_group_name":  ltsConfig["log_group_name"],
+		"log_stream_name": ltsConfig["log_stream_name"],
+	}
+}
+
+func buildSqlTypeRangeBodyParams(sqlTypeRanges []interface{}) []map[string]interface{} {
+	if len(sqlTypeRanges) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(sqlTypeRanges))
+	for _, item := range sqlTypeRanges {
+		sqlType, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		params := map[string]interface{}{
+			"category": sqlType["category"],
+			"prefixes": utils.ValueIgnoreEmpty(utils.ExpandToStringList(sqlType["prefixes"].([]interface{}))),
+		}
+
+		rst = append(rst, params)
+	}
+
+	return rst
+}
+
+func resourceFullSqlConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/full-sqls/start"
+		product = "opengauss"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildFullSqlConfigBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error starting GaussDB full SQL collection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, nil)
+	if jobId == nil {
+		return diag.Errorf("error starting GaussDB full SQL collection: unable to find job ID")
+	}
+	err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId.(string), 5, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(instanceID)
+
+	return nil
+}
+
+func resourceFullSqlConfigRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceFullSqlConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/full-sqls/start"
+		product = "opengauss"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildFullSqlConfigBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating GaussDB full SQL configuration: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, nil)
+	if jobId == nil {
+		return diag.Errorf("error updating GaussDB full SQL collection: unable to find job ID")
+	}
+	err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId.(string), 5, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceFullSqlConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/full-sqls/stop"
+		product = "opengauss"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("POST", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error stopping GaussDB full SQL collection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, nil)
+	if jobId == nil {
+		return diag.Errorf("error stopping GaussDB full SQL collection: unable to find job ID")
+	}
+	err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId.(string), 5, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource `(huaweicloud_gaussdb_instance_full_sqls_config) ` to config gaussdb instance full sqls.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add a new resource  huaweicloud_gaussdb_instance_full_sqls_config for GaussDB.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o gaussdb -f TestAccGaussDbFullSqlsConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/gaussdb" -v -coverprofile="./huaweicloud/services/acceptance/gaussdb/gaussdb_coverage.cov" -coverpkg="./huaweicloud/services/gaussdb" -run TestAccGaussDbFullSqlsConfig_basic -timeout 360m -parallel 10
=== RUN   TestAccGaussDbFullSqlsConfig_basic
=== PAUSE TestAccGaussDbFullSqlsConfig_basic
=== CONT  TestAccGaussDbFullSqlsConfig_basic
--- PASS: TestAccGaussDbFullSqlsConfig_basic (207.11s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/gaussdb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   208.999s        coverage: 4.6% of statements in ./huaweicloud/services/gaussdb

```
<img width="929" height="21" alt="config-full-sqls" src="https://github.com/user-attachments/assets/63f34e9e-4dfd-404f-bf7b-e467838a5dce" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
