### PR TITLE
feat(GeminiDB): the instance supports node auto expansion policy

### DIFF
--- a/docs/resources/geminidb_instance.md
+++ b/docs/resources/geminidb_instance.md
@@ -183,6 +183,30 @@ The following arguments are supported:
   If the `maintenance_start_time` value is **02:00**, the `maintenance_end_time` value must be **06:00**.
   <br/>3. The parameters `maintenance_start_time` and `maintenance_end_time` must be used together.
 
+* `node_switch_option` - (Optional, Bool) Specifies whether the switch for automatically adding nodes is enabled.
+  The valid values are **true** and **false**.
+
+  -> The node auto expansion policy is only supported GeminiDB Cassandra instance, and the instance CPU
+    need to greater than `2`.
+
+* `overload_node_threshold` - (Optional, Int) Specifies the percentage of overloaded nodes.
+  The value ranges from `1` to `100`.
+  For example, if there are three nodes in the current instance and the policy needs to be triggered
+  when a threshold is reached for two of them, the value can be 67% (= 2/3; rounded up).
+
+* `cpu_threshold` - (Optional, Int) Specifies the CPU usage of nodes for which autoscaling is triggered.
+  The value ranges from `1` to `100`. Defaults to `80`.
+
+* `mem_threshold` - (Optional, Int) Specifies the memory usage of nodes for which autoscaling is triggered.
+  The value ranges from `1` to `100`. Defaults to `80`.
+
+* `step` - (Optional, Int) Specifies the number of nodes to be added each time.
+  The maximum value cannot exceed the upper limit of nodes that can be added. Defaults to `3`.
+
+* `node_limit` - (Optional, Int) Specifies the maximum number of nodes that can be automatically added.
+  The maximum value cannot exceed the upper limit of nodes that can be added to the current instance.
+  The default value is the maximum number of nodes that can be added to the current instance.
+
 * `access_control` - (Optional, List) Specifies the access control for Load Balancer.
   The [access_control](#access_control_struct) structure is documented below.
 

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
@@ -582,6 +582,69 @@ func TestAccGeminiDbInstance_coldStorage(t *testing.T) {
 	})
 }
 
+func TestAccGeminiDbInstance_nodeAutoExpansionPolicy(t *testing.T) {
+	var obj interface{}
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_geminidb_instance.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getGeminiDbInstance,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBNodeAutoExpansion_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.type", "cassandra"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.version", "3.11"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.storage_engine", "rocksDB"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "Cluster"),
+					resource.TestCheckResourceAttr(resourceName, "node_switch_option", "true"),
+					resource.TestCheckResourceAttr(resourceName, "overload_node_threshold", "60"),
+					resource.TestCheckResourceAttr(resourceName, "cpu_threshold", "60"),
+					resource.TestCheckResourceAttr(resourceName, "mem_threshold", "60"),
+					resource.TestCheckResourceAttr(resourceName, "step", "2"),
+					resource.TestCheckResourceAttr(resourceName, "node_limit", "4"),
+				),
+			},
+			{
+				Config: testAccGeminiDBNodeAutoExpansion_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "node_switch_option", "false"),
+					resource.TestCheckResourceAttr(resourceName, "overload_node_threshold", "90"),
+					resource.TestCheckResourceAttr(resourceName, "cpu_threshold", "90"),
+					resource.TestCheckResourceAttr(resourceName, "mem_threshold", "90"),
+					resource.TestCheckResourceAttr(resourceName, "step", "3"),
+					resource.TestCheckResourceAttr(resourceName, "node_limit", "6"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"flavor.0.storage",
+					"ssl_option",
+					"delete_node_list",
+					"cold_storage_size",
+				},
+			},
+		},
+	})
+}
+
 func testAccGeminiDbInstance_base(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
@@ -1240,4 +1303,86 @@ resource "huaweicloud_geminidb_instance" "test" {
   cold_storage_size = %[3]d
 }
 `, common.TestBaseNetwork(name), name, storageSize)
+}
+
+func testAccGeminiDBNodeAutoExpansion_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus  = 4
+  engine = "cassandra"
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = "cn-north-4a,cn-north-4b,cn-north-4c"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "Test@1234"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "cassandra"
+    version        = "3.11"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "100"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+
+  node_switch_option      = true
+  overload_node_threshold = 60
+  cpu_threshold           = 60
+  mem_threshold           = 60
+  step                    = 2
+  node_limit              = 4
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccGeminiDBNodeAutoExpansion_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus  = 4
+  engine = "cassandra"
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = "cn-north-4a,cn-north-4b,cn-north-4c"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "Test@1234"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "cassandra"
+    version        = "3.11"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "100"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+
+  node_switch_option      = false
+  overload_node_threshold = 90
+  cpu_threshold           = 90
+  mem_threshold           = 90
+  step                    = 3
+  node_limit              = 6
+}
+`, common.TestBaseNetwork(name), name)
 }

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -58,6 +58,8 @@ var geminiDbInstanceNonUpdatableParams = []string{"datastore", "datastore.*.type
 // @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/cold-volume
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/cold-volume
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/maintenance-window
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/node-auto-expansion-policy
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/node-auto-expansion-policy
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/lb/access-control
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/lb/access-control
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
@@ -228,6 +230,36 @@ func ResourceGeminiDbInstance() *schema.Resource {
 			},
 			"maintenance_end_time": {
 				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"node_switch_option": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"overload_node_threshold": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"cpu_threshold": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"mem_threshold": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"step": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"node_limit": {
+				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
@@ -709,6 +741,14 @@ func resourceGeminiDbInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	// Setting node auto expansion policy
+	if v := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "node_switch_option"); v != nil && v.(bool) {
+		err = updateNodeAutoExpansionPolicy(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceGeminiDbInstanceRead(ctx, d, meta)
 }
 
@@ -1061,6 +1101,21 @@ func resourceGeminiDbInstanceRead(_ context.Context, d *schema.ResourceData, met
 	// Set password-free configuration
 	mErr = multierror.Append(mErr, getPasswordFreeConfigurationInfo(d, client))
 
+	// Set node auto expansion policy
+	nodePolicy, err := getNodeAutoExpansionPolicyInfo(client, d.Id())
+	if err != nil {
+		log.Printf("[Warn] error retrieving GeminiDB instance node auto expansion policy information")
+	} else {
+		mErr = multierror.Append(
+			d.Set("node_switch_option", utils.PathSearch("resultMsg.switch_option", nodePolicy, false).(bool)),
+			d.Set("overload_node_threshold", utils.PathSearch("resultMsg.overload_node_threshold", nodePolicy, nil)),
+			d.Set("cpu_threshold", utils.PathSearch("resultMsg.cpu_threshold", nodePolicy, nil)),
+			d.Set("mem_threshold", utils.PathSearch("resultMsg.mem_threshold", nodePolicy, nil)),
+			d.Set("step", utils.PathSearch("resultMsg.step", nodePolicy, nil)),
+			d.Set("node_limit", utils.PathSearch("resultMsg.node_limit", nodePolicy, nil)),
+		)
+	}
+
 	// Querying the Blacklist or Whitelist of Load Balancer IP Addresses
 	accessControlRespBody, err := getLBAccessControlInfo(client, d.Id())
 	if err != nil {
@@ -1336,10 +1391,31 @@ func getPasswordFreeConfigurationInfo(d *schema.ResourceData, client *golangsdk.
 
 	if err != nil {
 		log.Printf("[WARN] error retrieving GeminiDB instance password-free configuration: %s", err)
-		return nil
+		return d.Set("config_ips", make([]interface{}, 0))
 	}
 
 	return d.Set("config_ips", utils.PathSearch("config_ips", getRespBody, make([]interface{}, 0)).([]interface{}))
+}
+
+func getNodeAutoExpansionPolicyInfo(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/instances/{instance_id}/node-auto-expansion-policy"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getOpts := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
 }
 
 // nolint:gocyclo
@@ -1489,6 +1565,14 @@ func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 	// Update maintenance window
 	if d.HasChanges("maintenance_start_time", "maintenance_end_time") {
 		err = updateMaintenanceWindow(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Update node auto expansion policy
+	if d.HasChanges("node_switch_option", "overload_node_threshold", "cpu_threshold", "mem_threshold", "step", "node_limit") {
+		err = updateNodeAutoExpansionPolicy(ctx, d, client)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -1960,6 +2044,33 @@ func updateColdStorage(ctx context.Context, d *schema.ResourceData, client, bssC
 		return fmt.Errorf("error updating GeminiDB instance cold storage: %s", err)
 	}
 	return nil
+}
+
+func updateNodeAutoExpansionPolicy(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:             "v3/{project_id}/instances/{instance_id}/node-auto-expansion-policy",
+		httpMethod:          "PUT",
+		pathParams:          map[string]string{"instance_id": d.Id()},
+		updateBodyParams:    utils.RemoveNil(buildUpdateNodeAutoExpansionPolicyBodyParams(d)),
+		isWaitInstanceReady: true,
+	})
+	if err != nil {
+		return fmt.Errorf("error updating the GeminiDB instance node auto expansion policy: %s", err)
+	}
+	return nil
+}
+
+func buildUpdateNodeAutoExpansionPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"switch_option":           utils.ValueIgnoreEmpty(utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "node_switch_option")),
+		"overload_node_threshold": utils.ValueIgnoreEmpty(d.Get("overload_node_threshold")),
+		"cpu_threshold":           utils.ValueIgnoreEmpty(d.Get("cpu_threshold")),
+		"mem_threshold":           utils.ValueIgnoreEmpty(d.Get("mem_threshold")),
+		"step":                    utils.ValueIgnoreEmpty(d.Get("step")),
+		"node_limit":              utils.ValueIgnoreEmpty(d.Get("node_limit")),
+	}
+
+	return bodyParams
 }
 
 func updateLBAccessControl(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The instance supports node auto expansion policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.the instance supports node auto expansion policy.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_nodeAutoExpansionPolicy"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_nodeAutoExpansionPolicy -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_nodeAutoExpansionPolicy
=== PAUSE TestAccGeminiDbInstance_nodeAutoExpansionPolicy
=== CONT  TestAccGeminiDbInstance_nodeAutoExpansionPolicy
--- PASS: TestAccGeminiDbInstance_nodeAutoExpansionPolicy (1153.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1153.180s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_configuration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_configuration -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_configuration
=== PAUSE TestAccGeminiDbInstance_configuration
=== CONT  TestAccGeminiDbInstance_configuration
--- PASS: TestAccGeminiDbInstance_configuration (1511.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1511.209s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
