### PR TITLE
refactor(kafka): using auto-gen style to rewrite topic resource

### DIFF
--- a/docs/resources/dms_kafka_topic.md
+++ b/docs/resources/dms_kafka_topic.md
@@ -2,7 +2,8 @@
 subcategory: "Distributed Message Service (DMS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_dms_kafka_topic"
-description: ""
+description:  |-
+  Manages a DMS kafka topic resource within HuaweiCloud.
 ---
 
 # huaweicloud_dms_kafka_topic
@@ -13,10 +14,11 @@ Manages a DMS kafka topic resource within HuaweiCloud.
 
 ```hcl
 variable "kafka_instance_id" {}
+variable "topic_name" {}
 
-resource "huaweicloud_dms_kafka_topic" "topic" {
+resource "huaweicloud_dms_kafka_topic" "test" {
   instance_id = var.kafka_instance_id
-  name        = "topic_1"
+  name        = var.topic_name
   partitions  = 20
 }
 ```
@@ -25,17 +27,17 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the DMS kafka topic resource. If omitted, the
-  provider-level region will be used. Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the topic is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the ID of the DMS kafka instance to which the topic belongs.
-  Changing this creates a new resource.
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the DMS kafka instance to which the topic belongs.
 
-* `name` - (Required, String, ForceNew) Specifies the name of the topic. The name starts with a letter, consists of 3 to
-  200 characters, and supports only letters, digits, hyphens (-), underscores (_) and periods (.).
-  Changing this creates a new resource.
+* `name` - (Required, String, NonUpdatable) Specifies the name of the topic.  
+  The name starts with a letter, consists of `3` to `200` characters, and supports only letters, digits, hyphens (-),
+  underscores (_) and periods (.).
 
-* `partitions` - (Required, Int) Specifies the partition number. The value ranges from `1` to `200`.
+* `partitions` - (Required, Int) Specifies the partition number.  
+  The value ranges from `1` to `200`.
   
   -> Only support to add partitions.
 
@@ -43,17 +45,19 @@ The following arguments are supported:
   
   -> It's only valid when adding partitions.
 
-* `replicas` - (Optional, Int, ForceNew) Specifies the replica number.
-  The value ranges from `1` to `3` and defaults to `3`. Changing this creates a new resource.
+* `replicas` - (Optional, Int, NonUpdatable) Specifies the replica number.
+  The value ranges from `1` to `3` and defaults to `3`.
 
 * `aging_time` - (Optional, Int) Specifies the aging time in hours.
   The value ranges from `1` to `720` and defaults to `72`.
 
-* `sync_replication` - (Optional, Bool) Whether or not to enable synchronous replication.
+* `sync_replication` - (Optional, Bool) Specifies whether to enable synchronous replication.  
+  Defaults to **false**.
 
-* `sync_flushing` - (Optional, Bool) Whether or not to enable synchronous flushing.
+* `sync_flushing` - (Optional, Bool) Specifies whether to enable synchronous flushing.
+  Defaults to **false**.
 
-* `description` - (Optional, String) Specifies the description of topic.
+* `description` - (Optional, String) Specifies the description of the topic.
 
 * `configs` - (Optional, List) Specifies the other topic configurations.
 
@@ -75,16 +79,40 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID which equals to the topic name.
 
-* `policies_only` - Indicates whether this policy is the default policy.
+* `policies_only` - Whether this policy is the default policy.
 
-* `type` - Indicates the topic type.
+* `type` - The topic type.
 
-* `created_at` - Indicates the topic create time.
+* `created_at` - The topic create time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
 
 ## Import
 
-DMS kafka topics can be imported using the kafka instance ID and topic name separated by a slash, e.g.:
+DMS kafka topics can be imported using the `instance_id` and `name`, separated by a slash (/), e.g.:
 
-```sh
-terraform import huaweicloud_dms_kafka_topic.topic c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/topic_1
+```bash
+$ terraform import huaweicloud_dms_kafka_topic.test <instance_id>/<name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `new_partition_brokers`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dms_kafka_topic" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      new_partition_brokers,
+    ]
+  }
+}
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3693,7 +3693,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafkav2_smart_connect_task":              kafka.ResourceDmsKafkav2SmartConnectTask(),
 			"huaweicloud_dms_kafka_smart_connect_task_action":         kafka.ResourceDmsKafkaSmartConnectTaskAction(),
 			"huaweicloud_dms_kafka_smart_connector_validate":          kafka.ResourceSmartConnectorValidate(),
-			"huaweicloud_dms_kafka_topic":                             kafka.ResourceDmsKafkaTopic(),
+			"huaweicloud_dms_kafka_topic":                             kafka.ResourceTopic(),
 			"huaweicloud_dms_kafka_topic_message_batch_delete":        kafka.ResourceTopicMessageBatchDelete(),
 			"huaweicloud_dms_kafka_topic_quota":                       kafka.ResourceTopicQuota(),
 			"huaweicloud_dms_kafka_user":                              kafka.ResourceDmsKafkaUser(),

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_messages_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_messages_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceDmsKafkaMessages_basic(t *testing.T) {
+func TestAccDataSourceMessages_basic(t *testing.T) {
 	dataSource := "data.huaweicloud_dms_kafka_messages.test"
 	rName := acceptance.RandomAccResourceName()
 	dc := acceptance.InitDataSourceCheck(dataSource)
@@ -19,11 +19,12 @@ func TestAccDataSourceDmsKafkaMessages_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceDmsKafkaMessages_basic(rName),
+				Config: testAccDataSourceMessages_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSource, "messages.#"),
@@ -39,7 +40,34 @@ func TestAccDataSourceDmsKafkaMessages_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceDataSourceDmsKafkaMessages_basic(name string) string {
+func testAccDataSourceMessages_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  partitions  = 3
+}
+
+resource "huaweicloud_dms_kafka_message_produce" "test" {
+  depends_on = [huaweicloud_dms_kafka_topic.test]
+
+  instance_id = huaweicloud_dms_kafka_topic.test.instance_id
+  topic       = huaweicloud_dms_kafka_topic.test.name
+  body        = "test"
+
+  property_list {
+    name  = "KEY"
+    value = "testKey"
+  }
+
+  property_list {
+    name  = "PARTITION"
+    value = "1"
+  }
+}`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
+func testAccDataSourceMessages_basic(name string) string {
 	startTime := strconv.FormatInt(time.Now().UnixMilli(), 10)
 	endTime := strconv.FormatInt(time.Now().Add(1*time.Hour).UnixMilli(), 10)
 	return fmt.Sprintf(`
@@ -48,8 +76,8 @@ func testDataSourceDataSourceDmsKafkaMessages_basic(name string) string {
 data "huaweicloud_dms_kafka_messages" "test" {
   depends_on = [huaweicloud_dms_kafka_message_produce.test]
 
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  topic       = huaweicloud_dms_kafka_topic.topic.name
+  instance_id = huaweicloud_dms_kafka_topic.test.instance_id
+  topic       = huaweicloud_dms_kafka_topic.test.name
   start_time  = "%[2]s"
   end_time    = "%[3]s"
   download    = false
@@ -59,8 +87,8 @@ data "huaweicloud_dms_kafka_messages" "test" {
 data "huaweicloud_dms_kafka_messages" "by_keyword" {
   depends_on = [huaweicloud_dms_kafka_message_produce.test]
 
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  topic       = huaweicloud_dms_kafka_topic.topic.name
+  instance_id = huaweicloud_dms_kafka_topic.test.instance_id
+  topic       = huaweicloud_dms_kafka_topic.test.name
   start_time  = "%[2]s"
   end_time    = "%[3]s"
   download    = false
@@ -74,8 +102,8 @@ output "by_keyword_validation" {
 data "huaweicloud_dms_kafka_messages" "by_offset" {
   depends_on = [huaweicloud_dms_kafka_message_produce.test]
   
-  instance_id    = huaweicloud_dms_kafka_instance.test.id
-  topic          = huaweicloud_dms_kafka_topic.topic.name
+  instance_id    = huaweicloud_dms_kafka_topic.test.instance_id
+  topic          = huaweicloud_dms_kafka_topic.test.name
   partition      = 1
   message_offset = 0
 }
@@ -85,5 +113,5 @@ output "by_offset_validation" {
     [for v in data.huaweicloud_dms_kafka_messages.by_offset.messages[*].message_offset : v == 0]
   )
 }
-`, testAccKafkaMessageProduce_basic(name), startTime, endTime)
+`, testAccDataSourceMessages_base(name), startTime, endTime)
 }

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_topic_partitons_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_topic_partitons_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,22 +10,26 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceDmsKafkaTopicPartitions_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_dms_kafka_topic_partitions.test"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataSourceTopicPartitions_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		dataSource = "data.huaweicloud_dms_kafka_topic_partitions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDmsKafkaTopicPartitions_basic(rName),
+				Config: testDataSourceTopicPartitions_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "partitions.#"),
+					resource.TestMatchResourceAttr(dataSource, "partitions.#", regexp.MustCompile(`^[1-9]\d*$`)),
 					resource.TestCheckResourceAttrSet(dataSource, "partitions.0.partition"),
 				),
 			},
@@ -32,15 +37,25 @@ func TestAccDataSourceDmsKafkaTopicPartitions_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceDmsKafkaTopicPartitions_basic(name string) string {
+func testAccDataSourcePartitions_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  partitions  = 3
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
+func testDataSourceTopicPartitions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 data "huaweicloud_dms_kafka_topic_partitions" "test" {
-  depends_on = [huaweicloud_dms_kafka_topic.topic]
+  depends_on = [huaweicloud_dms_kafka_topic.test]
 
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  topic       = huaweicloud_dms_kafka_topic.topic.name
+  instance_id = huaweicloud_dms_kafka_topic.test.instance_id
+  topic       = huaweicloud_dms_kafka_topic.test.name
 }
-`, testAccDmsKafkaTopic_basic(name))
+`, testAccDataSourcePartitions_basic(name))
 }

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_topics_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_topics_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,53 +10,98 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceDmsKafkaTopics_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_dms_kafka_topics.all"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataSourceTopics_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dms_kafka_topics.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dms_kafka_topics.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceDmsKafkaTopics_basic(rName),
+				Config: testDataSourceTopics_basic(name),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "topics.#"),
-					resource.TestCheckOutput("name_validation", "true"),
+					resource.TestMatchResourceAttr(all, "topics.#", regexp.MustCompile(`^[1-9]\d*$`)),
+					// Filter by 'name' parameter.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestMatchResourceAttr(byName, "max_partitions", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestMatchResourceAttr(byName, "topic_max_partitions", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.name"),
+					resource.TestMatchResourceAttr(byName, "topics.0.partitions", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestMatchResourceAttr(byName, "topics.0.replicas", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestMatchResourceAttr(byName, "topics.0.aging_time", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.sync_replication"),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.sync_flushing"),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.description"),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.configs.#"),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.configs.0.name"),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.configs.0.value"),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.policies_only"),
+					resource.TestCheckResourceAttrSet(byName, "topics.0.type"),
+					resource.TestMatchResourceAttr(byName, "topics.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDataSourceDmsKafkaTopics_basic(name string) string {
+func testAccDataSourceTopics_basic(name string) string {
 	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_dms_kafka_topics" "all" {
-  depends_on = [huaweicloud_dms_kafka_topic.topic]
-
-  instance_id = huaweicloud_dms_kafka_instance.test.id
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s"
+  partitions       = 4
+  aging_time       = 36
+  description      = "Created by Terraform script"
+  sync_replication = true
+  sync_flushing    = true
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
 }
 
-// filter
-data "huaweicloud_dms_kafka_topics" "test" {
-  depends_on = [huaweicloud_dms_kafka_topic.topic]
+func testDataSourceTopics_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
 
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  name        = huaweicloud_dms_kafka_topic.topic.name
+# Without any filter parameters.
+data "huaweicloud_dms_kafka_topics" "all" {
+  depends_on = [huaweicloud_dms_kafka_topic.test]
+
+  instance_id = "%[2]s"
+}
+
+# Filter by 'name' parameter.
+locals {
+  topic_name = huaweicloud_dms_kafka_topic.test.name
+}
+
+data "huaweicloud_dms_kafka_topics" "filter_by_name" {
+  depends_on = [huaweicloud_dms_kafka_topic.test]
+
+  instance_id = "%[2]s"
+  name        = local.topic_name
 }
 
 locals {
-  filter_results = data.huaweicloud_dms_kafka_topics.test
+  name_filter_result = [for v in data.huaweicloud_dms_kafka_topics.filter_by_name.topics[*].name : strcontains(v, local.topic_name)]
 }
 
-output "name_validation" {
-  value = alltrue([for v in local.filter_results.topics[*].name : strcontains(v, huaweicloud_dms_kafka_topic.topic.name)])
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
 }
-`, testAccDmsKafkaTopic_basic(name))
+`, testAccDataSourceTopics_basic(name), acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
 }

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_message_produce_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_message_produce_test.go
@@ -9,32 +9,43 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccKafkaMessageProduce_basic(t *testing.T) {
+func TestAccMessageProduce_basic(t *testing.T) {
 	rName := acceptance.RandomAccResourceNameWithDash()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKafkaMessageProduce_basic(rName),
+				Config: testAccMessageProduce_basic(rName),
 			},
 		},
 	})
 }
 
-func testAccKafkaMessageProduce_basic(rName string) string {
+func testAccMessageProduce_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  partitions  = 3
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
+func testAccMessageProduce_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_dms_kafka_message_produce" "test" {
-  depends_on = [huaweicloud_dms_kafka_topic.topic]
+  depends_on = [huaweicloud_dms_kafka_topic.test]
 
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  topic       = huaweicloud_dms_kafka_topic.topic.name
+  instance_id = huaweicloud_dms_kafka_topic.test.instance_id
+  topic       = huaweicloud_dms_kafka_topic.test.name
   body        = "test"
 
   property_list {
@@ -46,5 +57,5 @@ resource "huaweicloud_dms_kafka_message_produce" "test" {
     name  = "PARTITION"
     value = "1"
   }
-}`, testAccDmsKafkaTopic_basic(rName))
+}`, testAccMessageProduce_base(name))
 }

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_permissions_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_permissions_test.go
@@ -21,7 +21,8 @@ func getDmsKafkaPermissionsFunc(cfg *config.Config, state *terraform.ResourceSta
 	return kafka.GetDmsKafkaPermissions(client, state.Primary.Attributes["instance_id"], state.Primary.Attributes["topic_name"])
 }
 
-func TestAccDmsKafkaPermissions_basic(t *testing.T) {
+// Before running this test, please ensure that the Kafka instance has SSL authentication enabled.
+func TestAccPermissions_basic(t *testing.T) {
 	var policies interface{}
 	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_dms_kafka_permissions.test"
@@ -34,12 +35,15 @@ func TestAccDmsKafkaPermissions_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDmsKafkaPermissions_basic(rName, password),
+				Config: testAccPermissions_basic_step1(rName, password),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "policies.0.user_name",
@@ -48,7 +52,7 @@ func TestAccDmsKafkaPermissions_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDmsKafkaPermissions_update(rName, password),
+				Config: testAccPermissions_basic_step2(rName, password),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "policies.0.user_name",
@@ -68,47 +72,57 @@ func TestAccDmsKafkaPermissions_basic(t *testing.T) {
 	})
 }
 
-func testAccDmsKafkaPermissions_basic(rName, password string) string {
+func testAccPermissions_base(rName string) string {
 	return fmt.Sprintf(`
-%s
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  partitions  = 3
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, rName)
+}
+
+func testAccPermissions_basic_step1(rName, password string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_dms_kafka_user" "test1" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
+  instance_id = "%[4]s"
   name        = "%[2]s-1"
   password    = "%[3]s"
 }
 
 resource "huaweicloud_dms_kafka_permissions" "test" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  topic_name  = huaweicloud_dms_kafka_topic.topic.name
+  instance_id = "%[4]s"
+  topic_name  = huaweicloud_dms_kafka_topic.test.name
 
   policies {
     user_name     = huaweicloud_dms_kafka_user.test1.name
     access_policy = "all"
   }
 }
-`, testAccDmsKafkaTopic_basic(rName), rName, password)
+`, testAccPermissions_base(rName), rName, password, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
 }
 
-func testAccDmsKafkaPermissions_update(rName, password string) string {
+func testAccPermissions_basic_step2(rName, password string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_dms_kafka_user" "test1" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
+  instance_id = "%[4]s"
   name        = "%[2]s-1"
   password    = "%[3]s"
 }
 
 resource "huaweicloud_dms_kafka_user" "test2" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
+  instance_id = "%[4]s"
   name        = "%[2]s-2"
   password    = "%[3]s"
 }
 
 resource "huaweicloud_dms_kafka_permissions" "test" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  topic_name  = huaweicloud_dms_kafka_topic.topic.name
+  instance_id = "%[4]s"
+  topic_name  = huaweicloud_dms_kafka_topic.test.name
 
   policies {
     user_name     = huaweicloud_dms_kafka_user.test1.name
@@ -120,5 +134,5 @@ resource "huaweicloud_dms_kafka_permissions" "test" {
     access_policy = "sub"
   }
 }
-`, testAccDmsKafkaTopic_basic(rName), rName, password)
+`, testAccPermissions_base(rName), rName, password, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
 }

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_topic_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_topic_test.go
@@ -8,151 +8,134 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/kafka"
 )
 
-func getDmsKafkaTopicFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.DmsV2Client(acceptance.HW_REGION_NAME)
+func getResourceTopicFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.NewServiceClient("dms", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating DMS client(V2): %s", err)
-	}
-	instanceID := state.Primary.Attributes["instance_id"]
-	allTopics, err := topics.List(client, instanceID).Extract()
-	if err != nil {
-		return nil, fmt.Errorf("Error listing DMS kafka topics in %s, error: %s", instanceID, err)
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
 	}
 
-	topicID := state.Primary.ID
-	for _, item := range allTopics {
-		if item.Name == topicID {
-			return item, nil
-		}
-	}
-
-	return nil, fmt.Errorf("can not found dms kafka topic instance")
+	return kafka.GetTopicByName(client, state.Primary.Attributes["instance_id"], state.Primary.ID)
 }
 
-func TestAccDmsKafkaTopic_basic(t *testing.T) {
-	var kafkaTopic topics.Topic
-	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_dms_kafka_topic.topic"
+func TestAccTopic_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&kafkaTopic,
-		getDmsKafkaTopicFunc,
+		obj   interface{}
+		rName = "huaweicloud_dms_kafka_topic.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getResourceTopicFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDmsKafkaTopic_basic(rName),
+				Config: testAccTopic_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "partitions", "10"),
-					resource.TestCheckResourceAttr(resourceName, "replicas", "3"),
-					resource.TestCheckResourceAttr(resourceName, "aging_time", "36"),
-					resource.TestCheckResourceAttr(resourceName, "sync_replication", "false"),
-					resource.TestCheckResourceAttr(resourceName, "sync_flushing", "false"),
-					resource.TestCheckResourceAttr(resourceName, "description", "test"),
-					resource.TestCheckResourceAttrSet(resourceName, "policies_only"),
-					resource.TestCheckResourceAttrSet(resourceName, "configs.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "type"),
-					resource.TestMatchResourceAttr(resourceName, "created_at",
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_DMS_KAFKA_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "partitions", "4"),
+					resource.TestCheckResourceAttr(rName, "replicas", "3"),
+					resource.TestCheckResourceAttr(rName, "aging_time", "36"),
+					resource.TestCheckResourceAttr(rName, "sync_replication", "true"),
+					resource.TestCheckResourceAttr(rName, "sync_flushing", "true"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by Terraform script"),
+					resource.TestCheckResourceAttr(rName, "configs.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "configs.*", map[string]string{
+						"name":  "max.message.bytes",
+						"value": "10000000",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "configs.*", map[string]string{
+						"name":  "message.timestamp.type",
+						"value": "LogAppendTime",
+					}),
+					resource.TestCheckResourceAttrSet(rName, "policies_only"),
+					resource.TestCheckResourceAttrSet(rName, "type"),
+					resource.TestMatchResourceAttr(rName, "created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
-				Config: testAccDmsKafkaTopic_update_part1(rName),
+				Config: testAccTopic_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "partitions", "20"),
-					resource.TestCheckResourceAttr(resourceName, "replicas", "3"),
-					resource.TestCheckResourceAttr(resourceName, "aging_time", "72"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "partitions", "5"),
+					resource.TestCheckResourceAttr(rName, "replicas", "3"),
+					resource.TestCheckResourceAttr(rName, "description", "Updated by Terraform script"),
+					resource.TestCheckResourceAttr(rName, "aging_time", "72"),
+					resource.TestCheckResourceAttr(rName, "sync_replication", "false"),
+					resource.TestCheckResourceAttr(rName, "sync_flushing", "false"),
+					resource.TestCheckResourceAttr(rName, "configs.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "configs.*", map[string]string{
+						"name":  "max.message.bytes",
+						"value": "10000001",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "configs.*", map[string]string{
+						"name":  "message.timestamp.type",
+						"value": "CreateTime",
+					}),
 				),
 			},
 			{
-				Config: testAccDmsKafkaTopic_update_part2(rName),
+				Config: testAccTopic_basic_step3(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "partitions", "20"),
-					resource.TestCheckResourceAttr(resourceName, "replicas", "3"),
-					resource.TestCheckResourceAttr(resourceName, "aging_time", "72"),
-					resource.TestCheckResourceAttr(resourceName, "sync_replication", "true"),
-					resource.TestCheckResourceAttr(resourceName, "sync_flushing", "true"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "partitions", "5"),
+					resource.TestCheckResourceAttr(rName, "replicas", "3"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "aging_time", "72"),
+					resource.TestCheckResourceAttr(rName, "sync_replication", "true"),
+					resource.TestCheckResourceAttr(rName, "sync_flushing", "true"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccKafkaTopicImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccTopicImportStateFunc(rName),
 			},
 		},
 	})
 }
 
-// testAccKafkaTopicImportStateFunc is used to import the resource
-func testAccKafkaTopicImportStateFunc(name string) resource.ImportStateIdFunc {
+func testAccTopicImportStateFunc(rName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		instance, ok := s.RootModule().Resources["huaweicloud_dms_kafka_instance.test"]
+		rs, ok := s.RootModule().Resources[rName]
 		if !ok {
-			return "", fmt.Errorf("DMS kafka instance not found")
-		}
-		topic, ok := s.RootModule().Resources[name]
-		if !ok {
-			return "", fmt.Errorf("DMS kafka topic not found")
+			return "", fmt.Errorf("resource (%s) not found", rName)
 		}
 
-		return fmt.Sprintf("%s/%s", instance.Primary.ID, topic.Primary.ID), nil
+		instanceId := rs.Primary.Attributes["instance_id"]
+		topicName := rs.Primary.ID
+		if instanceId == "" || topicName == "" {
+			return "", fmt.Errorf("missing some attributes, want '<instance_id>/<name>', but got '%s/%s'", instanceId, topicName)
+		}
+
+		return fmt.Sprintf("%s/%s", instanceId, topicName), nil
 	}
 }
 
-func testAccDmsKafkaTopic_basic(rName string) string {
+func testAccTopic_basic_step1(name string) string {
 	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dms_kafka_topic" "topic" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  name        = "%s"
-  partitions  = 10
-  aging_time  = 36
-  description = "test"
-}
-`, testAccKafkaInstance_newFormat(rName), rName)
-}
-
-func testAccDmsKafkaTopic_update_part1(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dms_kafka_topic" "topic" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  name        = "%s"
-  partitions  = 20
-  aging_time  = 72
-}
-`, testAccKafkaInstance_newFormat(rName), rName)
-}
-
-func testAccDmsKafkaTopic_update_part2(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dms_kafka_topic" "topic" {
-  instance_id      = huaweicloud_dms_kafka_instance.test.id
-  name             = "%s"
-  partitions       = 20
-  aging_time       = 72
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s"
+  partitions       = 4
+  aging_time       = 36
+  description      = "Created by Terraform script"
   sync_flushing    = true
   sync_replication = true
 
@@ -160,82 +143,130 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
     name  = "max.message.bytes"
     value = "10000000"
   }
-
   configs {
     name  = "message.timestamp.type"
     value = "LogAppendTime"
   }
 }
-`, testAccKafkaInstance_newFormat(rName), rName)
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
 }
 
-func TestAccDmsKafkaTopic_test_update_partition(t *testing.T) {
-	var kafkaTopic topics.Topic
-	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_dms_kafka_topic.topic"
+func testAccTopic_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s"
+  partitions       = 5
+  aging_time       = 72
+  description      = "Updated by Terraform script"
+  sync_flushing    = false
+  sync_replication = false
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&kafkaTopic,
-		getDmsKafkaTopicFunc,
+  configs {
+    name  = "max.message.bytes"
+    value = "10000001"
+  }
+  configs {
+    name  = "message.timestamp.type"
+    value = "CreateTime"
+  }
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
+func testAccTopic_basic_step3(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s"
+  partitions       = 5
+  aging_time       = 72
+  sync_flushing    = true
+  sync_replication = true
+
+  configs {
+    name  = "max.message.bytes"
+    value = "10000001"
+  }
+  configs {
+    name  = "message.timestamp.type"
+    value = "CreateTime"
+  }
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
+func TestAccTopic_new_partition_brokers(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		obj   interface{}
+		rName = "huaweicloud_dms_kafka_topic.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getResourceTopicFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDmsKafkaTopic_testUpdatePartitionsBasic(rName, 3),
+				Config: testAccTopic_new_partition_brokers_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "configs.#", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestCheckResourceAttr(rName, "partitions", "4"),
 				),
 			},
 			{
-				Config: testAccDmsKafkaTopic_testUpdatePartitionsBasic(rName, 5),
+				Config: testAccTopic_new_partition_brokers_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "partitions", "5"),
 				),
 			},
 			{
-				Config:      testAccDmsKafkaTopic_testError(rName, 3),
+				Config:      testAccTopic_new_partition_brokers_step3(name),
 				ExpectError: regexp.MustCompile(`only support to add partitions`),
-			},
-			{
-				Config: testAccDmsKafkaTopic_testError(rName, 7),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "partitions", "7"),
-				),
 			},
 		},
 	})
 }
 
-func testAccDmsKafkaTopic_testUpdatePartitionsBasic(rName string, partitions int) string {
+func testAccTopic_new_partition_brokers_step1(name string) string {
 	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dms_kafka_topic" "topic" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  name        = "%s"
-  partitions  = %v
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  partitions  = 4
   replicas    = 1
 }
-`, testAccKafkaInstance_newFormat(rName), rName, partitions)
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
 }
 
-func testAccDmsKafkaTopic_testError(rName string, partitions int) string {
+func testAccTopic_new_partition_brokers_step2(name string) string {
 	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dms_kafka_topic" "topic" {
-  instance_id           = huaweicloud_dms_kafka_instance.test.id
-  name                  = "%s"
-  partitions            = %v
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id           = "%[1]s"
+  name                  = "%[2]s"
+  partitions            = 5
   replicas              = 1
   new_partition_brokers = [0]
 }
-`, testAccKafkaInstance_newFormat(rName), rName, partitions)
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
+func testAccTopic_new_partition_brokers_step3(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id           = "%[1]s"
+  name                  = "%[2]s"
+  partitions            = 3
+  replicas              = 1
+  new_partition_brokers = [0]
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
 }

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic.go
@@ -3,104 +3,126 @@ package kafka
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// ResourceDmsKafkaTopic implements the resource of "huaweicloud_dms_kafka_topic"
-// @API Kafka POST /v2/{project_id}/instances/{instance_id}/topics/delete
-// @API Kafka GET /v2/{project_id}/instances/{instance_id}/topics
+var (
+	topicNonUpdatableParams = []string{
+		"instance_id",
+		"name",
+		"replicas",
+	}
+)
+
 // @API Kafka POST /v2/{project_id}/instances/{instance_id}/topics
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}/topics
 // @API Kafka PUT /v2/{project_id}/instances/{instance_id}/topics
-func ResourceDmsKafkaTopic() *schema.Resource {
+// @API Kafka POST /v2/{project_id}/instances/{instance_id}/topics/delete
+func ResourceTopic() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceDmsKafkaTopicCreate,
-		ReadContext:   resourceDmsKafkaTopicRead,
-		UpdateContext: resourceDmsKafkaTopicUpdate,
-		DeleteContext: resourceDmsKafkaTopicDelete,
+		CreateContext: resourceTopicCreate,
+		ReadContext:   resourceTopicRead,
+		UpdateContext: resourceTopicUpdate,
+		DeleteContext: resourceTopicDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceDmsKafkaTopicImport,
+			StateContext: resourceTopicImport,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
-			if d.HasChange("partitions") {
-				oldValue, newValue := d.GetChange("partitions")
-				if oldValue.(int) > newValue.(int) {
-					return fmt.Errorf("only support to add partitions")
+		CustomizeDiff: customdiff.All(
+			config.FlexibleForceNew(topicNonUpdatableParams),
+			func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+				if d.HasChange("partitions") {
+					oldValue, newValue := d.GetChange("partitions")
+					if oldValue.(int) > newValue.(int) {
+						return fmt.Errorf("only support to add partitions")
+					}
 				}
-			}
-			return nil
-		},
+				return nil
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the topic is located.`,
 			},
+
+			// Required parameters.
 			"instance_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the DMS kafka instance to which the topic belongs.`,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the topic.`,
 			},
 			"partitions": {
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The partition number.`,
+			},
+
+			// Optional parameters.
+			"new_partition_brokers": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Description: `The integers list of brokers for new partitions.`,
 			},
 			"replicas": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The replica number.`,
 			},
 			"aging_time": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The aging time in hours.`,
 			},
 			"sync_replication": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to enable synchronous replication.`,
 			},
 			"sync_flushing": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
-			"new_partition_brokers": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeInt},
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to enable synchronous flushing.`,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the topic.`,
 			},
 			"configs": {
 				Type:     schema.TypeSet,
@@ -109,106 +131,205 @@ func ResourceDmsKafkaTopic() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The configuration name.`,
 						},
 						"value": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The configuration value.`,
 						},
 					},
 				},
-			},
-			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: `The other topic configurations.`,
 			},
 			"policies_only": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether this policy is the default policy.`,
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The topic type.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The topic create time.`,
+			},
+
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					"Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.",
+					utils.SchemaDescInput{Internal: true},
+				),
 			},
 		},
 	}
 }
 
-func resourceDmsKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func buildCreateTopicBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Required parameters.
+		"id":        d.Get("name"),
+		"partition": d.Get("partitions"),
+		// Optional parameters.
+		"replication":         utils.ValueIgnoreEmpty(d.Get("replicas")),
+		"retention_time":      utils.ValueIgnoreEmpty(d.Get("aging_time")),
+		"sync_replication":    d.Get("sync_replication"),
+		"sync_message_flush":  d.Get("sync_flushing"),
+		"topic_desc":          utils.ValueIgnoreEmpty(d.Get("description")),
+		"topic_other_configs": buildTopicConfigs(d.Get("configs").(*schema.Set).List()),
+	}
+}
+
+func buildTopicConfigs(params []interface{}) []map[string]interface{} {
+	if len(params) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(params))
+	for _, v := range params {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("name", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		})
+	}
+
+	return result
+}
+
+func createTopic(client *golangsdk.ServiceClient, instanceId string, bodyParams map[string]interface{}) (interface{}, error) {
+	httpUrl := "v2/{project_id}/instances/{instance_id}/topics"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(bodyParams),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(createResp)
+}
+
+func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("dms", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
-	createOpts := &topics.CreateOps{
-		Name:             d.Get("name").(string),
-		Partition:        d.Get("partitions").(int),
-		Replication:      d.Get("replicas").(int),
-		RetentionTime:    d.Get("aging_time").(int),
-		SyncReplication:  d.Get("sync_replication").(bool),
-		SyncMessageFlush: d.Get("sync_flushing").(bool),
-		Description:      d.Get("description").(string),
-		Configs:          buildKafkaTopicParameters(d.Get("configs").(*schema.Set).List()),
-	}
-
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	instanceID := d.Get("instance_id").(string)
-	v, err := topics.Create(dmsV2Client, instanceID, createOpts).Extract()
+	instanceId := d.Get("instance_id").(string)
+	v, err := createTopic(client, instanceId, buildCreateTopicBodyParams(d))
 	if err != nil {
-		return diag.Errorf("error creating DMS kafka topic: %s", err)
+		return diag.Errorf("error creating topic for the kafka instance (%s): %s", instanceId, err)
 	}
 
 	// use topic name as the resource ID
-	d.SetId(v.Name)
+	topicName, _ := utils.PathSearch("name", v, "").(string)
+	if topicName == "" {
+		return diag.Errorf("unable to find the topic name from the API response")
+	}
+
+	d.SetId(topicName)
 
 	// wait for topic create complete
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"SUCCESS"},
-		Refresh:      kafkaTopicCreateRefreshFunc(dmsV2Client, d),
+		Refresh:      kafkaTopicCreateRefreshFunc(client, instanceId, topicName),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        1 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return diag.Errorf("error waiting for DMS kafka topic created: %s", err)
+		return diag.Errorf("error waiting for topic (%s) of the kafka instance (%s) to be created: %s", topicName, instanceId, err)
 	}
 
-	return resourceDmsKafkaTopicRead(ctx, d, meta)
+	return resourceTopicRead(ctx, d, meta)
 }
 
-func getKafkaTopic(client *golangsdk.ServiceClient, d *schema.ResourceData) (*topics.Topic, error) {
-	instanceID := d.Get("instance_id").(string)
-	allTopics, err := topics.List(client, instanceID).Extract()
+func listTopics(client *golangsdk.ServiceClient, instanceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/instances/{instance_id}/topics?limit={limit}"
+		// The limit maximum value is 200, default is 50.
+		limit  = 200
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		topics := utils.PathSearch("topics", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, topics...)
+		if len(topics) < limit {
+			break
+		}
+
+		offset += len(topics)
+	}
+
+	return result, nil
+}
+
+func GetTopicByName(client *golangsdk.ServiceClient, instanceId, topicName string) (interface{}, error) {
+	allTopics, err := listTopics(client, instanceId)
 	if err != nil {
 		return nil, err
 	}
 
-	topicID := d.Id()
-	isFound := false
-	var found topics.Topic
-	for _, item := range allTopics {
-		if item.Name == topicID {
-			found = item
-			isFound = true
-			break
-		}
-	}
-	if !isFound {
+	topic := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0]", topicName), allTopics, nil)
+	if topic == nil {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte("the topic not exist"),
+				Method:    "GET",
+				URL:       "/v2/{project_id}/instances/{instance_id}/topics",
+				RequestId: "NONE",
+				Body:      []byte("the topic not exist"),
 			},
 		}
 	}
-	return &found, nil
+
+	return topic, nil
 }
 
-func kafkaTopicCreateRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
+func kafkaTopicCreateRefreshFunc(client *golangsdk.ServiceClient, instanceId, topicName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		topic, err := getKafkaTopic(client, d)
+		topic, err := GetTopicByName(client, instanceId, topicName)
 		if err != nil {
 			if errCode, ok := err.(golangsdk.ErrDefault404); ok {
 				if reflect.DeepEqual(errCode.Body, []byte("the topic not exist")) {
@@ -224,50 +345,41 @@ func kafkaTopicCreateRefreshFunc(client *golangsdk.ServiceClient, d *schema.Reso
 	}
 }
 
-func buildKafkaTopicParameters(params []interface{}) []topics.ConfigParam {
-	paramList := make([]topics.ConfigParam, len(params))
-	for i, v := range params {
-		paramList[i] = topics.ConfigParam{
-			Name:  v.(map[string]interface{})["name"].(string),
-			Value: v.(map[string]interface{})["value"].(string),
-		}
-	}
-
-	return paramList
-}
-
-func resourceDmsKafkaTopicRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+func resourceTopicRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		topicName  = d.Id()
+	)
+	client, err := cfg.NewServiceClient("dms", region)
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
-	topic, err := getKafkaTopic(dmsV2Client, d)
+	topic, err := GetTopicByName(client, instanceId, topicName)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving topic")
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving topic (%s) of the instance (%s)", topicName, instanceId))
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", cfg.GetRegion(d)),
-		d.Set("name", topic.Name),
-		d.Set("partitions", topic.Partition),
-		d.Set("replicas", topic.Replication),
-		d.Set("aging_time", topic.RetentionTime),
-		d.Set("sync_replication", topic.SyncReplication),
-		d.Set("sync_flushing", topic.SyncMessageFlush),
-		d.Set("configs", flattenConfigs(topic.Configs)),
-		d.Set("description", topic.Description),
-		d.Set("created_at", utils.FormatTimeStampRFC3339(topic.CreatedAt/1000, false)),
-		d.Set("policies_only", topic.PoliciesOnly),
-		d.Set("type", setTopicType(topic.TopicType)),
+		d.Set("region", region),
+		// Required parameters.
+		d.Set("name", utils.PathSearch("name", topic, nil)),
+		d.Set("partitions", utils.PathSearch("partition", topic, nil)),
+		// Optional parameters.
+		d.Set("replicas", utils.PathSearch("replication", topic, nil)),
+		d.Set("aging_time", utils.PathSearch("retention_time", topic, nil)),
+		d.Set("sync_replication", utils.PathSearch("sync_replication", topic, nil)),
+		d.Set("sync_flushing", utils.PathSearch("sync_message_flush", topic, nil)),
+		d.Set("configs", flattenTopicConfigs(utils.PathSearch("topic_other_configs", topic, make([]interface{}, 0)).([]interface{}))),
+		d.Set("description", utils.PathSearch("topic_desc", topic, nil)),
+		d.Set("policies_only", utils.PathSearch("policiesOnly", topic, nil)),
+		d.Set("type", setTopicType(int(utils.PathSearch("topic_type", topic, float64(0)).(float64)))),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("created_at", topic, float64(0)).(float64))/1000, false)),
 	)
 
-	if mErr.ErrorOrNil() != nil {
-		return diag.FromErr(mErr)
-	}
-
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func setTopicType(topicValue int) string {
@@ -279,133 +391,143 @@ func setTopicType(topicValue int) string {
 	return topicType
 }
 
-func flattenConfigs(params []topics.ConfigParam) []map[string]interface{} {
+func flattenTopicConfigs(params []interface{}) []map[string]interface{} {
 	if len(params) < 1 {
 		return nil
 	}
 
-	result := make([]map[string]interface{}, len(params))
-	for i, val := range params {
-		result[i] = map[string]interface{}{
-			"name":  val.Name,
-			"value": val.Value,
-		}
+	result := make([]map[string]interface{}, 0, len(params))
+	for _, val := range params {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("name", val, nil),
+			"value": utils.PathSearch("value", val, nil),
+		})
 	}
 	return result
 }
 
-func buildBrokerList(params []interface{}) []int {
-	paramList := make([]int, len(params))
-	for i, v := range params {
-		paramList[i] = v.(int)
+func buildUpdateTopicBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"id": d.Get("name"),
 	}
 
-	return paramList
+	if d.HasChange("partitions") {
+		params["new_partition_numbers"] = d.Get("partitions").(int)
+		params["new_partition_brokers"] = utils.ValueIgnoreEmpty(d.Get("new_partition_brokers").(*schema.Set).List())
+	}
+
+	if d.HasChange("aging_time") {
+		params["retention_time"] = d.Get("aging_time")
+	}
+
+	if d.HasChange("sync_replication") {
+		params["sync_replication"] = d.Get("sync_replication")
+	}
+
+	if d.HasChange("sync_flushing") {
+		params["sync_message_flush"] = d.Get("sync_flushing")
+	}
+
+	if d.HasChange("description") {
+		params["topic_desc"] = d.Get("description")
+	}
+
+	if d.HasChange("configs") {
+		params["topic_other_configs"] = buildTopicConfigs(d.Get("configs").(*schema.Set).List())
+	}
+
+	return map[string]interface{}{
+		"topics": []map[string]interface{}{
+			params,
+		},
+	}
 }
 
-func resourceDmsKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateTopic(client *golangsdk.ServiceClient, instanceId string, bodyParams map[string]interface{}) error {
+	httpUrl := "v2/{project_id}/instances/{instance_id}/topics"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(bodyParams),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("dms", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
-	updateItem := topics.UpdateItem{
-		Name: d.Get("name").(string),
-	}
-	// Set value if it changed.
-	if d.HasChange("partitions") {
-		newPartition := d.Get("partitions").(int)
-		updateItem.Partition = &newPartition
-		updateItem.NewPartitionBrokers = buildBrokerList(d.Get("new_partition_brokers").(*schema.Set).List())
-	}
-	if d.HasChange("aging_time") {
-		retentionTime := d.Get("aging_time").(int)
-		updateItem.RetentionTime = &retentionTime
-	}
-	if d.HasChange("sync_replication") {
-		syncReplication := d.Get("sync_replication").(bool)
-		updateItem.SyncReplication = &syncReplication
-	}
-	if d.HasChange("sync_flushing") {
-		syncMessageFlush := d.Get("sync_flushing").(bool)
-		updateItem.SyncMessageFlush = &syncMessageFlush
-	}
-	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		updateItem.Description = &description
-	}
-	if d.HasChange("configs") {
-		updateItem.Configs = buildKafkaTopicParameters(d.Get("configs").(*schema.Set).List())
+	instanceId := d.Get("instance_id").(string)
+	err = updateTopic(client, instanceId, buildUpdateTopicBodyParams(d))
+	if err != nil {
+		return diag.Errorf("error updating topic (%s) of the kafka instance (%s): %s", d.Id(), instanceId, err)
 	}
 
-	updateOpts := topics.UpdateOpts{
-		Topics: []topics.UpdateItem{
-			updateItem,
+	return resourceTopicRead(ctx, d, meta)
+}
+
+func deleteTopic(client *golangsdk.ServiceClient, instanceId string, topicName string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/instances/{instance_id}/topics/delete"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"topics": []string{topicName},
 		},
 	}
 
-	log.Printf("[DEBUG] Update Options: %#v", updateOpts)
-	instanceID := d.Get("instance_id").(string)
-	err = topics.Update(dmsV2Client, instanceID, updateOpts).Err
+	resp, err := client.Request("POST", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error updating DMS kafka topic: %s", err)
+		return nil, err
 	}
 
-	return resourceDmsKafkaTopicRead(ctx, d, meta)
+	return utils.FlattenResponse(resp)
 }
 
-func resourceDmsKafkaTopicDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("dms", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
-	// check delete
-	_, err = getKafkaTopic(dmsV2Client, d)
+	topicName := d.Id()
+	instanceId := d.Get("instance_id").(string)
+	respBody, err := deleteTopic(client, instanceId, topicName)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error deleting DMS kafka topic")
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting topic (%s) of the kafka instance (%s)", topicName, instanceId))
 	}
 
-	topicID := d.Id()
-	instanceID := d.Get("instance_id").(string)
-	response, err := topics.Delete(dmsV2Client, instanceID, []string{topicID}).Extract()
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error deleting DMS kafka topic")
-	}
-
-	// the API will return success even deleting a non exist topic
-	var success bool
-	for _, item := range response {
-		if item.Name == topicID {
-			success = item.Success
-			break
-		}
-	}
+	// The API will return success even deleting a non-existent topic.
+	success := utils.PathSearch(fmt.Sprintf("topics[?id=='%s']|[0].success", topicName), respBody, false).(bool)
 	if !success {
-		return diag.Errorf("error deleting DMS kafka topic")
+		return diag.Errorf("error deleting topic (%s) of the kafka instance (%s)", topicName, instanceId)
 	}
 
-	d.SetId("")
 	return nil
 }
 
-// resourceDmsKafkaTopicImport query the rules from HuaweiCloud and imports them to Terraform.
-// It is a common function in waf and is also called by other rule resources.
-func resourceDmsKafkaTopicImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+func resourceTopicImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
-	parts := strings.SplitN(d.Id(), "/", 2)
+	importId := d.Id()
+	parts := strings.Split(importId, "/")
 	if len(parts) != 2 {
-		err := fmt.Errorf("invalid format specified for DMS kafka topic. Format must be <instance id>/<topic name>")
-		return nil, err
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<topic_name>', but got '%s'", importId)
 	}
 
-	instanceID := parts[0]
-	topicID := parts[1]
+	d.SetId(parts[1])
 
-	d.SetId(topicID)
-	err := d.Set("instance_id", instanceID)
-
-	return []*schema.ResourceData{d}, err
+	return []*schema.ResourceData{d}, d.Set("instance_id", parts[0])
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Using auto-gen style to refactor the topic resource's code.
   Add pagination logic to query topics interface.

3. Adjust some acceptance tests.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using auto-gen style to rewrite topic resource.
2. improve the documentation for topic resource.
4. adjust some acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccTopic_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccTopic_ -timeout 360m -parallel 10
=== RUN   TestAccTopic_basic
=== PAUSE TestAccTopic_basic
=== RUN   TestAccTopic_new_partition_brokers
=== PAUSE TestAccTopic_new_partition_brokers
=== CONT  TestAccTopic_basic
=== CONT  TestAccTopic_new_partition_brokers
--- PASS: TestAccTopic_new_partition_brokers (45.98s)
--- PASS: TestAccTopic_basic (62.86s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     63.001s coverage: 5.0% of statements in ./huaweicloud/services/kafka
```
<img width="1070" height="47" alt="image" src="https://github.com/user-attachments/assets/aa099ba3-757e-42f9-805a-0eea26167186" />

```
./scripts/coverage.sh -o kafka -f TestAccDataSourceTopics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataSourceTopics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceTopics_basic
=== PAUSE TestAccDataSourceTopics_basic
=== CONT  TestAccDataSourceTopics_basic
--- PASS: TestAccDataSourceTopics_basic (25.21s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     25.399s coverage: 4.6% of statements in ./huaweicloud/services/kafka
```
```
/scripts/coverage.sh -o kafka -f TestAccDataSourceTopicPartitions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataSourceTopicPartitions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceTopicPartitions_basic
=== PAUSE TestAccDataSourceTopicPartitions_basic
=== CONT  TestAccDataSourceTopicPartitions_basic
--- PASS: TestAccDataSourceTopicPartitions_basic (23.92s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     24.098s coverage: 4.8% of statements in ./huaweicloud/services/kafka
```
```
 ./scripts/coverage.sh -o kafka -f TestAccMessageProduce_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccMessageProduce_basic -timeout 360m -parallel 10
=== RUN   TestAccMessageProduce_basic
=== PAUSE TestAccMessageProduce_basic
=== CONT  TestAccMessageProduce_basic
--- PASS: TestAccMessageProduce_basic (24.98s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     25.155s coverage: 4.7% of statements in ./huaweicloud/services/kafka
```
```
/scripts/coverage.sh -o kafka -f TestAccDataSourceMessages_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataSourceMessages_basic -timeout 360m -parallel 10

=== RUN   TestAccDataSourceMessages_basic
=== PAUSE TestAccDataSourceMessages_basic
=== CONT  TestAccDataSourceMessages_basic
--- PASS: TestAccDataSourceMessages_basic (31.91s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     32.061s coverage: 5.9% of statements in ./huaweicloud/services/kafka
```
```
/scripts/coverage.sh -o kafka -f TestAccPermissions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccPermissions_basic -timeout 360m -parallel 10
=== RUN   TestAccPermissions_basic
=== PAUSE TestAccPermissions_basic
=== CONT  TestAccPermissions_basic
--- PASS: TestAccPermissions_basic (47.57s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     47.729s coverage: 7.4% of statements in ./huaweicloud/services/kafka
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1628" height="916" alt="image" src="https://github.com/user-attachments/assets/af6491bf-1485-43c1-aff4-575cff871518" />

    ab. Related resources (parent resources) not found
    <img width="1144" height="802" alt="image" src="https://github.com/user-attachments/assets/22149176-fa16-440d-8f33-52c8b3d60e83" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    Deleting a non-existent topic always results in a 200 status code.

    bb. Related resources (parent resources) not found
    <img width="1285" height="811" alt="image" src="https://github.com/user-attachments/assets/0c7b5496-7a34-4e9a-bcef-3ac79070bdcb" />
