### PR TITLE
feat(SecMaster): support data_class_type_layout resource

### DIFF
--- a/docs/resources/secmaster_data_class_type_layout.md
+++ b/docs/resources/secmaster_data_class_type_layout.md
@@ -1,0 +1,52 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_data_class_type_layout"
+description: |-
+  Manages a resource to bind data class type with layout within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_data_class_type_layout
+
+Manages a resource to bind data class type with layout within HuaweiCloud.
+
+-> This resource is a one-time action resource. Deleting this resource will not unbind the layout from the data class
+  type, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "dataclass_id" {}
+variable "type_id" {}
+
+resource "huaweicloud_secmaster_data_class_type_layout" "test" {
+  workspace_id = var.workspace_id
+  dataclass_id = var.dataclass_id
+  type_id      = var.type_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the workspace ID.
+
+* `dataclass_id` - (Required, String, NonUpdatable) Specifies the unique ID of the data class.
+
+* `type_id` - (Required, String, NonUpdatable) Specifies the type ID of the data class to which the layout will be bound.
+
+* `layout_id` - (Optional, String, NonUpdatable) Specifies the ID of the layout to bind with the data class type.
+
+* `layout_name` - (Optional, String, NonUpdatable) Specifies the name of the layout to bind with the data class type.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4520,6 +4520,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_collector_parser":            secmaster.ResourceCollectorParser(),
 			"huaweicloud_secmaster_component_template":          secmaster.ResourceComponentTemplate(),
 			"huaweicloud_secmaster_configuration_dictionary":    secmaster.ResourceConfigurationDictionary(),
+			"huaweicloud_secmaster_data_class_type_layout":      secmaster.ResourceDataClassTypeLayout(),
 			"huaweicloud_secmaster_data_object_relations":       secmaster.ResourceDataObjectRelations(),
 			"huaweicloud_secmaster_dataspace":                   secmaster.ResourceDataspace(),
 			"huaweicloud_secmaster_delete_nodes":                secmaster.ResourceDeleteNodes(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -594,6 +594,12 @@ var (
 	HW_SECMASTER_MAPPER_TYPE_ID = os.Getenv("HW_SECMASTER_MAPPER_TYPE_ID")
 	HW_SECMASTER_PIPE_ID        = os.Getenv("HW_SECMASTER_PIPE_ID")
 
+	// The SecMaster data class ID
+	HW_SECMASTER_DATACLASS_ID = os.Getenv("HW_SECMASTER_DATACLASS_ID")
+
+	// The SecMaster type ID
+	HW_SECMASTER_TYPE_ID = os.Getenv("HW_SECMASTER_TYPE_ID")
+
 	// The SecMaster dataspace ID
 	HW_SECMASTER_DATASPACE_ID = os.Getenv("HW_SECMASTER_DATASPACE_ID")
 
@@ -3329,6 +3335,20 @@ func TestAccPreCheckSecMasterPolicyID(t *testing.T) {
 func TestAccPreCheckSecMasterLayoutID(t *testing.T) {
 	if HW_SECMASTER_LAYOUT_ID == "" {
 		t.Skip("HW_SECMASTER_LAYOUT_ID must be set for SecMaster acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSecMasterDataClassID(t *testing.T) {
+	if HW_SECMASTER_DATACLASS_ID == "" {
+		t.Skip("HW_SECMASTER_DATACLASS_ID must be set for SecMaster acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSecMasterTypeID(t *testing.T) {
+	if HW_SECMASTER_TYPE_ID == "" {
+		t.Skip("HW_SECMASTER_TYPE_ID must be set for SecMaster acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_data_class_type_layout_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_data_class_type_layout_test.go
@@ -1,0 +1,38 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClassTypeLayout_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterDataClassID(t)
+			acceptance.TestAccPreCheckSecMasterTypeID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataClassTypeLayout_basic(),
+			},
+		},
+	})
+}
+
+func testDataClassTypeLayout_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_data_class_type_layout" "test" {
+  workspace_id = "%[1]s"
+  dataclass_id = "%[2]s"
+  type_id      = "%[3]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_DATACLASS_ID, acceptance.HW_SECMASTER_TYPE_ID)
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_data_class_type_layout.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_data_class_type_layout.go
@@ -1,0 +1,142 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var dataClassTypeLayoutNonUpdatableParams = []string{
+	"workspace_id",
+	"dataclass_id",
+	"type_id",
+	"layout_id",
+	"layout_name",
+}
+
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/soc/dataclasses/{dataclass_id}/types/layout
+func ResourceDataClassTypeLayout() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataClassTypeLayoutCreate,
+		ReadContext:   resourceDataClassTypeLayoutRead,
+		UpdateContext: resourceDataClassTypeLayoutUpdate,
+		DeleteContext: resourceDataClassTypeLayoutDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(dataClassTypeLayoutNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"dataclass_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"layout_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"layout_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDataClassTypeLayoutBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"id":          d.Get("type_id"),
+		"layout_id":   utils.ValueIgnoreEmpty(d.Get("layout_id")),
+		"layout_name": utils.ValueIgnoreEmpty(d.Get("layout_name")),
+	}
+}
+
+func resourceDataClassTypeLayoutCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		createHttpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/dataclasses/{dataclass_id}/types/layout"
+		workspaceId   = d.Get("workspace_id").(string)
+		dataclassId   = d.Get("dataclass_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", workspaceId)
+	createPath = strings.ReplaceAll(createPath, "{dataclass_id}", dataclassId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+		JSONBody: utils.RemoveNil(buildDataClassTypeLayoutBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error binding data class type with layout: %s", err)
+	}
+
+	resourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId.String())
+
+	return nil
+}
+
+func resourceDataClassTypeLayoutRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDataClassTypeLayoutUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDataClassTypeLayoutDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for binding data class type with layout. Deleting this
+		resource will not unbind the layout from the data class type, but will only remove the resource information from
+		the tfstate file.`
+
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support data_class_type_layout resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support data_class_type_layout resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/secmaster' TESTARGS='-run TestAccDataClassTypeLayout_basic -v'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccDataClassTypeLayout_basic -v -timeout 360m -parallel 4
=== RUN   TestAccDataClassTypeLayout_basic
=== PAUSE TestAccDataClassTypeLayout_basic
=== CONT  TestAccDataClassTypeLayout_basic
--- PASS: TestAccDataClassTypeLayout_basic (30.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 30.653s
```
<img width="528" height="20" alt="Snipaste_2026-07-02_16-41-37" src="https://github.com/user-attachments/assets/8aef4e92-9e02-4b47-b435-15c11da97c29" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
