### PR TITLE
feat(GaussDB): add new data source to query backup configurations

### DIFF
--- a/docs/data-sources/gaussdb_backup_configurations.md
+++ b/docs/data-sources/gaussdb_backup_configurations.md
@@ -1,0 +1,54 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_backup_configurations"
+description: |-
+  Use this data source to query the extended backup configurations.
+---
+
+# huaweicloud_gaussdb_backup_configurations
+
+Use this data source to query the extended backup configurations.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_gaussdb_backup_configurations" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the GaussDB instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rate_limit` - The backup flow control.
+
+* `file_split_size` - The shard size.
+
+* `prefetch_block` - The number of differential prefetch pages.
+
+* `enable_standby_backup` - Whether to enable standby node backup.
+
+* `close_compression` - Whether to disable backup compression.
+
+* `default_backup_method` - The default backup method.
+  + **PHYSICAL_BACKUP**: Indicates physical backup.
+  + **EBACKUP**: Indicates snapshot backup.
+
+* `default_backup_media_type` - The default backup storage medium.
+
+* `backup_parallel_degree` - The number of concurrent backup tasks.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1557,6 +1557,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_table_restored_tables":         geminidb.DataSourceGeminiDBTableRestoredTables(),
 
 			"huaweicloud_gaussdb_alarms":                          gaussdb.DataSourceAlarms(),
+			"huaweicloud_gaussdb_backup_configurations":           gaussdb.DataSourceBackupConfigurations(),
 			"huaweicloud_gaussdb_instance_alarm_statistics":       gaussdb.DataSourceInstanceAlarmStatistics(),
 			"huaweicloud_gaussdb_sql_explorer_status_records":     gaussdb.DataSourceInstanceSqlExplorerStatusRecords(),
 			"huaweicloud_gaussdb_instance_status_statistics":      gaussdb.DataSourceInstanceStatusStatistics(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_backup_configurations_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_backup_configurations_test.go
@@ -1,0 +1,46 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceBackupConfigurations_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_gaussdb_backup_configurations.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceBackupConfigurations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "rate_limit"),
+					resource.TestCheckResourceAttrSet(dataSource, "file_split_size"),
+					resource.TestCheckResourceAttrSet(dataSource, "prefetch_block"),
+					resource.TestCheckResourceAttrSet(dataSource, "enable_standby_backup"),
+					resource.TestCheckResourceAttrSet(dataSource, "close_compression"),
+					resource.TestCheckResourceAttrSet(dataSource, "default_backup_method"),
+					resource.TestCheckResourceAttrSet(dataSource, "default_backup_media_type"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceBackupConfigurations_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_backup_configurations" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_GAUSSDB_INSTANCE_ID)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_backup_configurations.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_backup_configurations.go
@@ -1,0 +1,122 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3/{project_id}/instances/{instance_id}/backups/config
+func DataSourceBackupConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBackupConfigurationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rate_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"file_split_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"prefetch_block": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"enable_standby_backup": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"close_compression": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"default_backup_method": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_backup_media_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"backup_parallel_degree": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceBackupConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/instances/{instance_id}/backups/config"
+	)
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the GaussDB backup configurations: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("rate_limit", utils.PathSearch("rate_limit", getRespBody, nil)),
+		d.Set("file_split_size", utils.PathSearch("file_split_size", getRespBody, nil)),
+		d.Set("prefetch_block", utils.PathSearch("prefetch_block", getRespBody, nil)),
+		d.Set("enable_standby_backup", utils.PathSearch("enable_standby_backup", getRespBody, nil)),
+		d.Set("close_compression", utils.PathSearch("close_compression", getRespBody, nil)),
+		d.Set("default_backup_method", utils.PathSearch("default_backup_method", getRespBody, nil)),
+		d.Set("default_backup_media_type", utils.PathSearch("default_backup_media_type", getRespBody, nil)),
+		d.Set("backup_parallel_degree", utils.PathSearch("backup_parallel_degree", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query backup configurations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to query backup configurations.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccDataSourceBackupConfigurations_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccDataSourceBackupConfigurations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceBackupConfigurations_basic
=== PAUSE TestAccDataSourceBackupConfigurations_basic
=== CONT  TestAccDataSourceBackupConfigurations_basic
--- PASS: TestAccDataSourceBackupConfigurations_basic (16.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   16.768s
```
<img width="1021" height="22" alt="image" src="https://github.com/user-attachments/assets/0a12133a-41ca-428f-9bfb-3902f2b4c7f9" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
