### PR TITLE
ci(tfproviderlint): upgrade workflow because action reference is outdate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,15 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: ">=1.18"
+          go-version: "1.24"
 
-      - uses: bflad/tfproviderlint-github-action@master
-        with:
-          args: -R019=false -S018=false -V011=false -V012=false -V013=false -V014=false ./...
+      - name: Install tfproviderlint
+        run: go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.31.0
+
+      - name: Run tfproviderlint
+        run: |
+          $(go env GOPATH)/bin/tfproviderlint \
+            -R019=false -S018=false -V011=false -V012=false -V013=false -V014=false ./...
 
   schema-markdown-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**1. Why Remediation Was Needed**

- The CI job relied on `bflad/tfproviderlint-github-action@master`, which is unmaintained (last updated around 2020) and pins to an unstable `master` reference instead of a reproducible release.
- Using a third-party GitHub Action introduced an extra, opaque dependency layer (Docker-based) whose embedded Go/tool versions could drift from the rest of the workflow.
- The `tfproviderlint` job used `go-version: ">=1.18"`, which was inconsistent with other CI jobs (e.g. `build`, `golangci`) that already pin Go `1.24`.
- Pinning `tfproviderlint` to a specific version was not possible with the old Action-based setup, making CI behavior harder to control and reproduce.

**2. How Remediation Was Done**

- Replaced `bflad/tfproviderlint-github-action@master` with an explicit `go install` step:
  `go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.31.0`
- Added a dedicated `Run tfproviderlint` step that invokes the installed binary from `$(go env GOPATH)/bin/tfproviderlint` with the same rule-disable flags as before:
  `-R019=false -S018=false -V011=false -V012=false -V013=false -V014=false ./...`
- Aligned the `tfproviderlint` job’s Go toolchain with other jobs by changing `go-version` from `">=1.18"` to `"1.24"`.
- Net effect: one file changed (`.github/workflows/ci.yml`), same lint behavior preserved, but with a pinned tool version, a consistent Go version, and the same installation pattern already used for `golangci-lint` in this workflow.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. uisng tfproviderlint directly and replace the action usage.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

Trigger R018 manually:
<img width="1241" height="966" alt="image" src="https://github.com/user-attachments/assets/7d92d884-9cca-48e0-94ba-361492378581" />
All codes pass the tfprovider lint:
<img width="1013" height="885" alt="image" src="https://github.com/user-attachments/assets/b2a11df3-67b2-4cbf-ab18-03f2e07429d4" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
