### PR TITLE
feat(GeminiDB): add data source to get list of GeminiDB Redis slow logs

### DIFF
--- a/docs/data-sources/geminidb_redis_slow_logs.md
+++ b/docs/data-sources/geminidb_redis_slow_logs.md
@@ -1,0 +1,112 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_redis_slow_logs"
+description: |-
+  Use this data source to query the list of GeminiDB Redis instance slow logs.
+---
+
+# huaweicloud_geminidb_redis_slow_logs
+
+Use this data source to query the list of GeminiDB Redis instance slow logs.
+
+## Example Usage
+
+### Query all slow logs
+
+```hcl
+variable "instance_id" {}
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_geminidb_redis_slow_logs" "test" {
+  instance_id = var.instance_id
+  start_time  = var.start_time
+  end_time    = var.end_time
+}
+```
+
+### Query slow logs by node ID
+
+```hcl
+variable "instance_id" {}
+variable "start_time" {}
+variable "end_time" {}
+variable "node_id" {}
+
+data "huaweicloud_geminidb_redis_slow_logs" "test" {
+  instance_id = var.instance_id
+  start_time  = var.start_time
+  end_time    = var.end_time
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the GeminiDB Redis instance ID.
+
+* `start_time` - (Required, String) Specifies the query start time.
+  The format is **yyyy-mm-ddThh:mm:ss+0800**, e.g. **2026-06-01T12:00:00+0800**.
+  The start time cannot be `30` days earlier than the current time.
+
+* `end_time` - (Required, String) Specifies the query end time.
+  The format is **yyyy-mm-ddThh:mm:ss+0800**, e.g. **2026-06-01T12:00:00+0800**.
+  The end time cannot be later than the current time.
+
+* `operate_type` - (Optional, String) Specifies the statement type.
+  The value can be **set**, **get**, **del**, **incr**, **incrby**, **incrbyfloat**, **decr**, **decrby**, **getset**,
+  **append**, **mget**, **keys**, **setnx**, **setex**, **psetex**, **delvx**, **mset**, **msetnx**, **getrange**,
+  **substr**, **setrange**, **strlen**, **exists**, **expire**, **pexpire**, **expireat**, **pexpireat**, **ttl**,
+  **pttl**, **persist**, **type**, **scanx**, **pksetexat**, **sort**, **hdel**, **hset**, **hget**, **hgetall**,
+  **hexists**, **hincrby**, **hincrbyfloat**, **hkeys**, **hlen**, **hmget**, **hmset**, **hsetnx**, **hstrlen**,
+  **hvals**, **hscan**, **hscanx**, **pkhscanrange**, **pkhrscanrange**, **lindex**, **linsert**, **llen**, **lpop**,
+  **lpush**, **lpushx**, **lrange**, **lrem**, **lset**, **ltrim**, **rpop**, **rpoplpush**, **rpush**, **rpushx**,
+  **zadd**, **zcard**,**zscan**,**zincrby**, **zrange**, **zrevrange**, **zrangebyscore**, **zrevrangebyscore**,
+  **zcount**, **zrem**, **zunionstore**, **zinterstore**, **zrank**, **zrevrank**, **zscore**, **zrangebylex**,
+  **zrevrangebylex**, **zlexcount**, **zremrangebyrank**, **zremrangebyscore**, **zremrangebylex**, **zpopmax**,
+  **zpopmin**, **sadd**, **spop**, **scard**, **smembers**, **sscan**, **srem**, **sunion**, **sunionstore**,
+  **sinter**, **sinterstore**, **sismember**, **sdiff**, **sdiffstore**, **smove**, **srandmember**, **bitset**,
+  **bitget**, **bitcount**, **bitpos**, **bitop**, **bitfield**, **pfadd**, **pfcount**, **pfmerge**, **geoadd**,
+  **georadiusbymember**, **georadius**, **geohash**, **geodist**, **geopos**, **xadd**, **xack**, **xgroup**, **xdel**,
+  **xtrim**, **xlen**, **xrange**, **xrevrange**, **xclaim**, **xpending**, **xinfo**, **xread**, or **xreadgroup**.
+
+* `node_id` - (Optional, String) Specifies the node ID.
+
+* `keywords` - (Optional, List) Specifies query the slow logs by keywords matched.
+  A maximum of `10` keywords are supported.
+
+* `max_cost_time` - (Optional, Int) Specifies the logs can be searched based on the maximum execution duration, in ms.
+
+* `min_cost_time` - (Optional, Int) Specifies the logs can be searched based on the minimum execution duration, in ms.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `slow_logs` - The list of slow logs.
+  The [slow_logs](#slow_logs_struct) structure is documented below.
+
+<a name="slow_logs_struct"></a>
+The `slow_logs` block supports:
+
+* `node_id` - The node ID.
+
+* `node_name` - The node name.
+
+* `whole_message` - The statement.
+
+* `operate_type` - The statement type.
+
+* `cost_time` - The execution time, in ms.
+
+* `log_time` - The UTC time when a log is generated.
+
+* `line_num` - The sequence number of a log event.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1543,6 +1543,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_pt_application_records":        geminidb.DataSourceGeminiDBPtApplicationRecords(),
 			"huaweicloud_geminidb_quotas":                        geminidb.DataSourceQuotas(),
 			"huaweicloud_geminidb_recycling_instances":           geminidb.DataSourceGeminiDBRecyclingInstances(),
+			"huaweicloud_geminidb_redis_slow_logs":               geminidb.DataSourceRedisSlowLogs(),
 			"huaweicloud_geminidb_restorable_time_window":        geminidb.DataSourceGeminiDBRestorableTimeWindow(),
 			"huaweicloud_geminidb_scheduled_tasks":               geminidb.DataSourceGeminiDBScheduledTasks(),
 			"huaweicloud_geminidb_slow_logs":                     geminidb.DataSourceGeminiDBSlowLogs(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_redis_slow_logs_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_redis_slow_logs_test.go
@@ -1,0 +1,109 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRedisSlowLogs_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_redis_slow_logs.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		start_time = time.Now().Add(-24 * time.Hour).Format("2006-01-02T15:04:05+0800")
+		end_time   = time.Now().Format("2006-01-02T15:04:05+0800")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccCheckGeminidbInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRedisSlowLogs_basic(start_time, end_time),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_logs.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_logs.0.node_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_logs.0.node_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_logs.0.whole_message"),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_logs.0.operate_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_logs.0.cost_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_logs.0.log_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_logs.0.line_num"),
+
+					resource.TestCheckOutput("node_id_filter_useful", "true"),
+					resource.TestCheckOutput("keywords_filter_useful", "true"),
+					resource.TestCheckOutput("max_cost_time_filter_useful", "true"),
+					resource.TestCheckOutput("min_cost_time_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRedisSlowLogs_basic(startTime, endTime string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_redis_slow_logs" "test" {
+  instance_id = "%[1]s"
+  start_time  = "%[2]s"
+  end_time    = "%[3]s"
+}
+
+locals {
+  node_id = data.huaweicloud_geminidb_redis_slow_logs.test.slow_logs[0].node_id
+}
+
+data "huaweicloud_geminidb_redis_slow_logs" "node_id_filter" {
+  instance_id = "%[1]s"
+  start_time  = "%[2]s"
+  end_time    = "%[3]s"
+  node_id     = local.node_id
+}
+
+output "node_id_filter_useful" {
+  value = length(data.huaweicloud_geminidb_redis_slow_logs.node_id_filter.slow_logs) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_redis_slow_logs.node_id_filter.slow_logs[*].node_id : v == local.node_id]
+  )
+}
+
+data "huaweicloud_geminidb_redis_slow_logs" "keywords_filter" {    
+  instance_id = "%[1]s"
+  start_time  = "%[2]s"
+  end_time    = "%[3]s"
+  keywords    = ["default"]
+}
+
+output "keywords_filter_useful" {
+  value = length(data.huaweicloud_geminidb_redis_slow_logs.keywords_filter.slow_logs) > 0
+}
+
+data "huaweicloud_geminidb_redis_slow_logs" "max_cost_time_filter" {
+  instance_id   = "%[1]s"
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+  max_cost_time = 800
+}
+
+output "max_cost_time_filter_useful" {
+  value = length(data.huaweicloud_geminidb_redis_slow_logs.max_cost_time_filter.slow_logs) > 0
+}
+
+data "huaweicloud_geminidb_redis_slow_logs" "min_cost_time_filter" {
+  instance_id   = "%[1]s"
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+  min_cost_time = 600
+}
+
+output "min_cost_time_filter_useful" {
+  value = length(data.huaweicloud_geminidb_redis_slow_logs.min_cost_time_filter.slow_logs) > 0
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID, startTime, endTime)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_redis_slow_logs.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_redis_slow_logs.go
@@ -1,0 +1,198 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB POST /v3/{project_id}/redis/instances/{instance_id}/slow-logs
+func DataSourceRedisSlowLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRedisSlowLogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"operate_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"keywords": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"max_cost_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"min_cost_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"slow_logs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"node_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"whole_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"operate_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cost_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"log_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"line_num": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildRedisSlowLogsBodyParams(d *schema.ResourceData, limit int, lineNum string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"start_time":    d.Get("start_time"),
+		"end_time":      d.Get("end_time"),
+		"limit":         limit,
+		"line_num":      utils.ValueIgnoreEmpty(lineNum),
+		"operate_type":  utils.ValueIgnoreEmpty(d.Get("operate_type")),
+		"node_id":       utils.ValueIgnoreEmpty(d.Get("node_id")),
+		"keywords":      utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("keywords").([]interface{}))),
+		"max_cost_time": utils.ValueIgnoreEmpty(d.Get("max_cost_time")),
+		"min_cost_time": utils.ValueIgnoreEmpty(d.Get("min_cost_time")),
+	}
+
+	return bodyParams
+}
+
+func dataSourceRedisSlowLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/redis/instances/{instance_id}/slow-logs"
+		instanceId = d.Get("instance_id").(string)
+		lineNum    = ""
+		limit      = 3
+		result     = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		listOpt.JSONBody = utils.RemoveNil(buildRedisSlowLogsBodyParams(d, limit, lineNum))
+		resp, err := client.Request("POST", listPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving GeminiDB Redis instance slow logs: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		logs := utils.PathSearch("slow_logs", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, logs...)
+		if len(logs) < limit {
+			break
+		}
+
+		lineNum = utils.PathSearch("[-1].line_num", logs, "").(string)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("slow_logs", flattenRedisSlowLogs(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRedisSlowLogs(instances []interface{}) []interface{} {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(instances))
+	for i, v := range instances {
+		rst[i] = map[string]interface{}{
+			"node_id":       utils.PathSearch("node_id", v, nil),
+			"node_name":     utils.PathSearch("node_name", v, nil),
+			"whole_message": utils.PathSearch("whole_message", v, nil),
+			"operate_type":  utils.PathSearch("operate_type", v, nil),
+			"cost_time":     utils.PathSearch("cost_time", v, nil),
+			"log_time":      utils.PathSearch("log_time", v, nil),
+			"line_num":      utils.PathSearch("line_num", v, nil),
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get list of GeminiDB Redis slow logs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get the list of  GeminiDB Redis slow logs.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceRedisSlowLogs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceRedisSlowLogs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRedisSlowLogs_basic
=== PAUSE TestAccDataSourceRedisSlowLogs_basic
=== CONT  TestAccDataSourceRedisSlowLogs_basic
--- PASS: TestAccDataSourceRedisSlowLogs_basic (28.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  28.369s
```
<img width="1018" height="18" alt="image" src="https://github.com/user-attachments/assets/af500b64-8e59-41c0-8625-385de981c261" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
