### PR TITLE
feat(secmaster): support `secmaster_policy_records` datasource

### DIFF
--- a/docs/data-sources/secmaster_policy_records.md
+++ b/docs/data-sources/secmaster_policy_records.md
@@ -1,0 +1,243 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_policy_records"
+description: |-
+  Use this data source to get the list of policy records within HuaweiCloud SecMaster.
+---
+
+# huaweicloud_secmaster_policy_records
+
+Use this data source to get the list of policy records within HuaweiCloud SecMaster.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "policy_id" {}
+
+data "huaweicloud_secmaster_policy_records" "test" {
+  workspace_id = var.workspace_id
+  policy_id    = var.policy_id
+
+  sort {
+    sort_by = "create_time"
+    order   = "desc"
+  }
+
+  group_by {
+    group_by_fields = ["workspace_id"]
+    group_by_hit {
+      source = "defense_policy_object"
+      dest   = "defense_policy_list"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the policy belongs.
+
+* `policy_id` - (Required, String) Specifies the ID of the policy to query records for.
+
+* `condition` - (Optional, List) Specifies the query conditions.
+
+  The [condition](#policys_condition_struct) structure is documented below.
+
+* `sort` - (Optional, List) Specifies the sort conditions.
+
+  The [sort](#policys_sort_struct) structure is documented below.
+
+* `group_by` - (Optional, List) Specifies the aggregation conditions.
+
+  The [group_by](#policys_group_by_struct) structure is documented below.
+
+<a name="policys_condition_struct"></a>
+The `condition` block supports:
+
+* `conditions` - (Optional, List) Specifies the list of query conditions.
+
+  The [conditions](#policys_conditions_struct) structure is documented below.
+
+* `logics` - (Optional, List) Specifies the list of condition names.
+
+<a name="policys_conditions_struct"></a>
+The `conditions` block supports:
+
+* `name` - (Optional, String) Specifies the condition name.
+
+* `data` - (Optional, List) Specifies the condition values.
+
+<a name="policys_sort_struct"></a>
+The `sort` block supports:
+
+* `sort_by` - (Optional, String) Specifies the sort field.
+
+* `order` - (Optional, String) Specifies the sort direction.
+
+<a name="policys_group_by_struct"></a>
+The `group_by` block supports:
+
+* `group_by_fields` - (Optional, List) Specifies the aggregation fields.
+
+* `group_by_hit` - (Optional, List) Specifies the aggregation result mapping.
+
+  The [group_by_hit](#policys_group_by_hit_struct) structure is documented below.
+
+<a name="policys_group_by_hit_struct"></a>
+The `group_by_hit` block supports:
+
+* `source` - (Optional, String) Specifies the source field.
+
+* `dest` - (Optional, String) Specifies the destination field.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of policy records.
+
+  The [records](#records_struct) structure is documented below.
+
+<a name="records_struct"></a>
+The `records` block supports:
+
+* `id` - The ID of the policy record.
+
+* `policy_id` - The ID of the policy.
+
+* `policy_task_id` - The ID of the policy task.
+
+* `policy_task_name` - The name of the policy task.
+
+* `policy_category` - The category of the policy. Valid values: **BLOCK**, **ALLOW**.
+
+* `policy_direction` - The direction of the policy. Valid values: **INGRESS**, **EGRESS**.
+
+* `policy_automation` - The automation type of the policy. Valid values: **AUTOMATION**, **MANUAL**.
+
+* `block_target` - The block target of the policy.
+
+* `description` - The description of the policy record.
+
+* `is_deleted` - Whether the policy record is deleted.
+
+* `trigger_flag` - Whether the policy is triggered.
+
+* `create_time` - The creation time of the policy record.
+
+* `update_time` - The update time of the policy record.
+
+* `dataclass_id` - The data class ID of the policy record.
+
+* `domain_id` - The domain ID.
+
+* `domain_name` - The domain name.
+
+* `project_id` - The project ID.
+
+* `region_id` - The region ID.
+
+* `region_name` - The region name.
+
+* `workflow_instance` - The workflow instance information.
+  The [workflow_instance](#workflow_instance_struct) structure is documented below.
+
+* `block_age` - The block aging information.
+  The [block_age](#block_age_struct) structure is documented below.
+
+* `policyrecord_type` - The policy record type information.
+  The [policyrecord_type](#policyrecord_type_struct) structure is documented below.
+
+* `environment` - The environment information.
+  The [environment](#environment_struct) structure is documented below.
+
+* `defense_policy_list` - The defense policy list.
+  The [defense_policy_list](#defense_policy_list_struct) structure is documented below.
+
+<a name="workflow_instance_struct"></a>
+The `workflow_instance` block supports:
+
+* `workflow_instance_id` - The ID of the workflow instance.
+
+* `workflow_instance_name` - The name of the workflow instance.
+
+* `workflow_instance_status` - The status of the workflow instance.
+
+<a name="block_age_struct"></a>
+The `block_age` block supports:
+
+* `is_block_ageing` - Whether the block is aging.
+
+* `block_ageing` - The block aging time.
+
+<a name="policyrecord_type_struct"></a>
+The `policyrecord_type` block supports:
+
+* `policy_type` - The type of the policy record.
+
+* `id` - The ID of the policy record type.
+
+* `category` - The category of the policy record type.
+
+<a name="environment_struct"></a>
+The `environment` block supports:
+
+* `domain_id` - The domain ID.
+
+* `domain_name` - The domain name.
+
+* `project_id` - The project ID.
+
+* `region_id` - The region ID.
+
+* `region_name` - The region name.
+
+* `vendor_type` - The vendor type.
+
+<a name="defense_policy_list_struct"></a>
+The `defense_policy_list` block supports:
+
+* `defense_id` - The ID of the defense.
+
+* `defense_type` - The type of the defense.
+
+* `defense_policy_id` - The ID of the defense policy.
+
+* `defense_policy_name` - The name of the defense policy.
+
+* `defense_connection_id` - The ID of the defense connection.
+
+* `defense_connection_name` - The name of the defense connection.
+
+* `defense_connection_region_id` - The region ID of the defense connection.
+
+* `defense_connection_region_name` - The region name of the defense connection.
+
+* `defense_block_status` - The block status of the defense.
+
+* `defense_block_action` - The block action of the defense.
+
+* `defense_failure_description` - The failure description of the defense.
+
+* `defense_creator_id` - The creator ID of the defense.
+
+* `defense_creator_name` - The creator name of the defense.
+
+* `target_project_id` - The target project ID.
+
+* `target_project_name` - The target project name.
+
+* `target_enterprise_id` - The target enterprise ID.
+
+* `target_enterprise_name` - The target enterprise name.
+
+* `description` - The description of the defense policy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2406,6 +2406,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_playbook_statistics":             secmaster.DataSourceSecmasterPlaybookStatistics(),
 			"huaweicloud_secmaster_playbook_versions":               secmaster.DataSourceSecmasterPlaybookVersions(),
 			"huaweicloud_secmaster_playbooks":                       secmaster.DataSourceSecmasterPlaybooks(),
+			"huaweicloud_secmaster_policy_records":                  secmaster.DataSourcePolicyRecords(),
 			"huaweicloud_secmaster_reports_emails":                  secmaster.DataSourceReportsEmails(),
 			"huaweicloud_secmaster_retrieve_scripts":                secmaster.DataSourceRetrieveScripts(),
 			"huaweicloud_secmaster_search_conditions":               secmaster.DataSourceSearchConditions(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -560,6 +560,7 @@ var (
 	HW_SECMASTER_METRIC_ID                = os.Getenv("HW_SECMASTER_METRIC_ID")
 	HW_SECMASTER_COMPONENT_VERSION_ID     = os.Getenv("HW_SECMASTER_COMPONENT_VERSION_ID")
 	HW_SECMASTER_ATTACH_ID                = os.Getenv("HW_SECMASTER_ATTACH_ID")
+	HW_SECMASTER_POLICY_ID                = os.Getenv("HW_SECMASTER_POLICY_ID")
 
 	// The SecMaster pipeline ID
 	HW_SECMASTER_PIPELINE_ID = os.Getenv("HW_SECMASTER_PIPELINE_ID")
@@ -3314,6 +3315,13 @@ func TestAccPreCheckSecMasterComponentVersionID(t *testing.T) {
 func TestAccPreCheckSecMasterRDSAssetID(t *testing.T) {
 	if HW_SECMASTER_RDS_ASSET_ID == "" {
 		t.Skip("HW_SECMASTER_RDS_ASSET_ID must be set for SecMaster acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSecMasterPolicyID(t *testing.T) {
+	if HW_SECMASTER_POLICY_ID == "" {
+		t.Skip("HW_SECMASTER_POLICY_ID must be set for SecMaster acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_policy_records_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_policy_records_test.go
@@ -1,0 +1,59 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePolicyRecords_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_policy_records.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterPolicyID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePolicyRecords_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "workspace_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "policy_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePolicyRecords_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_policy_records" "test" {
+  workspace_id = "%[1]s"
+  policy_id    = "%[2]s"
+
+  sort {
+    sort_by = "create_time"
+    order   = "desc"
+  }
+
+  group_by {
+    group_by_fields = ["workspace_id"]
+    group_by_hit {
+      source = "defense_policy_object"
+      dest   = "defense_policy_list"
+    }
+  }
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_POLICY_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_policy_records.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_policy_records.go
@@ -1,0 +1,701 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/soc/policy-records/{policy_id}/search
+func DataSourcePolicyRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePolicyRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"condition": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     policyRecordsConditionSchema(),
+			},
+			"sort": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     policyRecordsSortSchema(),
+			},
+			"group_by": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     policyRecordsGroupBySchema(),
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_task_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_task_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_direction": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_automation": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"block_target": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_deleted": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"trigger_flag": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dataclass_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"workflow_instance": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"workflow_instance_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"workflow_instance_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"workflow_instance_status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"block_age": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"is_block_ageing": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"block_ageing": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"policyrecord_type": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"policy_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"category": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"environment": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"domain_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"domain_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"project_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"region_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"region_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"vendor_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"defense_policy_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"defense_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_policy_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_policy_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_connection_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_connection_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_connection_region_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_connection_region_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_block_status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_block_action": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_failure_description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_creator_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"defense_creator_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_project_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_project_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_enterprise_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_enterprise_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func policyRecordsConditionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"conditions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     policyRecordsConditionsSchema(),
+			},
+			"logics": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func policyRecordsConditionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func policyRecordsSortSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"sort_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func policyRecordsGroupBySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"group_by_fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"group_by_hit": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     policyRecordsGroupByHitSchema(),
+			},
+		},
+	}
+}
+
+func policyRecordsGroupByHitSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dest": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourcePolicyRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/policy-records/{policy_id}/search"
+		result  = make([]interface{}, 0)
+		limit   = 1000
+		offset  = 0
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{policy_id}", d.Get("policy_id").(string))
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type":        "application/json;charset=UTF-8",
+			"X-Secmaster-Version": "25.5.0",
+		},
+	}
+
+	for {
+		currentBodyParams := buildPolicyRecordsBodyParams(d, limit, offset)
+		reqOpt.JSONBody = currentBodyParams
+
+		resp, err := client.Request("POST", requestPath, &reqOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving SecMaster policy records: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataRaw := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataRaw) == 0 {
+			break
+		}
+
+		result = append(result, dataRaw...)
+
+		total := utils.PathSearch("total", respBody, float64(0)).(float64)
+		if int(total) <= offset+len(dataRaw) {
+			break
+		}
+
+		offset += len(dataRaw)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("records", flattenPolicyRecords(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildPolicyRecordsBodyParams(d *schema.ResourceData, limit, offset int) map[string]interface{} {
+	return map[string]interface{}{
+		"limit":     limit,
+		"offset":    offset,
+		"condition": buildPolicyRecordsConditionBodyParams(d.Get("condition").([]interface{})),
+		"sort":      buildPolicyRecordsSortBodyParams(d.Get("sort").([]interface{})),
+		"group_by":  buildPolicyRecordsGroupByBodyParams(d.Get("group_by").([]interface{})),
+	}
+}
+
+func buildPolicyRecordsConditionBodyParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"conditions": buildPolicyRecordsConditionsBodyParams(rawMap["conditions"].([]interface{})),
+		"logics":     utils.ValueIgnoreEmpty(rawMap["logics"]),
+	}
+}
+
+func buildPolicyRecordsConditionsBodyParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"name": utils.ValueIgnoreEmpty(rawMap["name"]),
+			"data": utils.ValueIgnoreEmpty(rawMap["data"]),
+		})
+	}
+
+	return rst
+}
+
+func buildPolicyRecordsSortBodyParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"sort_by": utils.ValueIgnoreEmpty(rawMap["sort_by"]),
+			"order":   utils.ValueIgnoreEmpty(rawMap["order"]),
+		})
+	}
+
+	return rst
+}
+
+func buildPolicyRecordsGroupByBodyParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"group_by_fields": utils.ValueIgnoreEmpty(rawMap["group_by_fields"]),
+		"group_by_hit":    buildPolicyRecordsGroupByHitBodyParams(rawMap["group_by_hit"].([]interface{})),
+	}
+}
+
+func buildPolicyRecordsGroupByHitBodyParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"source": utils.ValueIgnoreEmpty(rawMap["source"]),
+		"dest":   utils.ValueIgnoreEmpty(rawMap["dest"]),
+	}
+}
+
+func flattenPolicyRecords(records []interface{}) []map[string]interface{} {
+	if len(records) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		dataObject := utils.PathSearch("data_object", record, nil)
+		if dataObject == nil {
+			continue
+		}
+
+		result = append(result, map[string]interface{}{
+			"id":                  utils.PathSearch("id", dataObject, nil),
+			"policy_id":           utils.PathSearch("policy_id", dataObject, nil),
+			"policy_task_id":      utils.PathSearch("policy_task_id", dataObject, nil),
+			"policy_task_name":    utils.PathSearch("policy_task_name", dataObject, nil),
+			"policy_category":     utils.PathSearch("policy_category", dataObject, nil),
+			"policy_direction":    utils.PathSearch("policy_direction", dataObject, nil),
+			"policy_automation":   utils.PathSearch("policy_automation", dataObject, nil),
+			"block_target":        utils.PathSearch("block_target", dataObject, nil),
+			"description":         utils.PathSearch("description", dataObject, nil),
+			"is_deleted":          utils.PathSearch("is_deleted", dataObject, nil),
+			"trigger_flag":        utils.PathSearch("trigger_flag", dataObject, nil),
+			"create_time":         utils.PathSearch("create_time", dataObject, nil),
+			"update_time":         utils.PathSearch("update_time", dataObject, nil),
+			"dataclass_id":        utils.PathSearch("dataclass_id", dataObject, nil),
+			"domain_id":           utils.PathSearch("domain_id", dataObject, nil),
+			"domain_name":         utils.PathSearch("domain_name", dataObject, nil),
+			"project_id":          utils.PathSearch("project_id", dataObject, nil),
+			"region_id":           utils.PathSearch("region_id", dataObject, nil),
+			"region_name":         utils.PathSearch("region_name", dataObject, nil),
+			"workflow_instance":   flattenWorkflowInstance(dataObject),
+			"block_age":           flattenBlockAge(dataObject),
+			"policyrecord_type":   flattenPolicyrecordType(dataObject),
+			"environment":         flattenEnvironment(dataObject),
+			"defense_policy_list": flattenDefensePolicyList(dataObject),
+		})
+	}
+
+	return result
+}
+
+func flattenWorkflowInstance(dataObject interface{}) []map[string]interface{} {
+	instance := utils.PathSearch("workflow_instance", dataObject, nil)
+	if instance == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"workflow_instance_id":     utils.PathSearch("workflow_instance_id", instance, nil),
+			"workflow_instance_name":   utils.PathSearch("workflow_instance_name", instance, nil),
+			"workflow_instance_status": utils.PathSearch("workflow_instance_status", instance, nil),
+		},
+	}
+}
+
+func flattenBlockAge(dataObject interface{}) []map[string]interface{} {
+	blockAge := utils.PathSearch("block_age", dataObject, nil)
+	if blockAge == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"is_block_ageing": utils.PathSearch("is_block_ageing", blockAge, nil),
+			"block_ageing":    utils.PathSearch("block_ageing", blockAge, nil),
+		},
+	}
+}
+
+func flattenPolicyrecordType(dataObject interface{}) []map[string]interface{} {
+	recordType := utils.PathSearch("policyrecord_type", dataObject, nil)
+	if recordType == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"policy_type": utils.PathSearch("policy_type", recordType, nil),
+			"id":          utils.PathSearch("id", recordType, nil),
+			"category":    utils.PathSearch("category", recordType, nil),
+		},
+	}
+}
+
+func flattenEnvironment(dataObject interface{}) []map[string]interface{} {
+	env := utils.PathSearch("environment", dataObject, nil)
+	if env == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"domain_id":   utils.PathSearch("domain_id", env, nil),
+			"domain_name": utils.PathSearch("domain_name", env, nil),
+			"project_id":  utils.PathSearch("project_id", env, nil),
+			"region_id":   utils.PathSearch("region_id", env, nil),
+			"region_name": utils.PathSearch("region_name", env, nil),
+			"vendor_type": utils.PathSearch("vendor_type", env, nil),
+		},
+	}
+}
+
+func flattenDefensePolicyList(dataObject interface{}) []map[string]interface{} {
+	listRaw := utils.PathSearch("defense_policy_list", dataObject, make([]interface{}, 0))
+	list, ok := listRaw.([]interface{})
+	if !ok || len(list) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, v := range list {
+		result = append(result, map[string]interface{}{
+			"defense_id":                     utils.PathSearch("defense_id", v, nil),
+			"defense_type":                   utils.PathSearch("defense_type", v, nil),
+			"defense_policy_id":              utils.PathSearch("defense_policy_id", v, nil),
+			"defense_policy_name":            utils.PathSearch("defense_policy_name", v, nil),
+			"defense_connection_id":          utils.PathSearch("defense_connection_id", v, nil),
+			"defense_connection_name":        utils.PathSearch("defense_connection_name", v, nil),
+			"defense_connection_region_id":   utils.PathSearch("defense_connection_region_id", v, nil),
+			"defense_connection_region_name": utils.PathSearch("defense_connection_region_name", v, nil),
+			"defense_block_status":           utils.PathSearch("defense_block_status", v, nil),
+			"defense_block_action":           utils.PathSearch("defense_block_action", v, nil),
+			"defense_failure_description":    utils.PathSearch("defense_failure_description", v, nil),
+			"defense_creator_id":             utils.PathSearch("defense_creator_id", v, nil),
+			"defense_creator_name":           utils.PathSearch("defense_creator_name", v, nil),
+			"target_project_id":              utils.PathSearch("target_project_id", v, nil),
+			"target_project_name":            utils.PathSearch("target_project_name", v, nil),
+			"target_enterprise_id":           utils.PathSearch("target_enterprise_id", v, nil),
+			"target_enterprise_name":         utils.PathSearch("target_enterprise_name", v, nil),
+			"description":                    utils.PathSearch("description", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `secmaster_policy_records` datasource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `secmaster_policy_records` datasource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o secmaster -f TestAccDataSourcePolicyRecords_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourcePolicyRecords_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourcePolicyRecords_basic
=== PAUSE TestAccDataSourcePolicyRecords_basic
=== CONT  TestAccDataSourcePolicyRecords_basic
--- PASS: TestAccDataSourcePolicyRecords_basic (14.77s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 16.221s coverage: 4.5% of statements in ./huaweicloud/services/secmaster
```
<img width="1055" height="37" alt="image" src="https://github.com/user-attachments/assets/a33eaabd-16f9-4d9a-8d9f-bef24d52ee98" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
