### PR TITLE
feat(dsc): new datasource to query threat trend

### DIFF
--- a/docs/data-sources/dsc_threat_trend.md
+++ b/docs/data-sources/dsc_threat_trend.md
@@ -1,0 +1,36 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_threat_trend"
+description: |-
+  Use this data source to get the threat trend information within HuaweiCloud.
+---
+
+# huaweicloud_dsc_threat_trend
+
+Use this data source to get the threat trend information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_threat_trend" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `api_attacked_variation` - The variation list of the number of API attacks.
+
+* `database_attacked_variation` - The variation list of the number of database attacks.
+
+* `time_axis` - The time axis.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1409,6 +1409,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_drivers":                  drs.DataSourceDrsDrivers(),
 
 			"huaweicloud_dsc_event_overview": dsc.DataSourceDscEventOverview(),
+			"huaweicloud_dsc_threat_trend":   dsc.DataSourceDscThreatTrend(),
 			// EventGrid
 			"huaweicloud_eg_connections":           eg.DataSourceConnections(),
 			"huaweicloud_eg_custom_event_channels": eg.DataSourceCustomEventChannels(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_threat_trend_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_threat_trend_test.go
@@ -1,0 +1,36 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscThreatTrend_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_dsc_threat_trend.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscThreatTrend_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "api_attacked_variation.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "database_attacked_variation.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "time_axis.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDscThreatTrend_basic = `
+data "huaweicloud_dsc_threat_trend" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_threat_trend.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_threat_trend.go
@@ -1,0 +1,91 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v2/{project_id}/sec-ops/situation-dashboard/threat-trend
+func DataSourceDscThreatTrend() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscThreatTrendRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"api_attacked_variation": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"database_attacked_variation": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"time_axis": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+		},
+	}
+}
+
+func dataSourceDscThreatTrendRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v2/{project_id}/sec-ops/situation-dashboard/threat-trend"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC threat trend: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("api_attacked_variation", utils.PathSearch("api_attacked_variation", respBody, nil)),
+		d.Set("database_attacked_variation", utils.PathSearch("database_attacked_variation", respBody, nil)),
+		d.Set("time_axis", utils.PathSearch("time_axis", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query threat trend

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscThreatTrend_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscThreatTrend_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscThreatTrend_basic
=== PAUSE TestAccDataSourceDscThreatTrend_basic
=== CONT  TestAccDataSourceDscThreatTrend_basic
--- PASS: TestAccDataSourceDscThreatTrend_basic (15.29s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       15.405s coverage: 5.8% of statements in ./huaweicloud/services/dsc
```
<img width="1282" height="83" alt="image" src="https://github.com/user-attachments/assets/5de1d6dd-5cdc-468e-b483-6f5ae8415674" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
