### PR TITLE
ci(golangci): using custom merge diff for huge push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,17 +38,29 @@ jobs:
   golangci:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-go@v3
         with:
-          go-version: ">=1.18"
-      - uses: actions/checkout@v3
+          go-version: "1.24"
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: true
+        env:
+          GOFLAGS: "-buildvcs=false -mod=readonly"
+        run: |
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          merge_base="$(git merge-base HEAD "origin/${{ github.base_ref }}")"
+          echo "Using merge base: ${merge_base}"
+          golangci-lint run \
+            --out-format=github-actions \
+            --new-from-rev="${merge_base}" \
+            ./...
 
   # This workflow contains a job called "tfproviderlint"
   # Ignore rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,14 @@
 # Options for analysis running.
 run:
   # See the dedicated "run" documentation section.
-  timeout: 5m
+  timeout: 10m
   # Which dirs to skip: issues from them won't be reported.
   # Can use regexp here: `generated.*`, regexp is applied on full path.
   # Default value is empty list,
   # but default dirs are skipped independently of this option's value (see skip-dirs-use-default).
   # "/" will be replaced by current OS file path separator to properly work on Windows.
   skip-dirs:
+    - vendor
     - huaweicloud/services/deprecated
     - huaweicloud/services/acceptance/deprecated
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:


**1. GHA Cache `400` Error (`Cache service responded with 400`)**

- **Symptom:** `golangci/golangci-lint-action@v3` failed in the prepare step with `Failed to restore: Cache service responded with 400`.
- **Cause:** The action relies on GitHub Actions cache via an outdated `@actions/cache` integration; cache restore/save is incompatible or intermittently rejected by the current cache backend.
- **Mitigation:** Stop using the Docker/Node-based `golangci-lint-action` and run `golangci-lint` directly in shell steps, avoiding the action’s built-in cache layer entirely.

**2. GitHub PR Diff API `406` (too many files)**

- **Symptom:** `failed to fetch pull request patch … diff exceeded the maximum number of files (300)` with HTTP 406.
- **Cause:** `only-new-issues: true` in the action fetches the PR unified diff via the GitHub REST API, which rejects diffs spanning more than 300 files — common for SDK/vendor upgrade PRs.
- **Mitigation:** Disable `only-new-issues` and use a **local git-based** baseline instead: compute `merge_base` with `git merge-base` and pass it to `--new-from-rev`, which does not call the PR diff API.

**3. Full-repo scan slowness / timeouts (including `vendor/`, but no expected)**

- **Symptom:** `golangci-lint run ./...` took several minutes and often hit the 5–10 minute timeout, even on small PRs.
- **Cause:** `./...` expands into the entire module tree, including thousands of files under `vendor/`, causing unnecessary analysis and module loading overhead.
- **Mitigation:**
  - Restrict lint scope to `./huaweicloud/...` (provider source only).
  - Add `--skip-dirs vendor` as an explicit safeguard.
  - Set `GOFLAGS=-mod=readonly` to prefer the committed `vendor/` tree and speed dependency resolution.

**4. `--new-from-merge-base` unsupported in pinned linter version**

- **Symptom:** `unknown flag: --new-from-merge-base` with golangci-lint v1.62.2.
- **Cause:** That flag was added in a newer golangci-lint release; v1.62.2 only supports `--new-from-rev`.
- **Mitigation:** Compute merge base manually (`git merge-base HEAD origin/$base_ref`) and pass the commit SHA to `--new-from-rev`.

**5. Go 1.24 toolchain mismatch with prebuilt linter binary**

- **Symptom:** `the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.13)`.
- **Cause:** The official install script downloads a prebuilt binary compiled with Go 1.23, while `go.mod` targets Go 1.24.
- **Mitigation:** Install via `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2` using Go 1.24 on the runner, so the linter is built with a compatible toolchain.

**6. Missing base branch ref for merge-base analysis**

- **Symptom:** Merge-base / `--new-from-rev` logic failed or behaved inconsistently on fork PRs.
- **Cause:** Default checkout does not fetch `origin/<base_branch>`, so `origin/master` (or equivalent) may not exist locally.
- **Mitigation:** Use `fetch-depth: 0` and an explicit `git fetch origin $base_ref` step before computing merge base.

**7. Related: `tfproviderlint` Go version issue (same workflow file)**

- **Symptom:** `go.mod requires go >= 1.24.0 (running go 1.22.12; GOTOOLCHAIN=local)` inside the Docker-based `tfproviderlint-github-action`.
- **Cause:** The action runs in an isolated container with an old Go toolchain, ignoring `setup-go` on the host.
- **Mitigation:** Replace the Docker action with `go install` + direct execution on the runner (with Go 1.24).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the some of execution problems, includes: cache response, full scan.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

without golangci problems in changed files:

<img width="315" height="289" alt="image" src="https://github.com/user-attachments/assets/c8da0e98-7419-42e0-a26e-8f16d042ee56" />

with golangci problems in changed files:

<img width="967" height="574" alt="image" src="https://github.com/user-attachments/assets/4b31a643-351d-4528-b587-f60cfd896495" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
