### PR TITLE
feat(TaurusDB): data source to query LTS configs of HTAP instances

### DIFF
--- a/docs/data-sources/taurusdb_htap_starrocks_lts_configs.md
+++ b/docs/data-sources/taurusdb_htap_starrocks_lts_configs.md
@@ -1,0 +1,90 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_starrocks_lts_configs"
+description: |-
+  Use this data source to query the LTS configurations of TaurusDB HTAP StarRocks instances within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_starrocks_lts_configs
+
+Use this data source to query the LTS configurations of TaurusDB HTAP StarRocks instances within HuaweiCloud.
+
+## Example Usage
+
+### Query All Instances LTS Configurations
+
+```hcl
+data "huaweicloud_taurusdb_htap_starrocks_lts_configs" "test" {}
+```
+
+### Query by Instance ID
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_taurusdb_htap_starrocks_lts_configs" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the LTS configurations.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Optional, String) Specifies the ID of the HTAP StarRocks instance.
+
+* `instance_name` - (Optional, String) Specifies the name of the HTAP StarRocks instance.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instance_lts_configs` - The list of instance LTS configurations.
+  The [instance_lts_configs](#instance_lts_configs) structure is documented below.
+
+<a name="instance_lts_configs"></a>
+The `instance_lts_configs` block supports:
+
+* `instance` - The instance basic information.
+  The [instance](#instance_lts_configs_instance) structure is documented below.
+
+* `lts_configs` - The LTS configuration list.
+  The [lts_configs](#instance_lts_configs_lts_configs) structure is documented below.
+
+<a name="instance_lts_configs_instance"></a>
+The `instance` block supports:
+
+* `id` - The instance ID.
+
+* `name` - The instance name.
+
+* `mode` - The instance type. The valid values are **Cluster** and **Single**.
+
+* `engine_name` - The engine name.
+
+* `engine_version` - The engine version.
+
+* `status` - The instance status.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `enterprise_project_name` - The enterprise project name.
+
+<a name="instance_lts_configs_lts_configs"></a>
+The `lts_configs` block supports:
+
+* `log_type` - The log type. The valid values are **error_log** and **slow_log**.
+
+* `lts_group_id` - The LTS log group ID.
+
+* `lts_stream_id` - The LTS log stream ID.
+
+* `enabled` - Whether the LTS configuration is enabled.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2570,6 +2570,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_htap_primary_instance_tables":             taurusdb.DataSourceTaurusDBHtapPrimaryInstanceTables(),
 			"huaweicloud_taurusdb_htap_sessions":                            taurusdb.DataSourceTaurusDBHtapSessions(),
 			"huaweicloud_taurusdb_htap_starrocks_databases":                 taurusdb.DataSourceTaurusDBHtapStarrocksDatabases(),
+			"huaweicloud_taurusdb_htap_starrocks_lts_configs":               taurusdb.DataSourceTaurusDBHtapStarrocksLtsConfigs(),
 			"huaweicloud_taurusdb_htap_starrocks_nodes":                     taurusdb.DataSourceTaurusDBHtapStarrocksNodes(),
 			"huaweicloud_taurusdb_htap_starrocks_parameters":                taurusdb.DataSourceTaurusDBHtapStarrocksParameters(),
 			"huaweicloud_taurusdb_htap_starrocks_replications":              taurusdb.DataSourceTaurusDBHtapStarrocksReplications(),

--- a/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_lts_configs_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_lts_configs_test.go
@@ -1,0 +1,109 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTaurusDBHtapStarrocksLtsConfigs_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSource := "data.huaweicloud_taurusdb_htap_starrocks_lts_configs.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTaurusDBHtapStarrocksLtsConfigs_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.instance.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.instance.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.instance.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.instance.0.mode"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.instance.0.engine_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.instance.0.engine_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.instance.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.instance.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.lts_configs.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.lts_configs.0.log_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.lts_configs.0.lts_group_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.lts_configs.0.lts_stream_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_lts_configs.0.lts_configs.0.enabled"),
+					resource.TestCheckOutput("filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaurusDBHtapStarrocksLtsConfigs_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 1
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  count = 2
+
+  group_id    = huaweicloud_lts_group.test.id
+  stream_name = "%[1]s_${count.index}"
+}
+
+resource "huaweicloud_taurusdb_htap_starrocks_lts_config" "test" {
+  instance_id   = "%[2]s"
+  log_type      = "error_log"
+  lts_group_id  = huaweicloud_lts_group.test.id
+  lts_stream_id = huaweicloud_lts_stream.test[0].id
+}
+
+resource "huaweicloud_taurusdb_htap_starrocks_lts_config" "test_slow" {
+  instance_id   = "%[2]s"
+  log_type      = "slow_log"
+  lts_group_id  = huaweicloud_lts_group.test.id
+  lts_stream_id = huaweicloud_lts_stream.test[1].id
+}
+`, rName, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID)
+}
+
+func testAccDataSourceTaurusDBHtapStarrocksLtsConfigs_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_taurusdb_htap_starrocks_lts_configs" "test" {
+  depends_on = [huaweicloud_taurusdb_htap_starrocks_lts_config.test, huaweicloud_taurusdb_htap_starrocks_lts_config.test_slow]
+}
+
+locals {
+  instance_id    = data.huaweicloud_taurusdb_htap_starrocks_lts_configs.test.instance_lts_configs[0].instance[0].id
+  instance_name  = data.huaweicloud_taurusdb_htap_starrocks_lts_configs.test.instance_lts_configs[0].instance[0].name
+  eps_project_id = data.huaweicloud_taurusdb_htap_starrocks_lts_configs.test.instance_lts_configs[0].instance[0].enterprise_project_id
+}
+
+data "huaweicloud_taurusdb_htap_starrocks_lts_configs" "filter" {
+  instance_id           = local.instance_id
+  instance_name         = local.instance_name
+  enterprise_project_id = local.eps_project_id
+}
+
+locals {
+  filtered_lts_configs  = data.huaweicloud_taurusdb_htap_starrocks_lts_configs.filter.instance_lts_configs
+  filtered_lts_instance = data.huaweicloud_taurusdb_htap_starrocks_lts_configs.filter.instance_lts_configs[0].instance[0]
+}
+
+output "filter_is_useful" {
+  value = length(local.filtered_lts_configs) > 0 && (local.filtered_lts_instance.id == local.instance_id
+  && local.filtered_lts_instance.name == local.instance_name && local.filtered_lts_instance.enterprise_project_id == local.eps_project_id)
+}
+`, testAccTaurusDBHtapStarrocksLtsConfigs_base(rName))
+}

--- a/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_lts_configs.go
+++ b/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_lts_configs.go
@@ -1,0 +1,244 @@
+package taurusdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API TaurusDB GET /v3/{project_id}/starrocks/instances/logs/lts-configs
+func DataSourceTaurusDBHtapStarrocksLtsConfigs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBHtapStarrocksLtsConfigsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_lts_configs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     htapStarrocksLtsConfigsSchema(),
+			},
+		},
+	}
+}
+
+func htapStarrocksLtsConfigsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"instance": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     htapStarrocksLtsInstanceSchema(),
+			},
+			"lts_configs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     htapStarrocksLtsConfigSchema(),
+			},
+		},
+	}
+}
+
+func htapStarrocksLtsInstanceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enterprise_project_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func htapStarrocksLtsConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"log_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"lts_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"lts_stream_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBHtapStarrocksLtsConfigsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/starrocks/instances/logs/lts-configs"
+	)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildGetTaurusDBHtapStarrocksLtsConfigsQueryParams(d)
+
+	listResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		listPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return diag.Errorf("error retrieving TaurusDB HTAP StarRocks LTS configs: %s", err)
+	}
+
+	listRespJson, err := json.Marshal(listResp)
+	if err != nil {
+		return diag.Errorf("error marshaling TaurusDB HTAP StarRocks LTS configs: %s", err)
+	}
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.Errorf("error unmarshalling TaurusDB HTAP StarRocks LTS configs: %s", err)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_lts_configs", flattenTaurusDBHtapStarrocksLtsConfigs(listRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetTaurusDBHtapStarrocksLtsConfigsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("instance_id"); ok {
+		res = fmt.Sprintf("%s&instance_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("instance_name"); ok {
+		res = fmt.Sprintf("%s&instance_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("enterprise_project_id"); ok {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func flattenTaurusDBHtapStarrocksLtsConfigs(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("instance_lts_configs", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"instance":    flattenTaurusDBHtapStarrocksInstance(v),
+			"lts_configs": flattenTaurusDBHtapStarrocksLtsConfigList(v),
+		})
+	}
+	return res
+}
+
+func flattenTaurusDBHtapStarrocksInstance(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("instance", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"id":                      utils.PathSearch("id", curJson, nil),
+			"name":                    utils.PathSearch("name", curJson, nil),
+			"mode":                    utils.PathSearch("mode", curJson, nil),
+			"engine_name":             utils.PathSearch("engine_name", curJson, nil),
+			"engine_version":          utils.PathSearch("engine_version", curJson, nil),
+			"status":                  utils.PathSearch("status", curJson, nil),
+			"enterprise_project_id":   utils.PathSearch("enterprise_project_id", curJson, nil),
+			"enterprise_project_name": utils.PathSearch("enterprise_project_name", curJson, nil),
+		},
+	}
+}
+
+func flattenTaurusDBHtapStarrocksLtsConfigList(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("lts_configs", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"log_type":      utils.PathSearch("log_type", v, nil),
+			"lts_group_id":  utils.PathSearch("lts_group_id", v, nil),
+			"lts_stream_id": utils.PathSearch("lts_stream_id", v, nil),
+			"enabled":       utils.PathSearch("enabled", v, nil),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
data source to query LTS configs of HTAP instances
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
data source to query LTS configs of HTAP instances
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccDataSourceTaurusDBHtapStarrocksLtsConfigs'
=== RUN   TestAccDataSourceTaurusDBHtapStarrocksLtsConfigs_basic
=== PAUSE TestAccDataSourceTaurusDBHtapStarrocksLtsConfigs_basic
=== CONT  TestAccDataSourceTaurusDBHtapStarrocksLtsConfigs_basic
--- PASS: TestAccDataSourceTaurusDBHtapStarrocksLtsConfigs_basic (46.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 46.663s
```
<img width="795" height="198" alt="image" src="https://github.com/user-attachments/assets/d5c2d0fa-580c-4be1-b47e-24b0b1ba2a90" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
