### PR TITLE
fix(modelarts): repair the incorrect API references

### DIFF
--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pools.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pools.go
@@ -17,7 +17,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ServiceStage GET /v2/{project_id}/pools
+// @API ModelArts GET /v2/{project_id}/pools
 func DataSourceV2ResourcePools() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceV2ResourcePoolsRead,

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_service.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_service.go
@@ -34,7 +34,7 @@ var v2ServiceNonUpdatableParams = []string{
 // @API ModelArts POST /v2/{project_id}/services/{service_id}/versions/switch
 // @API ModelArts PUT /v2/{project_id}/services/{service_id}
 // @API ModelArts POST /v2/{project_id}/modelarts-service-v2/{service_id}/tags/create
-// @API ModelArts DELETE /v2/{project_id}/modelarts-service-v2/{service_id}/tags/create
+// @API ModelArts DELETE /v2/{project_id}/modelarts-service-v2/{service_id}/tags/delete
 // @API ModelArts POST /v2/{project_id}/services/delete
 func ResourceV2Service() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix some incorrect API references for Modelarts.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix some incorrect API references
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
