### PR TITLE
feat(SecMaster): support collector_channel resource

### DIFF
--- a/docs/resources/secmaster_collector_channel.md
+++ b/docs/resources/secmaster_collector_channel.md
@@ -1,0 +1,258 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_collector_channel"
+description: |-
+  Manages a collector channel resource within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_collector_channel
+
+Manages a collector channel resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "group_id" {}
+variable "parser_id" {}
+variable "node_id" {}
+variable "input_template_id" {}
+variable "input_connection_module_id" {}
+variable "output_template_id" {}
+variable "output_connection_module_id" {}
+variable "input_mode_template_field_id" {}
+variable "input_port_template_field_id" {}
+variable "input_codec_template_field_id" {}
+variable "output_port_template_field_id" {}
+variable "output_codec_template_field_id" {}
+variable "output_host_template_field_id" {}
+
+resource "huaweicloud_secmaster_collector_channel" "test" {
+  workspace_id = var.workspace_id
+  title        = "test-channel"
+  group_id     = var.group_id
+  parser_id    = var.parser_id
+
+  input {
+    name                 = "tcp"
+    template_id          = var.input_template_id
+    connection_module_id = var.input_connection_module_id
+
+    fields {
+      name              = "mode"
+      type              = "string"
+      value             = "server"
+      template_field_id = var.input_mode_template_field_id
+    }
+    fields {
+      name              = "port"
+      type              = "number"
+      value             = "514"
+      template_field_id = var.input_port_template_field_id
+    }
+    fields {
+      name              = "codec"
+      type              = "string"
+      value             = "json"
+      template_field_id = var.input_codec_template_field_id
+    }
+  }
+
+  output {
+    name                 = "tcp"
+    template_id          = var.output_template_id
+    connection_module_id = var.output_connection_module_id
+
+    fields {
+      name              = "port"
+      type              = "number"
+      value             = "514"
+      template_field_id = var.output_port_template_field_id
+    }
+    fields {
+      name              = "codec"
+      type              = "string"
+      value             = "json_lines"
+      template_field_id = var.output_codec_template_field_id
+    }
+    fields {
+      name              = "host"
+      type              = "string"
+      value             = "192.168.0.196"
+      template_field_id = var.output_host_template_field_id
+    }
+  }
+
+  nodes {
+    node_id = var.node_id
+
+    args {
+      key   = "param1"
+      value = "value1"
+    }
+  }
+
+  description = "created by terraform"
+  action      = "INSTALL"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the workspace ID.
+
+* `title` - (Required, String) Specifies the collector channel title.
+
+* `group_id` - (Required, String) Specifies the collector channel group ID.
+
+* `parser_id` - (Required, String) Specifies the collector parser ID.
+
+* `input` - (Required, List) Specifies the list of input module configurations.
+
+  The [input](#input_struct) structure is documented below.
+
+* `output` - (Required, List) Specifies the list of output module configurations.
+
+  The [output](#output_struct) structure is documented below.
+
+* `nodes` - (Required, List) Specifies the list of node configurations.
+
+  The [nodes](#nodes_struct) structure is documented below.
+
+* `description` - (Optional, String) Specifies the collector channel description.
+
+* `action` - (Optional, String) Specifies the node operation action.
+  The valid values are as follows:
+  + **START**: Start.
+  + **STOP**: Stop.
+  + **REMOVE**: Remove.
+  + **RESTART**: Restart.
+  + **REFRESH**: Refresh.
+  + **INSTALL**: Install.
+
+<a name="input_struct"></a>
+The `input` block supports:
+
+* `name` - (Optional, String) Specifies the input module name.
+
+* `template_id` - (Optional, String) Specifies the input module template UUID.
+
+* `connection_module_id` - (Optional, String) Specifies the associated connection module UUID of the input
+  module.
+
+* `children` - (Optional, List) Specifies the list of input child modules.
+
+  The [input children](#input_children_struct) structure is documented below.
+
+* `fields` - (Optional, List) Specifies the list of input field configurations.
+
+  The [fields](#fields_struct) structure is documented below.
+
+<a name="input_children_struct"></a>
+The `input.children` block supports:
+
+* `name` - (Optional, String) Specifies the input child module name.
+
+* `template_id` - (Optional, String) Specifies the input child module template UUID.
+
+* `connection_module_id` - (Optional, String) Specifies the associated connection module UUID of the input
+  child module.
+
+* `fields` - (Optional, List) Specifies the list of input child field configurations.
+
+  The [fields](#fields_struct) structure is documented below.
+
+<a name="output_struct"></a>
+The `output` block supports:
+
+* `name` - (Optional, String) Specifies the output module name.
+
+* `template_id` - (Optional, String) Specifies the output module template UUID.
+
+* `connection_module_id` - (Optional, String) Specifies the associated connection module UUID of the output
+  module.
+
+* `children` - (Optional, List) Specifies the list of output child modules.
+
+  The [output children](#output_children_struct) structure is documented below.
+
+* `fields` - (Optional, List) Specifies the list of output field configurations.
+
+  The [fields](#fields_struct) structure is documented below.
+
+<a name="output_children_struct"></a>
+The `output.children` block supports:
+
+* `name` - (Optional, String) Specifies the output child module name.
+
+* `template_id` - (Optional, String) Specifies the output child module template UUID.
+
+* `connection_module_id` - (Optional, String) Specifies the associated connection module UUID of the output
+  child module.
+
+* `fields` - (Optional, List) Specifies the list of output child field configurations.
+
+  The [fields](#fields_struct) structure is documented below.
+
+<a name="fields_struct"></a>
+The `fields` block supports:
+
+* `name` - (Optional, String) Specifies the field name.
+
+* `type` - (Optional, String) Specifies the field type.
+
+* `value` - (Optional, String) Specifies the field value.
+
+* `other` - (Optional, String) Specifies other supplementary information.
+
+* `template_field_id` - (Optional, String) Specifies the template field UUID.
+
+* `connection_module_id` - (Optional, String) Specifies the associated connection module UUID.
+
+<a name="nodes_struct"></a>
+The `nodes` block supports:
+
+* `node_id` - (Optional, String) Specifies the node UUID.
+
+* `node_status` - (Optional, String) Specifies the node status.
+  The valid values are **RUN** and **STOP**.
+
+* `args` - (Optional, List) Specifies the list of custom arguments.
+
+  The [args](#args_struct) structure is documented below.
+
+<a name="args_struct"></a>
+The `args` block supports:
+
+* `key` - (Optional, String) Specifies the argument key.
+
+* `value` - (Optional, String) Specifies the argument value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the collector channel UUID.
+
+* `create_by` - The IAM user ID.
+
+* `error` - The collector channel error type.
+
+* `operation_status` - The deployment operation status.
+
+* `parser_name` - The collector parser name.
+
+## Import
+
+The collector channel can be imported using the `workspace_id` and `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_secmaster_collector_channel.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4491,6 +4491,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_clone_playbook_version":      secmaster.ResourceClonePlaybookAndVersion(),
 			"huaweicloud_secmaster_cloud_log_resource":          secmaster.ResourceCloudLogResource(),
 			"huaweicloud_secmaster_collect_config":              secmaster.ResourceCollectConfig(),
+			"huaweicloud_secmaster_collector_channel":           secmaster.ResourceCollectorChannel(),
 			"huaweicloud_secmaster_collector_channel_group":     secmaster.ResourceCollectorChannelGroup(),
 			"huaweicloud_secmaster_collector_channel_operation": secmaster.ResourceCollectorChannelOperation(),
 			"huaweicloud_secmaster_collector_parser":            secmaster.ResourceCollectorParser(),

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_collector_channel_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_collector_channel_test.go
@@ -1,0 +1,51 @@
+package secmaster
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to the lack of a test environment, only the expected failure scenario can be tested at present.
+// The values of `group_id` and `parser_id` in the test script are mock data.
+func TestAccResourceCollectorChannel_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceCollectorChannel_basic(),
+				ExpectError: regexp.MustCompile(`参数不合法`),
+			},
+		},
+	})
+}
+
+func testAccResourceCollectorChannel_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_collector_channel" "test" {
+  workspace_id = "%[1]s"
+  title        = "tf_test_channel"
+  group_id     = "00000000-0000-0000-0000-000000000000"
+  parser_id    = "00000000-0000-0000-0000-000000000000"
+
+  input {
+  }
+
+  output {
+  }
+
+  nodes {
+  }
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_channel.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_channel.go
@@ -1,0 +1,747 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var collectorChannelNonUpdatableParams = []string{"workspace_id"}
+
+var collectorChannelActions = []string{"START", "STOP", "REMOVE", "RESTART", "REFRESH", "INSTALL"}
+
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/collector/channels
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/collector/channels
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/collector/channels/{channel_id}
+// @API SecMaster PUT /v1/{project_id}/workspaces/{workspace_id}/collector/channels/{channel_id}
+// @API SecMaster DELETE /v1/{project_id}/workspaces/{workspace_id}/collector/channels/{channel_id}
+func ResourceCollectorChannel() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCollectorChannelCreate,
+		ReadContext:   resourceCollectorChannelRead,
+		UpdateContext: resourceCollectorChannelUpdate,
+		DeleteContext: resourceCollectorChannelDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCollectorChannelImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(collectorChannelNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"parser_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"input": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     collectorChannelModuleSchema(),
+			},
+			"output": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     collectorChannelModuleSchema(),
+			},
+			"nodes": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     collectorChannelNodeSchema(),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"action": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(collectorChannelActions, false),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"create_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"operation_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parser_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func collectorChannelNodeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"node_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"args": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func collectorChannelModuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"connection_module_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"children": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     collectorChannelChildModuleSchema(),
+			},
+			"fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     collectorChannelFieldSchema(),
+			},
+		},
+	}
+}
+
+func collectorChannelChildModuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"connection_module_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     collectorChannelFieldSchema(),
+			},
+		},
+	}
+}
+
+func collectorChannelFieldSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"other": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template_field_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"connection_module_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCollectorChannelBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"title":       d.Get("title"),
+		"group_id":    d.Get("group_id"),
+		"parser_id":   d.Get("parser_id"),
+		"input":       buildCollectorChannelModulesBodyParams(d.Get("input").([]interface{})),
+		"output":      buildCollectorChannelModulesBodyParams(d.Get("output").([]interface{})),
+		"nodes":       buildCollectorChannelNodesBodyParams(d.Get("nodes").([]interface{})),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"action":      utils.ValueIgnoreEmpty(d.Get("action")),
+	}
+
+	return bodyParams
+}
+
+func buildCollectorChannelNodesBodyParams(nodes []interface{}) []map[string]interface{} {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(nodes))
+	for _, v := range nodes {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		node := map[string]interface{}{
+			"node_id":     utils.ValueIgnoreEmpty(rawMap["node_id"]),
+			"node_status": utils.ValueIgnoreEmpty(rawMap["node_status"]),
+			"args":        buildCollectorChannelArgsBodyParams(rawMap["args"].([]interface{})),
+		}
+		rst = append(rst, node)
+	}
+
+	return rst
+}
+
+func buildCollectorChannelArgsBodyParams(args []interface{}) []map[string]interface{} {
+	if len(args) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(args))
+	for _, v := range args {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		arg := map[string]interface{}{
+			"key":   utils.ValueIgnoreEmpty(rawMap["key"]),
+			"value": utils.ValueIgnoreEmpty(rawMap["value"]),
+		}
+		rst = append(rst, arg)
+	}
+
+	return rst
+}
+
+func buildCollectorChannelModulesBodyParams(modules []interface{}) []map[string]interface{} {
+	if len(modules) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(modules))
+	for _, v := range modules {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		module := map[string]interface{}{
+			"name":                 utils.ValueIgnoreEmpty(rawMap["name"]),
+			"template_id":          utils.ValueIgnoreEmpty(rawMap["template_id"]),
+			"connection_module_id": utils.ValueIgnoreEmpty(rawMap["connection_module_id"]),
+			"children":             buildCollectorChannelChildModulesBodyParams(rawMap["children"].([]interface{})),
+			"fields":               buildCollectorChannelFieldsBodyParams(rawMap["fields"].([]interface{})),
+		}
+		rst = append(rst, module)
+	}
+
+	return rst
+}
+
+func buildCollectorChannelChildModulesBodyParams(modules []interface{}) []map[string]interface{} {
+	if len(modules) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(modules))
+	for _, v := range modules {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		module := map[string]interface{}{
+			"name":                 utils.ValueIgnoreEmpty(rawMap["name"]),
+			"template_id":          utils.ValueIgnoreEmpty(rawMap["template_id"]),
+			"connection_module_id": utils.ValueIgnoreEmpty(rawMap["connection_module_id"]),
+			"fields":               buildCollectorChannelFieldsBodyParams(rawMap["fields"].([]interface{})),
+		}
+		rst = append(rst, module)
+	}
+
+	return rst
+}
+
+func buildCollectorChannelFieldsBodyParams(fields []interface{}) []map[string]interface{} {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(fields))
+	for _, v := range fields {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		field := map[string]interface{}{
+			"name":                 utils.ValueIgnoreEmpty(rawMap["name"]),
+			"type":                 utils.ValueIgnoreEmpty(rawMap["type"]),
+			"value":                utils.ValueIgnoreEmpty(rawMap["value"]),
+			"other":                utils.ValueIgnoreEmpty(rawMap["other"]),
+			"template_field_id":    utils.ValueIgnoreEmpty(rawMap["template_field_id"]),
+			"connection_module_id": utils.ValueIgnoreEmpty(rawMap["connection_module_id"]),
+		}
+		rst = append(rst, field)
+	}
+
+	return rst
+}
+
+func resourceCollectorChannelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		title       = d.Get("title").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/collector/channels"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", workspaceId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCollectorChannelBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating collector channel: %s", err)
+	}
+
+	channel, err := GetCollectorChannelByTitle(client, workspaceId, title)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	channelId := utils.PathSearch("channel_id", channel, "").(string)
+	if channelId == "" {
+		return diag.Errorf("error creating collector channel: unable to find channel ID")
+	}
+
+	d.SetId(channelId)
+
+	return resourceCollectorChannelRead(ctx, d, meta)
+}
+
+func GetCollectorChannelByTitle(client *golangsdk.ServiceClient, workspaceId, title string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/workspaces/{workspace_id}/collector/channels"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{workspace_id}", workspaceId)
+	queryParams := url.Values{}
+	queryParams.Add("title", title)
+	queryParams.Add("limit", "200")
+	queryParams.Add("offset", "0")
+	listPath = fmt.Sprintf("%s?%s", listPath, queryParams.Encode())
+
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", listPath, &listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	record := utils.PathSearch("records|[0]", respBody, nil)
+	if record == nil {
+		// When the collector channel does not exist, the status code is `200` and the records list is empty.
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/workspaces/{workspace_id}/collector/channels",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the collector channel (%s) does not exist", title)),
+			},
+		}
+	}
+	return record, nil
+}
+
+func GetCollectorChannelById(client *golangsdk.ServiceClient, workspaceId, channelId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/workspaces/{workspace_id}/collector/channels/{channel_id}"
+	readPath := client.Endpoint + httpUrl
+	readPath = strings.ReplaceAll(readPath, "{project_id}", client.ProjectID)
+	readPath = strings.ReplaceAll(readPath, "{workspace_id}", workspaceId)
+	readPath = strings.ReplaceAll(readPath, "{channel_id}", channelId)
+
+	readOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", readPath, &readOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceCollectorChannelRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	respBody, err := GetCollectorChannelById(client, workspaceId, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving collector channel")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("workspace_id", workspaceId),
+		d.Set("title", utils.PathSearch("title", respBody, nil)),
+		d.Set("group_id", utils.PathSearch("group_id", respBody, nil)),
+		d.Set("parser_id", utils.PathSearch("parser_id", respBody, nil)),
+		d.Set("input", flattenCollectorChannelModules(utils.PathSearch("input", respBody, nil))),
+		d.Set("output", flattenCollectorChannelModules(utils.PathSearch("output", respBody, nil))),
+		d.Set("nodes", flattenCollectorChannelNodes(utils.PathSearch("nodes", respBody, nil))),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("create_by", utils.PathSearch("create_by", respBody, nil)),
+		d.Set("error", utils.PathSearch("error", respBody, nil)),
+		d.Set("operation_status", utils.PathSearch("operation_status", respBody, nil)),
+		d.Set("parser_name", utils.PathSearch("parser_name", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCollectorChannelNodes(nodesResp interface{}) []interface{} {
+	if nodesResp == nil {
+		return nil
+	}
+
+	nodes, ok := nodesResp.([]interface{})
+	if !ok || len(nodes) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(nodes))
+	for _, v := range nodes {
+		rst = append(rst, map[string]interface{}{
+			"node_id":     utils.ValueIgnoreEmpty(utils.PathSearch("node_id", v, "").(string)),
+			"node_status": utils.PathSearch("node_status", v, nil),
+			"args":        flattenCollectorChannelArgs(utils.PathSearch("args", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenCollectorChannelArgs(argsResp interface{}) []interface{} {
+	if argsResp == nil {
+		return nil
+	}
+
+	args, ok := argsResp.([]interface{})
+	if !ok || len(args) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(args))
+	for _, v := range args {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenCollectorChannelModules(modulesResp interface{}) []interface{} {
+	if modulesResp == nil {
+		return nil
+	}
+
+	modules, ok := modulesResp.([]interface{})
+	if !ok || len(modules) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(modules))
+	for _, v := range modules {
+		rst = append(rst, map[string]interface{}{
+			"name":                 utils.PathSearch("name", v, nil),
+			"template_id":          utils.PathSearch("template_id", v, nil),
+			"connection_module_id": utils.PathSearch("connection_module_id", v, nil),
+			"children":             flattenCollectorChannelChildModules(utils.PathSearch("children", v, nil)),
+			"fields":               flattenCollectorChannelFields(utils.PathSearch("fields", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenCollectorChannelChildModules(modulesResp interface{}) []interface{} {
+	if modulesResp == nil {
+		return nil
+	}
+
+	modules, ok := modulesResp.([]interface{})
+	if !ok || len(modules) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(modules))
+	for _, v := range modules {
+		rst = append(rst, map[string]interface{}{
+			"name":                 utils.PathSearch("name", v, nil),
+			"template_id":          utils.PathSearch("template_id", v, nil),
+			"connection_module_id": utils.PathSearch("connection_module_id", v, nil),
+			"fields":               flattenCollectorChannelFields(utils.PathSearch("fields", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenCollectorChannelFields(fieldsResp interface{}) []interface{} {
+	if fieldsResp == nil {
+		return nil
+	}
+
+	fields, ok := fieldsResp.([]interface{})
+	if !ok || len(fields) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(fields))
+	for _, v := range fields {
+		rst = append(rst, map[string]interface{}{
+			"name":                 utils.PathSearch("name", v, nil),
+			"type":                 utils.PathSearch("type", v, nil),
+			"value":                utils.PathSearch("value", v, nil),
+			"other":                utils.PathSearch("other", v, nil),
+			"template_field_id":    utils.PathSearch("template_field_id", v, nil),
+			"connection_module_id": utils.PathSearch("connection_module_id", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func resourceCollectorChannelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/collector/channels/{channel_id}"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{workspace_id}", workspaceId)
+	updatePath = strings.ReplaceAll(updatePath, "{channel_id}", d.Id())
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCollectorChannelBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating collector channel: %s", err)
+	}
+
+	return resourceCollectorChannelRead(ctx, d, meta)
+}
+
+func resourceCollectorChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/collector/channels/{channel_id}"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{workspace_id}", workspaceId)
+	deletePath = strings.ReplaceAll(deletePath, "{channel_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting collector channel (%s)", d.Id()))
+	}
+
+	if err := waitCollectorChannelDeleted(ctx, client, workspaceId, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for collector channel (%s) deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func waitCollectorChannelDeleted(ctx context.Context, client *golangsdk.ServiceClient, workspaceId, channelId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"DELETED"},
+		Refresh:      collectorChannelDeleteStateRefreshFunc(client, workspaceId, channelId),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func collectorChannelDeleteStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, channelId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		channel, err := GetCollectorChannelById(client, workspaceId, channelId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return map[string]interface{}{}, "DELETED", nil
+			}
+			return channel, "ERROR", err
+		}
+
+		return channel, "PENDING", nil
+	}
+}
+
+func resourceCollectorChannelImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, d.Set("workspace_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support collector_channel resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support collector_channel resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/secmaster' TESTARGS='-run TestAccResourceCollectorChannel_basic -v'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccResourceCollectorChannel_basic -v -timeout 360m -parallel 4
=== RUN   TestAccResourceCollectorChannel_basic
=== PAUSE TestAccResourceCollectorChannel_basic
=== CONT  TestAccResourceCollectorChannel_basic
--- PASS: TestAccResourceCollectorChannel_basic (86.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 87.023s

```
<img width="487" height="19" alt="Snipaste_2026-06-29_15-30-04" src="https://github.com/user-attachments/assets/a4b9c120-fe02-4f6d-8132-51f97cb2ca6e" />

<img width="840" height="747" alt="Snipaste_2026-06-29_16-09-31" src="https://github.com/user-attachments/assets/2f455adf-a67e-434c-a6ba-2b27d0c234c5" />
<img width="1003" height="501" alt="Snipaste_2026-06-29_16-23-02" src="https://github.com/user-attachments/assets/bed2a95f-6b7b-4023-993b-d162d155705a" />
<img width="1195" height="266" alt="Snipaste_2026-06-29_16-20-27" src="https://github.com/user-attachments/assets/b525d9d4-e181-42f5-aa29-4d3ea923b9aa" />

<img width="888" height="745" alt="Snipaste_2026-06-29_16-12-57" src="https://github.com/user-attachments/assets/30a4eae3-1e6b-46c5-830c-6805e7ac4116" />



<img width="1385" height="180" alt="Snipaste_2026-06-29_16-24-50" src="https://github.com/user-attachments/assets/ae179f86-3df8-4df9-804e-b36ee60fd6b2" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    
<img width="1124" height="699" alt="Snipaste_2026-06-29_16-43-05" src="https://github.com/user-attachments/assets/8bcd8711-8e72-486f-bcef-9671b3a333be" />


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
