### PR TITLE
feat(TaurusDB): data source to query audit logs of a TaurusDB instance

### DIFF
--- a/docs/data-sources/taurusdb_audit_logs.md
+++ b/docs/data-sources/taurusdb_audit_logs.md
@@ -1,0 +1,62 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_audit_logs"
+description: |-
+  Use this data source to get the list of audit logs of TaurusDB instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_audit_logs
+
+Use this data source to get the list of audit logs of TaurusDB instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_taurusdb_audit_logs" "test" {
+  instance_id = var.instance_id
+  start_time  = var.start_time
+  end_time    = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the TaurusDB instance.
+
+* `start_time` - (Required, String) Specifies the start time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `end_time` - (Required, String) Specifies the end time in the **yyyy-mm-ddThh:mm:ssZ** format.
+  The end time must be later than the start time and the time span cannot be longer than 30 days.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `audit_logs` - Indicates the list of audit logs.
+
+  The [audit_logs](#audit_logs_struct) structure is documented below.
+
+<a name="audit_logs_struct"></a>
+The `audit_logs` block supports:
+
+* `id` - Indicates the audit log ID.
+
+* `name` - Indicates the audit log file name.
+
+* `size` - Indicates the audit log size, in KB.
+
+* `begin_time` - Indicates the start time of the audit log.
+
+* `end_time` - Indicates the end time of the audit log.

--- a/docs/data-sources/taurusdb_audit_logs_download_links.md
+++ b/docs/data-sources/taurusdb_audit_logs_download_links.md
@@ -1,0 +1,45 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_audit_logs_download_links"
+description: |-
+  Use this data source to get the download links for specific audit logs of a TaurusDB instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_audit_logs_download_links
+
+Use this data source to get the download links for specific audit logs of a TaurusDB instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "audit_log_ids" {
+  type = list(string)
+}
+
+data "huaweicloud_taurusdb_audit_logs_download_links" "test" {
+  instance_id = var.instance_id
+  ids         = var.audit_log_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the TaurusDB instance.
+
+* `ids` - (Required, List) Specifies the list of audit log IDs.
+  A maximum of 50 audit log IDs are allowed in the list.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `links` - Indicates the list of audit log download links. The links are valid for 5 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2618,6 +2618,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_error_logs_download_links":                taurusdb.DataSourceTaurusDBErrorLogsDownloadLinks(),
 			"huaweicloud_taurusdb_diagnosis_statistics":                     taurusdb.DataSourceTaurusDBDiagnosisStatistics(),
 			"huaweicloud_taurusdb_diagnosis_instances":                      taurusdb.DataSourceTaurusDBDiagnosisInstances(),
+			"huaweicloud_taurusdb_audit_logs":                               taurusdb.DataSourceTaurusDBAuditLogs(),
 			"huaweicloud_taurusdb_audit_log_download_links":                 taurusdb.DataSourceTaurusDBAuditLogDownloadLinks(),
 			"huaweicloud_taurusdb_node_sessions":                            taurusdb.DataSourceTaurusDBNodeSessions(),
 			"huaweicloud_taurusdb_sql_auto_throttling_records":              taurusdb.DataSourceTaurusDBSqlAutoThrottlingRecords(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2620,6 +2620,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_diagnosis_instances":                      taurusdb.DataSourceTaurusDBDiagnosisInstances(),
 			"huaweicloud_taurusdb_audit_logs":                               taurusdb.DataSourceTaurusDBAuditLogs(),
 			"huaweicloud_taurusdb_audit_log_download_links":                 taurusdb.DataSourceTaurusDBAuditLogDownloadLinks(),
+			"huaweicloud_taurusdb_audit_logs_download_links":                taurusdb.DataSourceTaurusDBAuditLogsDownloadLinks(),
 			"huaweicloud_taurusdb_node_sessions":                            taurusdb.DataSourceTaurusDBNodeSessions(),
 			"huaweicloud_taurusdb_sql_auto_throttling_records":              taurusdb.DataSourceTaurusDBSqlAutoThrottlingRecords(),
 			"huaweicloud_taurusdb_sql_control_history_rules":                taurusdb.DataSourceSqlControlHistoryRules(),

--- a/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_audit_logs_download_links_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_audit_logs_download_links_test.go
@@ -1,0 +1,48 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTaurusDBAuditLogsDownloadLinks_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_taurusdb_audit_logs_download_links.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTaurusDBAuditLogsDownloadLinks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "links.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "links.0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceTaurusDBAuditLogsDownloadLinks_basic() string {
+	return fmt.Sprintf(`
+%s
+
+locals {
+  ids = data.huaweicloud_taurusdb_audit_logs.test.audit_logs.*.id
+}
+
+data "huaweicloud_taurusdb_audit_logs_download_links" "test" {
+  instance_id = "%s"
+  ids         = local.ids
+}
+`, testDataSourceTaurusDBAuditLogs_basic(), acceptance.HW_TAURUSDB_INSTANCE_ID)
+}

--- a/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_audit_logs_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_audit_logs_test.go
@@ -1,0 +1,51 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTaurusDBAuditLogs_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_taurusdb_audit_logs.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceTaurusDBAuditLogs_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "audit_logs.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "audit_logs.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "audit_logs.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "audit_logs.0.size"),
+					resource.TestCheckResourceAttrSet(dataSource, "audit_logs.0.begin_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "audit_logs.0.end_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceTaurusDBAuditLogs_basic() string {
+	cst := time.FixedZone("CST", 8*3600)
+	endTime := time.Now().In(cst).Format("2006-01-02T15:04:05-0700")
+	startTime := time.Now().In(cst).Add(-24 * time.Hour).Format("2006-01-02T15:04:05-0700")
+	return fmt.Sprintf(`
+data "huaweicloud_taurusdb_audit_logs" "test" {
+  instance_id = "%s"
+  start_time  = "%s"
+  end_time    = "%s"
+}
+`, acceptance.HW_TAURUSDB_INSTANCE_ID, startTime, endTime)
+}

--- a/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_audit_logs.go
+++ b/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_audit_logs.go
@@ -1,0 +1,153 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/audit-logs
+func DataSourceTaurusDBAuditLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBAuditLogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"audit_logs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"begin_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"end_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBAuditLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/instances/{instance_id}/audit-logs"
+		offset  = 0
+		limit   = 50
+		res     = make([]map[string]interface{}, 0)
+	)
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	getBasePath := client.Endpoint + httpUrl
+	getBasePath = strings.ReplaceAll(getBasePath, "{project_id}", client.ProjectID)
+	getBasePath = strings.ReplaceAll(getBasePath, "{instance_id}", d.Get("instance_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		getPath := getBasePath + buildGetAuditLogsQueryParams(d, offset, limit)
+		getResp, err := client.Request("GET", getPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving TaurusDB audit logs: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		auditLogs := flattenTaurusDBAuditLogs(getRespBody)
+		res = append(res, auditLogs...)
+
+		if len(auditLogs) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("audit_logs", res),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetAuditLogsQueryParams(d *schema.ResourceData, offset, limit int) string {
+	startTime := d.Get("start_time").(string)
+	endTime := d.Get("end_time").(string)
+	return fmt.Sprintf("?start_time=%s&end_time=%s&offset=%d&limit=%d", startTime, endTime, offset, limit)
+}
+
+func flattenTaurusDBAuditLogs(resp interface{}) []map[string]interface{} {
+	auditLogsJson := utils.PathSearch("audit_logs", resp, make([]interface{}, 0))
+	auditLogsArray := auditLogsJson.([]interface{})
+	result := make([]map[string]interface{}, 0, len(auditLogsArray))
+	for _, auditLog := range auditLogsArray {
+		result = append(result, map[string]interface{}{
+			"id":         utils.PathSearch("id", auditLog, nil),
+			"name":       utils.PathSearch("name", auditLog, nil),
+			"size":       utils.PathSearch("size", auditLog, nil),
+			"begin_time": utils.PathSearch("begin_time", auditLog, nil),
+			"end_time":   utils.PathSearch("end_time", auditLog, nil),
+		})
+	}
+	return result
+}

--- a/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_audit_logs_download_links.go
+++ b/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_audit_logs_download_links.go
@@ -1,0 +1,92 @@
+package taurusdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API TaurusDB POST /v3/{project_id}/instances/{instance_id}/audit-log-link
+func DataSourceTaurusDBAuditLogsDownloadLinks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBAuditLogsDownloadLinksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"links": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBAuditLogsDownloadLinksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/instances/{instance_id}/audit-log-link"
+	)
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	postPath := client.Endpoint + httpUrl
+	postPath = strings.ReplaceAll(postPath, "{project_id}", client.ProjectID)
+	postPath = strings.ReplaceAll(postPath, "{instance_id}", d.Get("instance_id").(string))
+
+	postOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"ids": utils.ExpandToStringList(d.Get("ids").([]interface{})),
+		},
+	}
+
+	postResp, err := client.Request("POST", postPath, &postOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving TaurusDB audit logs download links: %s", err)
+	}
+
+	postRespBody, err := utils.FlattenResponse(postResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("links", utils.ExpandToStringList(
+			utils.PathSearch("links", postRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
data source to query audit logs of a TaurusDB instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. data source to query audit logs of a TaurusDB instance
2. data source to get download links of specific audit logs
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccDataSourceTaurusDBAuditLogs'
=== RUN   TestAccDataSourceTaurusDBAuditLogs_basic
=== PAUSE TestAccDataSourceTaurusDBAuditLogs_basic
=== CONT  TestAccDataSourceTaurusDBAuditLogs_basic
--- PASS: TestAccDataSourceTaurusDBAuditLogs_basic (20.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 20.623s
```

<img width="741" height="200" alt="image" src="https://github.com/user-attachments/assets/e14f0d56-e139-45a7-a523-f8715e7b20b2" />

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccDataSourceTaurusDBAuditLogsDownloadLinks'
=== RUN   TestAccDataSourceTaurusDBAuditLogsDownloadLinks_basic
=== PAUSE TestAccDataSourceTaurusDBAuditLogsDownloadLinks_basic
=== CONT  TestAccDataSourceTaurusDBAuditLogsDownloadLinks_basic
--- PASS: TestAccDataSourceTaurusDBAuditLogsDownloadLinks_basic (23.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 23.883s
```

<img width="872" height="223" alt="image" src="https://github.com/user-attachments/assets/b0a64a0a-e0b1-4317-bf2a-1319d47fb73d" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
