### PR TITLE
feat(GaussDB): add gaussdb instance auto enlarge policy data source

### DIFF
--- a/docs/data-sources/huaweicloud_gaussdb_instance_auto_enlarge_policy.md
+++ b/docs/data-sources/huaweicloud_gaussdb_instance_auto_enlarge_policy.md
@@ -1,0 +1,52 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_instance_auto_enlarge_policy"
+description: |-
+  Use this data source to query the storage auto scaling policy of a GaussDB instance within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_instance_auto_enlarge_policy
+
+Use this data source to query the storage auto-scaling policy of a GaussDB instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_gaussdb_instance_auto_enlarge_policy" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource. If omitted, the provider-level
+  region will be used.
+
+* `instance_id` - (Required, String) Specifies the GaussDB instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `switch_option` - Whether the storage auto-scaling is enabled.
+
+* `limit_volume_size` - The upper limit of storage auto scaling (GB).
+
+* `min_volume_size` - The minimum disk capacity to expand (GB).
+
+* `max_volume_size` - The maximum disk capacity to expand (GB).
+
+* `trigger_available_percent` - The available storage space percentage threshold.
+
+* `percents` - The list of available storage space percentages.
+
+* `step_size` - The expansion step size for fixed size expansion (GB).
+
+* `step_percent` - The expansion step size for percentage expansion.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1560,6 +1560,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_instance_lts_log_configs":        gaussdb.DataSourceGaussDBInstanceLtsLogConfigs(),
 			"huaweicloud_gaussdb_instance_supported_plugins":      gaussdb.DataSourceSupportedPlugins(),
 			"huaweicloud_gaussdb_instance_plugin_extensions":      gaussdb.DataSourceInstancePluginExtensions(),
+			"huaweicloud_gaussdb_instance_auto_enlarge_policy":    gaussdb.DataSourceGaussDBInstanceAutoEnlargePolicy(),
 			"huaweicloud_gaussdb_storage_types":                   gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                      gaussdb.DataSourceGaussDbDatastores(),
 			"huaweicloud_gaussdb_flavors":                         gaussdb.DataSourceGaussDbFlavors(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_instance_auto_enlarge_policy_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_instance_auto_enlarge_policy_test.go
@@ -1,0 +1,46 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGaussDBInstanceAutoEnlargePolicy_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_gaussdb_instance_auto_enlarge_policy.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBInstanceAutoEnlargePolicy_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "switch_option"),
+					resource.TestCheckResourceAttrSet(dataSource, "limit_volume_size"),
+					resource.TestCheckResourceAttrSet(dataSource, "min_volume_size"),
+					resource.TestCheckResourceAttrSet(dataSource, "max_volume_size"),
+					resource.TestCheckResourceAttrSet(dataSource, "trigger_available_percent"),
+					resource.TestCheckResourceAttrSet(dataSource, "percents.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "step_size"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGaussDBInstanceAutoEnlargePolicy_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_instance_auto_enlarge_policy" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_GAUSSDB_INSTANCE_ID)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_instance_auto_enlarge_policy.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_instance_auto_enlarge_policy.go
@@ -1,0 +1,122 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3/{project_id}/instances/{instance_id}/auto-enlarge-policy
+func DataSourceGaussDBInstanceAutoEnlargePolicy() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGaussDBInstanceAutoEnlargePolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"switch_option": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"limit_volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"min_volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"max_volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"trigger_available_percent": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"percents": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"step_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"step_percent": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGaussDBInstanceAutoEnlargePolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/auto-enlarge-policy"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving GaussDB instance auto enlarge policy: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("switch_option", utils.PathSearch("switch_option", getRespBody, nil)),
+		d.Set("limit_volume_size", utils.PathSearch("limit_volume_size", getRespBody, nil)),
+		d.Set("min_volume_size", utils.PathSearch("min_volume_size", getRespBody, nil)),
+		d.Set("max_volume_size", utils.PathSearch("max_volume_size", getRespBody, nil)),
+		d.Set("trigger_available_percent", utils.PathSearch("trigger_available_percent", getRespBody, nil)),
+		d.Set("percents", utils.PathSearch("percents", getRespBody, nil)),
+		d.Set("step_size", utils.PathSearch("step_size", getRespBody, nil)),
+		d.Set("step_percent", utils.PathSearch("step_percent", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb instance auto enlarge policy data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb instance auto enlarge policy data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBInstanceAutoEnlargePolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstanceAutoEnlargePolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstanceAutoEnlargePolicy_basic
=== PAUSE TestAccGaussDBInstanceAutoEnlargePolicy_basic
=== CONT  TestAccGaussDBInstanceAutoEnlargePolicy_basic
--- PASS: TestAccGaussDBInstanceAutoEnlargePolicy_basic (25.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   25.224s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
