### PR TITLE
feat(dli): dli queue resource add some attributes

### DIFF
--- a/docs/resources/dli_queue.md
+++ b/docs/resources/dli_queue.md
@@ -148,6 +148,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `create_time` - Time when a queue is created.
 
+* `owner` - The owner of the queue.
+
+* `resource_id` - The resource ID of the queue.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
@@ -65,6 +65,8 @@ func TestAccDliQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(typeSQL, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(typeSQL, "resource_mode", "1"),
 					resource.TestCheckResourceAttrSet(typeSQL, "create_time"),
+					resource.TestCheckResourceAttrSet(typeSQL, "owner"),
+					resource.TestCheckResourceAttrSet(typeSQL, "resource_id"),
 					rcForTypeGeneral.CheckResourceExists(),
 					resource.TestCheckResourceAttr(typeGeneral, "elastic_resource_pool_name", elasticResourceName),
 					resource.TestCheckResourceAttr(typeGeneral, "name", rName+"_general"),
@@ -72,6 +74,8 @@ func TestAccDliQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(typeGeneral, "cu_count", fmt.Sprintf("%d", dli.CU16)),
 					resource.TestCheckResourceAttr(typeGeneral, "resource_mode", "1"),
 					resource.TestCheckResourceAttrSet(typeGeneral, "create_time"),
+					resource.TestCheckResourceAttrSet(typeGeneral, "owner"),
+					resource.TestCheckResourceAttrSet(typeGeneral, "resource_id"),
 				),
 			},
 			{

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_queue.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_queue.go
@@ -218,6 +218,14 @@ func ResourceDliQueue() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 
 			"management_subnet_cidr": {
 				Type:       schema.TypeString,
@@ -369,6 +377,8 @@ func resourceDliQueueRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("resource_mode", queueDetail.ResourceMode),
 		d.Set("feature", queueDetail.Feature),
 		d.Set("create_time", queueDetail.CreateTime),
+		d.Set("owner", queueDetail.Owner),
+		d.Set("resource_id", queueDetail.ResourceId),
 		d.Set("vpc_cidr", queueDetail.CidrInVpc),
 		d.Set("elastic_resource_pool_name", queueDetail.ElasticResourcePoolName),
 		d.Set("tags", d.Get("tags")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add some attributes to dli queue resource.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. add `owner`, `resource_id` into the schema of the resource.
2. add correspond document.
3. add correspond test case.
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccDliQueue_basic -timeout 360m -parallel 10
=== RUN   TestAccDliQueue_basic
--- PASS: TestAccDliQueue_basic (265.78s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       265.921s        coverage: 4.4% of statements in ./huaweicloud/services/dli
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.