### PR TITLE
feat(geminidb): geminidb instance add new param parameter

### DIFF
--- a/docs/resources/geminidb_instance.md
+++ b/docs/resources/geminidb_instance.md
@@ -55,6 +55,11 @@ resource "huaweicloud_geminidb_instance" "test" {
     foo = "bar"
     key = "value"
   }
+
+  parameters {
+    name  = "AuthFailLockTime"
+    value = "6"
+  }
 }
 ```
 
@@ -128,6 +133,9 @@ The following arguments are supported:
   The [availability_zone_detail](#availability_zone_detail_struct) structure is documented below.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the instance.
+
+* `parameters` - (Optional, List) Specify an array of one or more parameters to be set to the GeminiDB instance after
+  launched. You can check on console to see which parameters supported. Structure is documented below.
 
 * `switch_option` - (Optional, String) Specifies whether the autoscaling is enabled.
   The valid values are as follows:
@@ -227,6 +235,13 @@ The following arguments are supported:
   This parameter is mandatory if `charging_mode` is set to **prePaid**.
 
 * `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled. Valid values are **true** and **false**.
+
+The `parameters` block supports:
+
+* `name` - (Required, String) Specifies the parameter name. Some of them needs the instance to be restarted
+  to take effect.
+
+* `value` - (Required, String) Specifies the parameter value.
 
 <a name="datastore_struct"></a>
 The `datastore` block supports:

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
@@ -391,6 +391,8 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "flavor.0.storage", "ULTRAHIGH"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor.0.spec_code",
 						"data.huaweicloud_gaussdb_nosql_flavors.test", "flavors.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "AuthFailLockTime"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "6"),
 					resource.TestCheckResourceAttr(resourceName, "switch_option", "on"),
 					resource.TestCheckResourceAttr(resourceName, "second_level_monitoring_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "2"),
@@ -423,6 +425,8 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lb_ip_address", "192.168.0.118"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_start_time", "06:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_end_time", "10:00"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "AuthFailLockTime"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "7"),
 
 					resource.TestCheckResourceAttr(resourceName, "access_control.0.type", "blackList"),
 					resource.TestCheckResourceAttr(resourceName, "access_control.0.enabled", "true"),
@@ -440,6 +444,9 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "access_control.0.type", "blackList"),
 					resource.TestCheckResourceAttr(resourceName, "access_control.0.enabled", "false"),
 
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "AuthFailLockTime"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "8"),
+
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_start_time"),
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_end_time"),
 				),
@@ -453,6 +460,7 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					"flavor.0.storage",
 					"ssl_option",
 					"delete_node_list",
+					"parameters",
 				},
 			},
 		},
@@ -1042,6 +1050,11 @@ resource "huaweicloud_geminidb_instance" "test" {
     spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
   }
 
+  parameters {
+    name  = "AuthFailLockTime"
+    value = "6"
+  }
+
   # setting auto enlarge policy
   switch_option = "on"
 
@@ -1105,6 +1118,11 @@ resource "huaweicloud_geminidb_instance" "test" {
     spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
   }
 
+  parameters {
+    name  = "AuthFailLockTime"
+    value = "7"
+  }
+
   switch_option = "on"
 
   policy {
@@ -1163,6 +1181,11 @@ resource "huaweicloud_geminidb_instance" "test" {
     size      = "16"
     storage   = "ULTRAHIGH"
     spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+
+  parameters {
+    name  = "AuthFailLockTime"
+    value = "8"
   }
 
   switch_option                   = "off"

--- a/huaweicloud/services/geminidb/common.go
+++ b/huaweicloud/services/geminidb/common.go
@@ -352,3 +352,25 @@ func getInstanceField(client *golangsdk.ServiceClient, params getInstanceFieldPa
 	}
 	return utils.FlattenResponse(getResp)
 }
+
+func handleTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// if the http status code is 500 and the error code is DBS.111205, it indicates timeout for the service
+	// error should be ignored, just wait for success
+	if errCode, ok := err.(golangsdk.ErrDefault500); ok {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return false
+		}
+		errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
+		if errorCodeErr != nil {
+			return false
+		}
+		if errorCode.(string) == "DBS.111205" {
+			return true
+		}
+	}
+	return false
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -30,6 +31,8 @@ var geminiDbInstanceNonUpdatableParams = []string{"datastore", "datastore.*.type
 	"product_type", "dedicated_resource_id", "availability_zone_detail", "availability_zone_detail.*.primary_availability_zone",
 	"availability_zone_detail.*.secondary_availability_zone", "charging_mode", "period_unit", "period",
 }
+
+type ctxType string
 
 // @API GeminiDB POST /v3/{project_id}/instances
 // @API GeminiDB GET /v3/{project_id}/jobs
@@ -62,6 +65,9 @@ var geminiDbInstanceNonUpdatableParams = []string{"datastore", "datastore.*.type
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/node-auto-expansion-policy
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/lb/access-control
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/lb/access-control
+// @API GeminiDB PUT /v3.1/{project_id}/instances/{instance_id}/configurations
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/configurations
+// @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/restart
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
 // @API BSS DELETE /v2/orders/subscriptions/resources/autorenew/{instance_id}
@@ -299,6 +305,13 @@ func ResourceGeminiDbInstance() *schema.Resource {
 			},
 			"auto_renew": common.SchemaAutoRenewUpdatable(nil),
 			"tags":       common.TagsSchema(),
+			"parameters": {
+				Type:     schema.TypeSet,
+				Elem:     geminiDbInstanceParameterSchema(),
+				Set:      parameterToHash,
+				Optional: true,
+				Computed: true,
+			},
 			"enable_force_new": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -346,6 +359,22 @@ func ResourceGeminiDbInstance() *schema.Resource {
 			},
 		},
 	}
+}
+
+func geminiDbInstanceParameterSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+	return &sc
 }
 
 func geminiDbAccessControlSchema() *schema.Resource {
@@ -749,6 +778,13 @@ func resourceGeminiDbInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	// Set Parameters
+	if parameters := d.Get("parameters").(*schema.Set); parameters.Len() > 0 {
+		if err = initializeParameters(ctx, d, client, parameters); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceGeminiDbInstanceRead(ctx, d, meta)
 }
 
@@ -959,6 +995,77 @@ func buildCreateGeminiDbInstanceChargeInfoBody(d *schema.ResourceData) map[strin
 	return rst
 }
 
+func buildUpdateInstanceParametersBodyParams(params *schema.Set) map[string]interface{} {
+	values := make(map[string]string)
+	for _, v := range params.List() {
+		key := v.(map[string]interface{})["name"].(string)
+		value := v.(map[string]interface{})["value"].(string)
+		values[key] = value
+	}
+	bodyParams := map[string]interface{}{
+		"values": values,
+	}
+	return bodyParams
+}
+
+func initializeParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	parametersRaw *schema.Set) error {
+	bodyParams := buildUpdateInstanceParametersBodyParams(parametersRaw)
+	res, err := modifyParameters(ctx, d, client, bodyParams)
+	if err != nil {
+		return err
+	}
+
+	restart := utils.PathSearch("restart_required", res, false).(bool)
+	if restart {
+		if err = rebootInstance(ctx, d, client); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func modifyParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	bodyParams interface{}) (interface{}, error) {
+	res, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:            "v3.1/{project_id}/instances/{instance_id}/configurations",
+		httpMethod:         "PUT",
+		pathParams:         map[string]string{"instance_id": d.Id()},
+		updateBodyParams:   bodyParams,
+		isRetry:            true,
+		timeout:            schema.TimeoutUpdate,
+		checkJobExpression: "job_id",
+	})
+	if err != nil && !handleTimeoutError(err) {
+		return nil, fmt.Errorf("error modifying parameters for GeminiDB instance (%s): %s", d.Id(), err)
+	}
+
+	return res, nil
+}
+
+func rebootInstance(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:            "v3/{project_id}/instances/{instance_id}/restart",
+		httpMethod:         "POST",
+		pathParams:         map[string]string{"instance_id": d.Id()},
+		updateBodyParams:   buildRebootInstanceBodyParams(),
+		isRetry:            true,
+		timeout:            schema.TimeoutUpdate,
+		checkJobExpression: "job_id",
+	})
+	if err != nil {
+		return fmt.Errorf("error rebooting instance (%s): %s", d.Id(), err)
+	}
+	return nil
+}
+
+func buildRebootInstanceBodyParams() map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"restart": make(map[string]interface{}),
+	}
+	return bodyParams
+}
+
 func updateSecondLevelMonitor(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
 	if !d.HasChange("second_level_monitoring_enabled") {
 		return nil
@@ -1010,7 +1117,7 @@ func buildUpdatePasswordFreeConfigurationBodyParams(d *schema.ResourceData) map[
 	return bodyParams
 }
 
-func resourceGeminiDbInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGeminiDbInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -1126,7 +1233,73 @@ func resourceGeminiDbInstanceRead(_ context.Context, d *schema.ResourceData, met
 		)
 	}
 
-	return diag.FromErr(mErr.ErrorOrNil())
+	diagErr := setGeminiDBInstanceParameters(ctx, d, client)
+	resErr := append(diag.FromErr(mErr.ErrorOrNil()), diagErr...)
+
+	return resErr
+}
+
+func setGeminiDBInstanceParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) diag.Diagnostics {
+	// Set Parameters
+	getRespBody, err := getInstanceField(client, getInstanceFieldParams{
+		httpUrl:    "v3/{project_id}/instances/{instance_id}/configurations",
+		httpMethod: "GET",
+		pathParams: map[string]string{"instance_id": d.Id()},
+	})
+	if err != nil {
+		log.Printf("[WARN] error fetching parameters of instance (%s): %s", d.Id(), err)
+		return nil
+	}
+
+	configParameters := utils.PathSearch("configuration_parameters", getRespBody, make([]interface{}, 0)).([]interface{})
+	var configurationRestart bool
+	var paramRestart []string
+	var params []map[string]interface{}
+	rawParameterList := d.Get("parameters").(*schema.Set).List()
+	for _, v := range configParameters {
+		if utils.PathSearch("restart_required", v, false).(bool) {
+			configurationRestart = true
+		}
+		for _, parameter := range rawParameterList {
+			name := parameter.(map[string]interface{})["name"]
+			if utils.PathSearch("name", v, "").(string) == name {
+				p := map[string]interface{}{
+					"name":  utils.PathSearch("name", v, nil),
+					"value": utils.PathSearch("value", v, nil),
+				}
+				params = append(params, p)
+				if utils.PathSearch("restart_required", v, false).(bool) {
+					paramRestart = append(paramRestart, utils.PathSearch("name", v, "").(string))
+				}
+				break
+			}
+		}
+	}
+
+	var diagnostics diag.Diagnostics
+	if len(params) > 0 {
+		if err = d.Set("parameters", params); err != nil {
+			log.Printf("error saving parameters to GeminiDB instance (%s): %s", d.Id(), err)
+		}
+		if len(paramRestart) > 0 && ctx.Value(ctxType("parametersChanged")) == "true" {
+			diagnostics = append(diagnostics, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Parameters Changed",
+				Detail:   fmt.Sprintf("Parameters %s changed which needs reboot.", paramRestart),
+			})
+		}
+	}
+	if configurationRestart && ctx.Value(ctxType("configurationChanged")) == "true" {
+		diagnostics = append(diagnostics, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Configuration Changed",
+			Detail:   "Configuration changed which needs reboot.",
+		})
+	}
+	if len(diagnostics) > 0 {
+		return diagnostics
+	}
+	return nil
 }
 
 func getLBAccessControlInfo(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
@@ -1455,8 +1628,11 @@ func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	err = updateGeminiDbInstanceConfigurationId(ctx, d, client)
-	if err != nil {
+	if ctx, err = updateGeminiDbInstanceConfigurationId(ctx, d, client); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if ctx, err = updateGeminiDbParameters(ctx, d, client); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -1685,9 +1861,9 @@ func buildUpdateGeminiDbInstancePortBodyParams(d *schema.ResourceData) map[strin
 	return bodyParams
 }
 
-func updateGeminiDbInstanceConfigurationId(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+func updateGeminiDbInstanceConfigurationId(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) (context.Context, error) {
 	if !d.HasChange("configuration_id") {
-		return nil
+		return ctx, nil
 	}
 
 	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
@@ -1701,9 +1877,21 @@ func updateGeminiDbInstanceConfigurationId(ctx context.Context, d *schema.Resour
 		isWaitInstanceReady: true,
 	})
 	if err != nil {
-		return fmt.Errorf("error updating GeminiDB instance(%s) configuration ID: %s", d.Id(), err)
+		return ctx, fmt.Errorf("error updating GeminiDB instance(%s) configuration ID: %s", d.Id(), err)
 	}
-	return nil
+
+	// if parameters is set, it should be modified
+	if parameters, ok := d.GetOk("parameters"); ok {
+		bodyParams := buildUpdateInstanceParametersBodyParams(parameters.(*schema.Set))
+		_, err = modifyParameters(ctx, d, client, bodyParams)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	// Sending configurationChanged to Read to warn users the instance needs a reboot.
+	ctx = context.WithValue(ctx, ctxType("configurationChanged"), "true")
+	return ctx, nil
 }
 
 func buildUpdateGeminiDbInstanceConfigurationIdBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -1711,6 +1899,30 @@ func buildUpdateGeminiDbInstanceConfigurationIdBodyParams(d *schema.ResourceData
 		"instance_ids": []string{d.Id()},
 	}
 	return bodyParams
+}
+
+func updateGeminiDbParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) (context.Context, error) {
+	if !d.HasChange("parameters") {
+		return ctx, nil
+	}
+
+	o, n := d.GetChange("parameters")
+	os, ns := o.(*schema.Set), n.(*schema.Set)
+	change := ns.Difference(os)
+	if change.Len() > 0 {
+		bodyParams := buildUpdateInstanceParametersBodyParams(change)
+		res, err := modifyParameters(ctx, d, client, bodyParams)
+		if err != nil {
+			return ctx, nil
+		}
+
+		if utils.PathSearch("restart_required", res, false).(bool) {
+			// Sending parametersChanged to Read to warn users the instance needs a reboot.
+			ctx = context.WithValue(ctx, ctxType("parametersChanged"), "true")
+		}
+	}
+
+	return ctx, nil
 }
 
 func updateGeminiDbInstanceVolumeSize(ctx context.Context, d *schema.ResourceData, client, bssClient *golangsdk.ServiceClient) error {
@@ -2310,4 +2522,9 @@ func getGeminiDbInstance(client *golangsdk.ServiceClient, instanceId string) (in
 	}
 
 	return instance, nil
+}
+
+func parameterToHash(v interface{}) int {
+	m := v.(map[string]interface{})
+	return hashcode.String(m["name"].(string) + m["value"].(string))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new resource instance parameter
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resource instance parameter
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_configuration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_configuration -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_configuration
=== PAUSE TestAccGeminiDbInstance_configuration
=== CONT  TestAccGeminiDbInstance_configuration
--- PASS: TestAccGeminiDbInstance_configuration (1463.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1464.740s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
