### PR TITLE
feat(gaussdb): query gaussdb sql explorer status records

### DIFF
--- a/docs/data-sources/gaussdb_sql_explorer_status_records.md
+++ b/docs/data-sources/gaussdb_sql_explorer_status_records.md
@@ -1,0 +1,95 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_sql_explorer_status_records"
+description: |-
+  Use this data source to query full SQL switch configurations of a GaussDB instance within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_sql_explorer_status_records
+
+Use this data source to query full SQL switch configurations of a GaussDB instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_gaussdb_sql_explorer_status_records" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the GaussDB instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `full_sql_switches` - The list of full SQL switch configuration records.
+  The [full_sql_switches](#gaussdb_instance_full_sql_switches) structure is documented below.
+
+* `allowed_sql_types` - The list of system preset SQL type rules supported by the instance.
+  The [allowed_sql_types](#gaussdb_instance_allowed_sql_types) structure is documented below.
+
+<a name="gaussdb_instance_full_sql_switches"></a>
+The `full_sql_switches` block supports:
+
+* `is_open` - Whether the full SQL collection task is enabled.
+
+* `begin_time` - The start timestamp of the collection task.
+
+* `end_time` - The end timestamp of the collection task, null if the task is running.
+
+* `save_days` - The log retention days.
+
+* `storage_mode` - The log storage mode, fixed to LTS.
+
+* `is_exclude_sys_user` - Whether to exclude system user SQL records.
+
+* `lts_config` - The LTS log storage configuration block.
+  The [lts_config](#gaussdb_instance_lts_config) structure is documented below.
+
+* `sql_type_range` - Custom SQL type filtering rules for this switch task.
+  The [sql_type_range](#gaussdb_instance_allowed_sql_types) structure is documented below.
+
+<a name="gaussdb_instance_lts_config"></a>
+The `lts_config` block supports:
+
+* `group_ttl_in_days` - The retention days of the LTS log group.
+
+* `group_log_type` - The log type of the log group.
+
+* `log_group_name` - The name of the LTS log group.
+
+* `log_group_id` - The ID of the LTS log group.
+
+* `log_stream_name` - The name of the LTS log stream.
+
+* `log_stream_id` - The ID of the LTS log stream.
+
+* `stream_log_type` - The log type of the log stream.
+
+* `stream_ttl_in_days` - The retention days of the log stream.
+
+* `stream_structure_config_id` - The ID of stream structure configuration.
+
+* `stream_index_config_id` - The ID of stream index configuration.
+
+<a name="gaussdb_instance_allowed_sql_types"></a>
+The `sql_type_range` / `allowed_sql_types` block supports:
+
+* `category` - The SQL rule category, valid values: `all`, `dml`, `ddl`, `dcl`, `tcl`, `dql`, `custom`.
+
+* `prefixes` - The list of SQL statement prefix filters.
+
+* `is_preset` - Whether this rule is a system built-in preset rule.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1557,6 +1557,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_gaussdb_alarms":                          gaussdb.DataSourceAlarms(),
 			"huaweicloud_gaussdb_instance_alarm_statistics":       gaussdb.DataSourceInstanceAlarmStatistics(),
+			"huaweicloud_gaussdb_sql_explorer_status_records":     gaussdb.DataSourceInstanceSqlExplorerStatusRecords(),
 			"huaweicloud_gaussdb_instance_status_statistics":      gaussdb.DataSourceInstanceStatusStatistics(),
 			"huaweicloud_gaussdb_instance_installed_plugins":      gaussdb.DataSourceInstalledPlugins(),
 			"huaweicloud_gaussdb_instance_lts_log_configs":        gaussdb.DataSourceGaussDBInstanceLtsLogConfigs(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_sql_explorer_status_records_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_sql_explorer_status_records_test.go
@@ -1,0 +1,72 @@
+package gaussdb
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGaussDbSqlExplorerStatusRecords_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_gaussdb_sql_explorer_status_records.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBInstanceId(t)
+			acceptance.TestAccPreCheckHighCostAllow(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGaussDbSqlExplorerStatusRecords_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "region"),
+					resource.TestMatchResourceAttr(dataSourceName, "full_sql_switches.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "full_sql_switches.0.is_open"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "full_sql_switches.0.begin_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "full_sql_switches.0.end_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "full_sql_switches.0.save_days"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "full_sql_switches.0.storage_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "full_sql_switches.0.is_exclude_sys_user"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "full_sql_switches.0.lts_config.0.log_group_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "full_sql_switches.0.lts_config.0.log_stream_name"),
+					resource.TestMatchResourceAttr(dataSourceName, "allowed_sql_types.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "allowed_sql_types.0.category"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "allowed_sql_types.0.is_preset"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceGaussDbSqlExplorerStatusRecords_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_instance_full_sqls_config" "test" {
+  instance_id         = "%[1]s"
+  storage_mode        = "LTS"
+  save_days           = 7
+  is_exclude_sys_user = true
+
+  lts_config {
+    log_group_name  = "GROUP_GAUSSDB_APS-%[1]s"
+    log_stream_name = "STREAM_APS_FULL_SQL-%[1]s"
+  }
+
+  sql_type_range {
+    category = "all"
+  }
+}
+
+data "huaweicloud_gaussdb_sql_explorer_status_records" "test" {
+  instance_id = "%[1]s"
+}
+`, acceptance.HW_GAUSSDB_INSTANCE_ID)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_sql_explorer_status_records.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_sql_explorer_status_records.go
@@ -1,0 +1,295 @@
+package gaussdb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3/{project_id}/instances/{instance_id}/full-sql-switches
+func DataSourceInstanceSqlExplorerStatusRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceFullSqlSwitchesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"full_sql_switches": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     gaussDbInstanceFullSqlSwitchesSchema(),
+			},
+			"allowed_sql_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     gaussDbSqlTypeRangeSchema(),
+			},
+		},
+	}
+}
+
+func gaussDbInstanceFullSqlSwitchesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"is_open": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"begin_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"save_days": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"storage_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_exclude_sys_user": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"lts_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     gaussDbLtsConfigSchema(),
+			},
+			"sql_type_range": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     gaussDbSqlTypeRangeSchema(),
+			},
+		},
+	}
+}
+
+func gaussDbLtsConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"group_ttl_in_days": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"group_log_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_stream_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_stream_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stream_log_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stream_ttl_in_days": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"stream_structure_config_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stream_index_config_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func gaussDbSqlTypeRangeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"prefixes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"is_preset": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func listFullSqlSwitches(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, []interface{}, error) {
+	var (
+		httpUrl         = "v3/{project_id}/instances/{instance_id}/full-sql-switches?limit={limit}"
+		result          = make([]interface{}, 0)
+		allowedSqlTypes = make([]interface{}, 0)
+		limit           = 100
+		offset          = 0
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if len(allowedSqlTypes) == 0 {
+			allowedSqlTypes = flattenSqlTypeRange(respBody, "allowed_sql_types")
+		}
+
+		sqlSwitches := utils.PathSearch("full_sql_switches", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, sqlSwitches...)
+		if len(sqlSwitches) < limit {
+			break
+		}
+
+		offset += len(sqlSwitches)
+	}
+
+	return result, allowedSqlTypes, nil
+}
+
+func dataSourceInstanceFullSqlSwitchesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	switches, allowedSqlTypes, err := listFullSqlSwitches(client, d)
+	if err != nil {
+		return diag.Errorf("error querying GaussDB sql explorer status records: %s", err)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("full_sql_switches", flattenFullSqlSwitches(switches)),
+		d.Set("allowed_sql_types", allowedSqlTypes),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenFullSqlSwitches(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+	res := make([]interface{}, 0, len(resp))
+
+	for _, v := range resp {
+		res = append(res, map[string]interface{}{
+			"is_open":             utils.PathSearch("is_open", v, nil),
+			"begin_time":          utils.PathSearch("begin_time", v, nil),
+			"end_time":            utils.PathSearch("end_time", v, nil),
+			"save_days":           utils.PathSearch("save_days", v, nil),
+			"storage_mode":        utils.PathSearch("storage_mode", v, nil),
+			"is_exclude_sys_user": utils.PathSearch("is_exclude_sys_user", v, nil),
+			"lts_config": []interface{}{
+				flattenLtsConfig(utils.PathSearch("lts_config", v, nil)),
+			},
+			"sql_type_range": flattenSqlTypeRange(v, "sql_type_range"),
+		})
+	}
+	return res
+}
+
+func flattenSqlTypeRange(resp interface{}, key string) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curArray := utils.PathSearch(key, resp, make([]interface{}, 0)).([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"category":  utils.PathSearch("category", v, nil),
+			"prefixes":  utils.PathSearch("prefixes", v, nil),
+			"is_preset": utils.PathSearch("is_preset", v, nil),
+		})
+	}
+	return res
+}
+
+func flattenLtsConfig(ltsConfig interface{}) map[string]interface{} {
+	if ltsConfig == nil {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"group_ttl_in_days":          utils.PathSearch("group_ttl_in_days", ltsConfig, nil),
+		"group_log_type":             utils.PathSearch("group_log_type", ltsConfig, nil),
+		"log_group_name":             utils.PathSearch("log_group_name", ltsConfig, nil),
+		"log_group_id":               utils.PathSearch("log_group_id", ltsConfig, nil),
+		"log_stream_name":            utils.PathSearch("log_stream_name", ltsConfig, nil),
+		"log_stream_id":              utils.PathSearch("log_stream_id", ltsConfig, nil),
+		"stream_log_type":            utils.PathSearch("stream_log_type", ltsConfig, nil),
+		"stream_ttl_in_days":         utils.PathSearch("stream_ttl_in_days", ltsConfig, nil),
+		"stream_structure_config_id": utils.PathSearch("stream_structure_config_id", ltsConfig, nil),
+		"stream_index_config_id":     utils.PathSearch("stream_index_config_id", ltsConfig, nil),
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source `(huaweicloud_gaussdb_instance_full_sql_switches) `  to query instance full sql switches.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add a new data source  `(huaweicloud_gaussdb_instance_full_sql_switches) ` for GaussDB.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o gaussdb -f TestAccDataSourceGaussDbInstanceFullS
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/gaussdb" -v -coverprofile="./huaweicloud/services/acceptance/gaussdb/gaussdb_coverage.cov" -coverpkg="./huaweicloud/services/gaussdb" -run TestAccDataSourceGaussDbInstanceFullS -timeout 360m -parallel 10
=== RUN   TestAccDataSourceGaussDbInstanceFullSqlSwitches_basic
=== PAUSE TestAccDataSourceGaussDbInstanceFullSqlSwitches_basic
=== CONT  TestAccDataSourceGaussDbInstanceFullSqlSwitches_basic
--- PASS: TestAccDataSourceGaussDbInstanceFullSqlSwitches_basic (107.44s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/gaussdb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   109.308s        coverage: 5.1% of statements in ./huaweicloud/services/gaussdb


```

<img width="929" height="23" alt="full-sql-switches" src="https://github.com/user-attachments/assets/955611e0-9099-4929-92f1-bbe05bf3e2d6" />



* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
