### PR TITLE
chore(kafka): unify resources task status waiting pending logic

### DIFF
--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_partition_reassign_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_partition_reassign_test.go
@@ -13,13 +13,13 @@ func TestAccKafkaPartitionReassign_basic(t *testing.T) {
 	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_dms_kafka_partition_reassign.test"
 
-	// Avoid CheckDestroy
-	// lintignore:AT001
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKafkaPartitionReassign_basic(rName),
@@ -43,21 +43,25 @@ func TestAccKafkaPartitionReassign_basic(t *testing.T) {
 	})
 }
 
+func testAccKafkaPartitionReassign_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  partitions  = 2
+  replicas    = 3
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
 func testAccKafkaPartitionReassign_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dms_kafka_topic" "test" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  name        = "%s"
-  partitions  = 2
-  replicas    = 3
-}
-
 resource "huaweicloud_dms_kafka_partition_reassign" "test" {
   depends_on = [huaweicloud_dms_kafka_topic.test]
 
-  instance_id = huaweicloud_dms_kafka_instance.test.id
+  instance_id = "%[2]s"
   
   reassignments {
     topic = huaweicloud_dms_kafka_topic.test.name
@@ -72,31 +76,24 @@ resource "huaweicloud_dms_kafka_partition_reassign" "test" {
       partition_brokers = [2,0,1]
     }
   }
-}`, testAccKafkaInstance_newFormat(rName), rName)
+}`, testAccKafkaPartitionReassign_base(rName), acceptance.HW_DMS_KAFKA_INSTANCE_ID)
 }
 
 func testAccKafkaPartitionReassign_automatical(rName string, timeEstimate bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dms_kafka_topic" "test" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  name        = "%s"
-  partitions  = 2
-  replicas    = 3
-}
-
 resource "huaweicloud_dms_kafka_partition_reassign" "test" {
   depends_on = [huaweicloud_dms_kafka_topic.test]
 
-  instance_id   = huaweicloud_dms_kafka_instance.test.id
+  instance_id   = "%[2]s"
   throttle      = -1
-  time_estimate = %t
+  time_estimate = %[3]t
   
   reassignments {
     topic              = huaweicloud_dms_kafka_topic.test.name
     brokers            = [0,1,2]
     replication_factor = 3
   }
-}`, testAccKafkaInstance_newFormat(rName), rName, timeEstimate)
+}`, testAccKafkaPartitionReassign_base(rName), acceptance.HW_DMS_KAFKA_INSTANCE_ID, timeEstimate)
 }

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_user_client_quota_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_user_client_quota_test.go
@@ -113,7 +113,10 @@ func TestAccDmsKafkaUserClientQuota_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -148,28 +151,24 @@ func TestAccDmsKafkaUserClientQuota_basic(t *testing.T) {
 
 func testDmsKafkaUserClientQuota_basic(rName string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_dms_kafka_user_client_quota" "test" {
-  instance_id        = huaweicloud_dms_kafka_instance.test.id
+  instance_id        = "%[1]s"
   user               = "%[2]s"
   client             = "%[2]s"
   producer_byte_rate = 1024
   consumer_byte_rate = 0
 }
-`, testAccKafkaInstance_newFormat(rName), rName)
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, rName)
 }
 
 func testDmsKafkaUserClientQuota_update(rName string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_dms_kafka_user_client_quota" "test" {
-  instance_id        = huaweicloud_dms_kafka_instance.test.id
+  instance_id        = "%[1]s"
   user               = "%[2]s"
   client             = "%[2]s"
   producer_byte_rate = 0
   consumer_byte_rate = 2048
 }
-`, testAccKafkaInstance_newFormat(rName), rName)
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, rName)
 }

--- a/huaweicloud/services/kafka/common.go
+++ b/huaweicloud/services/kafka/common.go
@@ -42,10 +42,10 @@ func instanceTaskStatusRefreshFunc(client *golangsdk.ServiceClient, instanceID, 
 			return nil, "QUERY ERROR", err
 		}
 
-		// DELETED, SUCCESS, EXECUTING, FAILED
+		// The status enumeration values are as follows: `DELETED`, `SUCCESS`, `EXECUTING` and `FAILED`.
 		status := utils.PathSearch("tasks[0].status", resp, "").(string)
 		if status == "FAILED" || status == "DELETED" {
-			return resp, "FAILED", fmt.Errorf("unexpect status (%s)", status)
+			return resp, "FAILED", fmt.Errorf("unexpected status (%s)", status)
 		}
 
 		if utils.StrSliceContains(targets, status) {
@@ -56,6 +56,7 @@ func instanceTaskStatusRefreshFunc(client *golangsdk.ServiceClient, instanceID, 
 	}
 }
 
+// For Job ID task, use waitForInstanceTaskStatusComplete method.
 func waitForInstanceTaskStatusComplete(ctx context.Context, client *golangsdk.ServiceClient, instanceId, taskId string,
 	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
@@ -65,6 +66,91 @@ func waitForInstanceTaskStatusComplete(ctx context.Context, client *golangsdk.Se
 		Timeout:      timeout,
 		Delay:        20 * time.Second,
 		PollInterval: 30 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func getInstanceTasks(client *golangsdk.ServiceClient, instanceId string) ([]interface{}, error) {
+	var (
+		listHttpUrl = "v2/{project_id}/instances/{instance_id}/tasks"
+		// limit range is `1` to `100`.
+		limit = 100
+		// `start` must be greater than or equal to `1`.
+		start  = 1
+		result = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + listHttpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath += fmt.Sprintf("?limit=%v", limit)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithStart := listPath + fmt.Sprintf("&start=%d", start)
+		resp, err := client.Request("GET", listPathWithStart, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		tasks := utils.PathSearch("tasks", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, tasks...)
+		if len(tasks) < limit {
+			break
+		}
+
+		start += len(tasks)
+	}
+
+	return result, nil
+}
+
+func refreshTaskStatusByName(client *golangsdk.ServiceClient, instanceId, taskName string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		tasks, err := getInstanceTasks(client, instanceId)
+		if err != nil {
+			return nil, "QUERY ERROR", err
+		}
+
+		task := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0]", taskName), tasks, nil)
+		// The status enumeration values are as follows: `DELETED`, `SUCCESS`, `EXECUTING` and `FAILED`.
+		status := utils.PathSearch("status", task, "").(string)
+		if status == "FAILED" || status == "DELETED" {
+			return nil, "FAILED", fmt.Errorf("unexpected status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return task, "COMPLETED", nil
+		}
+
+		return task, "PENDING", nil
+	}
+}
+
+// For task without job ID, use task name to wait for the task to complete.
+func waitForInstanceTaskStatusCompleteByName(ctx context.Context, client *golangsdk.ServiceClient, instanceId, taskName string,
+	timeout time.Duration, targets ...[]string) error {
+	completedStatuses := []string{"SUCCESS"}
+	if len(targets) > 0 {
+		completedStatuses = targets[0]
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshTaskStatusByName(client, instanceId, taskName, completedStatuses),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
@@ -993,16 +993,9 @@ func createKafkaInstanceWithFlavor(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[INFO] Creating Kafka instance, ID: %s", instanceID)
 	d.SetId(instanceID)
 
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"CREATING"},
-		Target:       []string{"RUNNING"},
-		Refresh:      KafkaInstanceStateRefreshFunc(client, instanceID),
-		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        delayTime * time.Second,
-		PollInterval: 15 * time.Second,
-	}
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return diag.Errorf("error waiting for Kafka instance (%s) to be ready: %s", instanceID, err)
+	err = waitForInstanceStatusComplete(ctx, client, instanceID, d.Timeout(schema.TimeoutCreate), delayTime)
+	if err != nil {
+		return diag.Errorf("error waiting for Kafka instance (%s) to be created: %s", instanceID, err)
 	}
 
 	return nil
@@ -1148,15 +1141,7 @@ func createKafkaInstanceWithProductID(ctx context.Context, d *schema.ResourceDat
 	// Store the instance ID now
 	d.SetId(instanceID)
 
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"CREATING"},
-		Target:       []string{"RUNNING"},
-		Refresh:      KafkaInstanceStateRefreshFunc(client, instanceID),
-		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        delayTime * time.Second,
-		PollInterval: 15 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
+	err = waitForInstanceStatusComplete(ctx, client, instanceID, d.Timeout(schema.TimeoutCreate), delayTime)
 	if err != nil {
 		return diag.Errorf("error waiting for Kafka instance (%s) to be ready: %s", instanceID, err)
 	}
@@ -1609,6 +1594,7 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error initializing DMS Kafka(v2) client: %s", err)
 	}
 
+	instanceId := d.Id()
 	var mErr *multierror.Error
 	if d.HasChanges("name", "description", "maintain_begin", "maintain_end",
 		"security_group_id", "retention_policy", "enterprise_project_id") {
@@ -1627,14 +1613,14 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		retryFunc := func() (interface{}, bool, error) {
-			err = instances.Update(client, d.Id(), updateOpts).Err
+			err = instances.Update(client, instanceId, updateOpts).Err
 			retry, err := handleMultiOperationsError(err)
 			return nil, retry, err
 		}
 		_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
 			Ctx:          ctx,
 			RetryFunc:    retryFunc,
-			WaitFunc:     KafkaInstanceStateRefreshFunc(client, d.Id()),
+			WaitFunc:     KafkaInstanceStateRefreshFunc(client, instanceId),
 			WaitTarget:   []string{"RUNNING"},
 			Timeout:      d.Timeout(schema.TimeoutUpdate),
 			DelayTimeout: 1 * time.Second,
@@ -1654,9 +1640,9 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 
 	if d.HasChange("tags") {
 		// update tags
-		if err = utils.UpdateResourceTags(client, d, engineKafka, d.Id()); err != nil {
+		if err = utils.UpdateResourceTags(client, d, engineKafka, instanceId); err != nil {
 			mErr = multierror.Append(mErr, fmt.Errorf("error updating tags of Kafka instance: %s, err: %s",
-				d.Id(), err))
+				instanceId, err))
 		}
 	}
 
@@ -1671,8 +1657,8 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
-			return diag.Errorf("error updating the auto-renew of the Kafka instance (%s): %s", d.Id(), err)
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
+			return diag.Errorf("error updating the auto-renew of the Kafka instance (%s): %s", instanceId, err)
 		}
 	}
 
@@ -1682,14 +1668,14 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 			EnableAutoTopic: &enableAutoTopic,
 		}
 		retryFunc := func() (interface{}, bool, error) {
-			err = instances.UpdateAutoTopic(client, d.Id(), autoTopicOpts).Err
+			err = instances.UpdateAutoTopic(client, instanceId, autoTopicOpts).Err
 			retry, err := handleMultiOperationsError(err)
 			return nil, retry, err
 		}
 		_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
 			Ctx:          ctx,
 			RetryFunc:    retryFunc,
-			WaitFunc:     KafkaInstanceStateRefreshFunc(client, d.Id()),
+			WaitFunc:     KafkaInstanceStateRefreshFunc(client, instanceId),
 			WaitTarget:   []string{"RUNNING"},
 			Timeout:      d.Timeout(schema.TimeoutUpdate),
 			DelayTimeout: 1 * time.Second,
@@ -1700,19 +1686,10 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		// The enabling or disabling automatic topic is done if the status of its related task is SUCCESS
-		stateConf := &resource.StateChangeConf{
-			Pending:      []string{"CREATED"},
-			Target:       []string{"SUCCESS"},
-			Refresh:      FilterTaskRefreshFunc(client, d.Id(), "kafkaConfigModify"),
-			Timeout:      d.Timeout(schema.TimeoutUpdate),
-			Delay:        1 * time.Second,
-			PollInterval: 5 * time.Second,
-		}
-
-		_, err = stateConf.WaitForStateContext(ctx)
+		err = waitForInstanceTaskStatusCompleteByName(ctx, client, instanceId, "kafkaConfigModify", d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("error waiting for the automatic topic task of the instance (%s) to be done: %s", d.Id(), err))
+			mErr = multierror.Append(mErr, fmt.Errorf("error waiting for the automatic topic task of the instance (%s) to be done: %s",
+				instanceId, err))
 		}
 	}
 
@@ -2012,17 +1989,7 @@ func switchInstancePortProtocol(ctx context.Context, client *golangsdk.ServiceCl
 		return fmt.Errorf("unable to find job ID of the instance port protocol (%s) update", protocol)
 	}
 
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"CREATED"},
-		Target:       []string{"SUCCESS"},
-		Refresh:      kafkaInstanceTaskStatusRefreshFunc(client, instanceId, jobId),
-		Timeout:      updateTimeout,
-		Delay:        15 * time.Second,
-		PollInterval: 15 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
-
-	return err
+	return waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, updateTimeout)
 }
 
 func updateInstancePortProtocol(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
@@ -2175,6 +2142,52 @@ func KafkaInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID s
 		}
 
 		return v, v.Status, nil
+	}
+}
+
+func waitForInstanceStatusComplete(ctx context.Context, client *golangsdk.ServiceClient, instanceId string, timeout time.Duration,
+	delay ...time.Duration) error {
+	var delayTime time.Duration = 10
+	if len(delay) > 0 {
+		delayTime = delay[0]
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      instanceStatusRefreshFunc(client, instanceId, []string{"RUNNING"}),
+		Timeout:      timeout,
+		Delay:        delayTime * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func instanceStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := instances.Get(client, instanceId).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil, "DELETED", nil
+			}
+			return nil, "QUERY ERROR", err
+		}
+
+		status := respBody.Status
+		// The status enumeration values are as follows:
+		// + ERROR: The instance is fault.
+		// + EXTENDEDFAILED: The instance specification change operation failed.
+		// + FROZEN: The instance is frozen.
+		if utils.StrSliceContains([]string{"ERROR", "EXTENDEDFAILED", "FROZEN"}, status) {
+			return respBody, "FAILED", fmt.Errorf("unexpected status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
 	}
 }
 
@@ -2348,15 +2361,8 @@ func modifyParameters(ctx context.Context, client *golangsdk.ServiceClient, time
 	modifyConfigurationResp := r.(*instances.ModifyConfigurationResp)
 
 	// wait for task complete
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"CREATED"},
-		Target:       []string{"SUCCESS"},
-		Refresh:      kafkaInstanceTaskStatusRefreshFunc(client, instanceID, modifyConfigurationResp.JobId),
-		Timeout:      timeout,
-		Delay:        2 * time.Second,
-		PollInterval: 2 * time.Second,
-	}
-	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+	err = waitForInstanceTaskStateComplete(ctx, client, instanceID, modifyConfigurationResp.JobId, timeout)
+	if err != nil {
 		return nil, fmt.Errorf("error waiting for the Kafka instance (%s) parameter to be updated: %s ", instanceID, err)
 	}
 
@@ -2391,17 +2397,11 @@ func restartKafkaInstance(ctx context.Context, timeout time.Duration, client *go
 	}
 
 	// wait for the instance state to be 'RUNNING'.
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"RESTARTING"},
-		Target:       []string{"RUNNING"},
-		Refresh:      KafkaInstanceStateRefreshFunc(client, instanceID),
-		Timeout:      timeout,
-		Delay:        5 * time.Second,
-		PollInterval: 5 * time.Second,
-	}
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+	err = waitForInstanceStatusComplete(ctx, client, instanceID, timeout)
+	if err != nil {
 		return fmt.Errorf("error waiting for the Kafka instance (%s) become RUNNING status: %s", instanceID, err)
 	}
+
 	return nil
 }
 
@@ -2438,17 +2438,4 @@ func updateKafkaParameters(ctx context.Context, d *schema.ResourceData, client *
 	}
 
 	return ctx, nil
-}
-
-func kafkaInstanceTaskStatusRefreshFunc(client *golangsdk.ServiceClient, instanceID, taskID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		taskResp, err := instances.GetTask(client, instanceID, taskID).Extract()
-		if err != nil {
-			return nil, "QUERY ERROR", err
-		}
-		if len(taskResp.Tasks) == 0 {
-			return nil, "NIL ERROR", fmt.Errorf("failed to find task(%s)", taskID)
-		}
-		return taskResp.Tasks[0], taskResp.Tasks[0].Status, nil
-	}
 }

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_message_offset_reset.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_message_offset_reset.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
@@ -83,6 +82,7 @@ func resourceMessageOffsetResetCreate(ctx context.Context, d *schema.ResourceDat
 		cfg           = meta.(*config.Config)
 		createHttpUrl = "v2/kafka/{project_id}/instances/{instance_id}/groups/{group}/reset-message-offset"
 		consumerGroup = d.Get("group").(string)
+		instanceId    = d.Get("instance_id").(string)
 	)
 
 	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
@@ -97,7 +97,7 @@ func resourceMessageOffsetResetCreate(ctx context.Context, d *schema.ResourceDat
 
 	createPath := client.Endpoint + createHttpUrl
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
-	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
 	createPath = strings.ReplaceAll(createPath, "{group}", consumerGroup)
 
 	createOpt := golangsdk.RequestOpts{
@@ -121,21 +121,9 @@ func resourceMessageOffsetResetCreate(ctx context.Context, d *schema.ResourceDat
 
 	// when topic is empty string, reset all topic, and a job will be created
 	if _, ok := d.GetOk("topic"); !ok {
-		stateConf := &resource.StateChangeConf{
-			Pending:      []string{"CREATED"},
-			Target:       []string{"SUCCESS"},
-			Refresh:      FilterTaskRefreshFunc(client, d.Get("instance_id").(string), "kafkaResetConsumerOffset"),
-			Timeout:      d.Timeout(schema.TimeoutCreate),
-			Delay:        5 * time.Second,
-			PollInterval: 5 * time.Second,
-		}
-
-		task, err := stateConf.WaitForStateContext(ctx)
+		err = waitForInstanceTaskStatusCompleteByName(ctx, client, instanceId, "kafkaResetConsumerOffset", d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			if taskID := utils.PathSearch("id", task, ""); taskID != "" {
-				return diag.Errorf("error waiting for job (%s) to be done: %s", taskID, err)
-			}
-			return diag.Errorf("error waiting for job to be done: %s", err)
+			return diag.Errorf("error waiting for resetting message offset task to be done: %s", err)
 		}
 	}
 

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_partition_reassign.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_partition_reassign.go
@@ -163,17 +163,9 @@ func resourceDmsKafkaPartitionReassignCreate(ctx context.Context, d *schema.Reso
 	case jobID != nil:
 		// wait for task complete
 		// if it's not scheduled task, use `/v2/{project_id}/instances/{instance_id}/tasks/{task_id}` to search task.
-		stateConf := &resource.StateChangeConf{
-			Pending:      []string{"CREATED", "EXECUTING"},
-			Target:       []string{"SUCCESS"},
-			Refresh:      kafkaInstanceTaskStatusRefreshFunc(client, instanceID, jobID.(string)),
-			Timeout:      d.Timeout(schema.TimeoutCreate),
-			Delay:        1 * time.Second,
-			PollInterval: 5 * time.Second,
-		}
-		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-			return diag.Errorf("error waiting for the Kafka instance (%s) partition reassignment task to be finished: %s ",
-				instanceID, err)
+		err = waitForInstanceTaskStateComplete(ctx, client, instanceID, jobID.(string), d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return diag.Errorf("error waiting for the instance (%s) partition reassignment task to be finished: %s ", instanceID, err)
 		}
 
 		// since the resource ID is in UUID format, return `job_id`.
@@ -191,6 +183,20 @@ func resourceDmsKafkaPartitionReassignCreate(ctx context.Context, d *schema.Reso
 	}
 
 	return resourceDmsKafkaPartitionReassignRead(ctx, d, meta)
+}
+
+// Delay and PollInterval are shorter here than in waitForInstanceTaskStatusComplete (common.go), so the common helper is not applicable.
+func waitForInstanceTaskStateComplete(ctx context.Context, client *golangsdk.ServiceClient, instanceId, taskId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      instanceTaskStatusRefreshFunc(client, instanceId, taskId, []string{"SUCCESS"}),
+		Timeout:      timeout,
+		Delay:        2 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
 }
 
 func buildCreateKafkaPartitionReassignBodyParams(d *schema.ResourceData) map[string]interface{} {

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_user_client_quota.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_user_client_quota.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
@@ -148,7 +147,7 @@ func resourceDmsKafkaUserClientQuotaCreate(ctx context.Context, d *schema.Resour
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	jobId := utils.PathSearch("job_id", createQuotaRespBody, "")
+	jobId := utils.PathSearch("job_id", createQuotaRespBody, "").(string)
 	if jobId == "" {
 		return diag.Errorf("error creating DMS kafka user client quota: job_id is not found in API response")
 	}
@@ -160,18 +159,9 @@ func resourceDmsKafkaUserClientQuotaCreate(ctx context.Context, d *schema.Resour
 	d.SetId(instanceID + "/" + user + "/" + strconv.FormatBool(userDefault) + "/" + client + "/" + strconv.FormatBool(clientDefault))
 
 	// The quota creation triggers a related task, if the task status is SUCCESS, the quota has been created.
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"CREATED"},
-		Target:       []string{"SUCCESS"},
-		Refresh:      kafkaInstanceTaskStatusRefreshFunc(createKafkaUserClientQuotaClient, instanceID, jobId.(string)),
-		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        1 * time.Second,
-		PollInterval: 5 * time.Second,
-	}
-
-	_, err = stateConf.WaitForStateContext(ctx)
+	err = waitForInstanceTaskStateComplete(ctx, createKafkaUserClientQuotaClient, instanceID, jobId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error waiting for the quota (%s) to be created: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the user client quota task to be created: %s", err)
 	}
 
 	return resourceDmsKafkaUserClientQuotaRead(ctx, d, meta)
@@ -337,24 +327,15 @@ func resourceDmsKafkaUserClientQuotaUpdate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	jobId := utils.PathSearch("job_id", updateQuotaRespBody, "")
+	jobId := utils.PathSearch("job_id", updateQuotaRespBody, "").(string)
 	if jobId == "" {
 		return diag.Errorf("error updating the quota: job_id is not found in API response")
 	}
 
 	// The quota modification triggers a related task, if the task status is SUCCESS, the quota has been modified.
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"CREATED"},
-		Target:       []string{"SUCCESS"},
-		Refresh:      kafkaInstanceTaskStatusRefreshFunc(updateKafkaUserClientQuotaClient, instanceID, jobId.(string)),
-		Timeout:      d.Timeout(schema.TimeoutUpdate),
-		Delay:        1 * time.Second,
-		PollInterval: 5 * time.Second,
-	}
-
-	_, err = stateConf.WaitForStateContext(ctx)
+	err = waitForInstanceTaskStateComplete(ctx, updateKafkaUserClientQuotaClient, instanceID, jobId, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
-		return diag.Errorf("error waiting for the quota (%s) to be updated: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the user client quota task to be updated: %s", err)
 	}
 
 	return resourceDmsKafkaUserClientQuotaRead(ctx, d, meta)
@@ -411,24 +392,15 @@ func resourceDmsKafkaUserClientQuotaDelete(ctx context.Context, d *schema.Resour
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	jobId := utils.PathSearch("job_id", disablePluginRespBody, "")
+	jobId := utils.PathSearch("job_id", disablePluginRespBody, "").(string)
 	if jobId == "" {
 		return diag.Errorf("error deleting the quota: job_id is not found in API response")
 	}
 
 	// The quota deletion triggers a related task, if the task status is SUCCESS, the quota has been deleted.
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"CREATED"},
-		Target:       []string{"SUCCESS"},
-		Refresh:      kafkaInstanceTaskStatusRefreshFunc(deleteKafkaUserClientQuotaClient, instanceID, jobId.(string)),
-		Timeout:      d.Timeout(schema.TimeoutDelete),
-		Delay:        1 * time.Second,
-		PollInterval: 5 * time.Second,
-	}
-
-	_, err = stateConf.WaitForStateContext(ctx)
+	err = waitForInstanceTaskStateComplete(ctx, deleteKafkaUserClientQuotaClient, instanceID, jobId, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.Errorf("error waiting for the quota (%s) to be deleted: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the user client quota task to be deleted: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Unify resources task status waiting pending logic.
- Add `instanceTaskStatusRefreshFunc `and `waitForInstanceTaskComplete `methods to `common.go`
- `huaweicloud_dms_kafka_instance`, `huaweicloud_dms_kafka_partition_reassign`, `huaweicloud_dms_kafka_user_client_quota`,
  `huaweicloud_dms_kafka_message_offset_reset` resources to use unified wait helpers
- For the acceptance tests of the `huaweicloud_dms_kafka_partition_reassign `and `huaweicloud_dms_kafka_user_client_quota `resources, use `HW_DMS_KAFKA_INSTANCE_ID `instead of creating a new instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccKafkaInstance_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccKafkaInstance_ -timeout 360m -parallel 10
=== RUN   TestAccKafkaInstance_prePaid
=== PAUSE TestAccKafkaInstance_prePaid
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== RUN   TestAccKafkaInstance_publicIp
=== PAUSE TestAccKafkaInstance_publicIp
=== CONT  TestAccKafkaInstance_prePaid
=== CONT  TestAccKafkaInstance_publicIp
=== CONT  TestAccKafkaInstance_newFormat
--- PASS: TestAccKafkaInstance_prePaid (900.33s)
--- PASS: TestAccKafkaInstance_publicIp (1656.30s)
--- PASS: TestAccKafkaInstance_newFormat (2273.68s)
PASS
coverage: 18.6% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     2273.866s       coverage: 18.6% of statements in ./huaweicloud/services/kafka
```
```
./scripts/coverage.sh -o kafka -f TestAccKafkaPartitionReassign_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccKafkaPartitionReassign_basic -timeout 360m -parallel 10
=== RUN   TestAccKafkaPartitionReassign_basic
=== PAUSE TestAccKafkaPartitionReassign_basic
=== CONT  TestAccKafkaPartitionReassign_basic
--- PASS: TestAccKafkaPartitionReassign_basic (71.16s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     71.406s coverage: 5.8% of statements in ./huaweicloud/services/kafka
```

```
./scripts/coverage.sh -o kafka -f TestAccDmsKafkaUserClientQuota_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDmsKafkaUserClientQuota_basic -timeout 360m -parallel 10
=== RUN   TestAccDmsKafkaUserClientQuota_basic
=== PAUSE TestAccDmsKafkaUserClientQuota_basic
=== CONT  TestAccDmsKafkaUserClientQuota_basic
--- PASS: TestAccDmsKafkaUserClientQuota_basic (113.89s)
PASS
coverage: 5.5% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     114.066s        coverage: 5.5% of statements in ./huaweicloud/services/kafka
```


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
