### PR TITLE
feat(dsc): new datasource to query alarms

### DIFF
--- a/docs/data-sources/dsc_alarms.md
+++ b/docs/data-sources/dsc_alarms.md
@@ -1,0 +1,111 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_alarms"
+description: |-
+  Use this data source to get the list of DSC alarms within HuaweiCloud.
+---
+
+# huaweicloud_dsc_alarms
+
+Use this data source to get the list of DSC alarms within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_alarms" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `alarm_level` - (Optional, String) Specifies the alarm level.
+
+* `alarm_name` - (Optional, String) Specifies the alarm name.
+
+* `alarm_status` - (Optional, String) Specifies the alarm status.
+
+* `end_time` - (Optional, Int) Specifies the end time of the query (timestamp).
+
+* `start_time` - (Optional, Int) Specifies the start time of the query (timestamp).
+
+* `responsible_person` - (Optional, String) Specifies the responsible person for the alarm.
+
+* `source_name` - (Optional, String) Specifies the alarm source name.
+
+* `source_type` - (Optional, String) Specifies the alarm source type.
+
+* `verification_status` - (Optional, String) Specifies the verification status.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `alarms` - The alarm information list.
+
+  The [alarms](#alarms_struct) structure is documented below.
+
+<a name="alarms_struct"></a>
+The `alarms` block supports:
+
+* `id` - The alarm ID.
+
+* `alarm_name` - The alarm name.
+
+* `alarm_level` - The alarm level.
+
+* `alarm_status` - The alarm status.
+
+* `alarm_type` - The alarm type.
+
+* `close_reason` - The reason for closing the alarm.
+
+* `create_time` - The alarm creation time.
+
+* `description` - The alarm description.
+
+* `disposal_suggestion` - The disposal suggestion.
+
+* `domain_id` - The domain ID.
+
+* `occur_time` - The alarm occurrence time.
+
+* `project_id` - The project ID.
+
+* `source_module` - The alarm source module.
+
+* `source_sub_type` - The alarm source sub type.
+
+* `source_type` - The alarm source type.
+
+* `verification_status` - The verification status.
+
+* `affected_asset` - The affected assets.
+
+* `responsible_person` - The responsible person information.
+
+  The [responsible_person](#alarms_responsible_person_struct) structure is documented below.
+
+* `source_instance` - The alarm source instance information.
+
+  The [source_instance](#alarms_source_instance_struct) structure is documented below.
+
+<a name="alarms_responsible_person_struct"></a>
+The `responsible_person` block supports:
+
+* `user_id` - The user ID.
+
+* `user_name` - The user name.
+
+<a name="alarms_source_instance_struct"></a>
+The `source_instance` block supports:
+
+* `instance_id` - The instance ID.
+
+* `instance_name` - The instance name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1410,6 +1410,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_timelines":                drs.DataSourceDrsTimelines(),
 			"huaweicloud_drs_drivers":                  drs.DataSourceDrsDrivers(),
 
+			"huaweicloud_dsc_alarms":               dsc.DataSourceDscAlarms(),
 			"huaweicloud_dsc_alarm_handling_trend": dsc.DataSourceDscAlarmHandlingTrend(),
 			"huaweicloud_dsc_event_overview":       dsc.DataSourceDscEventOverview(),
 			"huaweicloud_dsc_threat_trend":         dsc.DataSourceDscThreatTrend(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_alarms_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_alarms_test.go
@@ -1,0 +1,34 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscAlarms_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_dsc_alarms.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscAlarms_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "alarms.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDscAlarms_basic = `
+data "huaweicloud_dsc_alarms" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_alarms.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_alarms.go
@@ -1,0 +1,382 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v2/{project_id}/sec-ops/alarms
+func DataSourceDscAlarms() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscAlarmsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"alarm_level": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the alarm level.",
+			},
+			"alarm_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the alarm name.",
+			},
+			"alarm_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the alarm status.",
+			},
+			"end_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the end time of the query (timestamp).",
+			},
+			"start_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the start time of the query (timestamp).",
+			},
+			"responsible_person": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the responsible person for the alarm.",
+			},
+			"source_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the alarm source name.",
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the alarm source type.",
+			},
+			"verification_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the verification status.",
+			},
+			"alarms": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The alarm information list.",
+				Elem:        dscAlarmsRecordsSchema(),
+			},
+		},
+	}
+}
+
+func dscAlarmsRecordsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The alarm ID.",
+			},
+			"alarm_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alarm name.",
+			},
+			"alarm_level": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alarm level.",
+			},
+			"alarm_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alarm status.",
+			},
+			"alarm_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alarm type.",
+			},
+			"close_reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The reason for closing the alarm.",
+			},
+			"create_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The alarm creation time.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alarm description.",
+			},
+			"disposal_suggestion": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The disposal suggestion.",
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The domain ID.",
+			},
+			"occur_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The alarm occurrence time.",
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The project ID.",
+			},
+			"source_module": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alarm source module.",
+			},
+			"source_sub_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alarm source sub type.",
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alarm source type.",
+			},
+			"verification_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The verification status.",
+			},
+			"affected_asset": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The affected assets.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"responsible_person": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The responsible person information.",
+				Elem:        dscAlarmsResponsiblePersonSchema(),
+			},
+			"source_instance": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The alarm source instance information.",
+				Elem:        dscAlarmsSourceInstanceSchema(),
+			},
+		},
+	}
+}
+
+func dscAlarmsResponsiblePersonSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The user ID.",
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The user name.",
+			},
+		},
+	}
+}
+
+func dscAlarmsSourceInstanceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The instance ID.",
+			},
+			"instance_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The instance name.",
+			},
+		},
+	}
+}
+
+func buildDscAlarmsQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("alarm_level"); ok {
+		queryParams = fmt.Sprintf("%s&alarm_level=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("alarm_name"); ok {
+		queryParams = fmt.Sprintf("%s&alarm_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("alarm_status"); ok {
+		queryParams = fmt.Sprintf("%s&alarm_status=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams = fmt.Sprintf("%s&end_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("start_time"); ok {
+		queryParams = fmt.Sprintf("%s&start_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("responsible_person"); ok {
+		queryParams = fmt.Sprintf("%s&responsible_person=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("source_name"); ok {
+		queryParams = fmt.Sprintf("%s&source_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("source_type"); ok {
+		queryParams = fmt.Sprintf("%s&source_type=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("verification_status"); ok {
+		queryParams = fmt.Sprintf("%s&verification_status=%v", queryParams, v)
+	}
+
+	if offset > 0 {
+		queryParams = fmt.Sprintf("%s&offset=%v", queryParams, offset)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func dataSourceDscAlarmsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v2/{project_id}/sec-ops/alarms"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := requestPath + buildDscAlarmsQueryParams(d, offset)
+		requestResp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DSC alarms: %s", err)
+		}
+
+		requestRespBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		alarmInfoList := utils.PathSearch("alarm_info_list", requestRespBody, make([]interface{}, 0)).([]interface{})
+		if len(alarmInfoList) == 0 {
+			break
+		}
+
+		result = append(result, alarmInfoList...)
+		offset += len(alarmInfoList)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("alarms", flattenDscAlarmsRecords(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDscAlarmsRecords(alarmInfoList []interface{}) []interface{} {
+	if len(alarmInfoList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(alarmInfoList))
+	for _, v := range alarmInfoList {
+		rst = append(rst, map[string]interface{}{
+			"id":                  utils.PathSearch("id", v, nil),
+			"alarm_name":          utils.PathSearch("alarm_name", v, nil),
+			"alarm_level":         utils.PathSearch("alarm_level", v, nil),
+			"alarm_status":        utils.PathSearch("alarm_status", v, nil),
+			"alarm_type":          utils.PathSearch("alarm_type", v, nil),
+			"close_reason":        utils.PathSearch("close_reason", v, nil),
+			"create_time":         utils.PathSearch("create_time", v, nil),
+			"description":         utils.PathSearch("description", v, nil),
+			"disposal_suggestion": utils.PathSearch("disposal_suggestion", v, nil),
+			"domain_id":           utils.PathSearch("domain_id", v, nil),
+			"occur_time":          utils.PathSearch("occur_time", v, nil),
+			"project_id":          utils.PathSearch("project_id", v, nil),
+			"source_module":       utils.PathSearch("source_module", v, nil),
+			"source_sub_type":     utils.PathSearch("source_sub_type", v, nil),
+			"source_type":         utils.PathSearch("source_type", v, nil),
+			"verification_status": utils.PathSearch("verification_status", v, nil),
+			"affected_asset":      utils.PathSearch("affected_asset", v, nil),
+			"responsible_person":  flattenDscAlarmsResponsiblePerson(v),
+			"source_instance":     flattenDscAlarmsSourceInstance(v),
+		})
+	}
+
+	return rst
+}
+
+func flattenDscAlarmsResponsiblePerson(respBody interface{}) []interface{} {
+	responsiblePersonResp := utils.PathSearch("responsible_person", respBody, nil)
+	if responsiblePersonResp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"user_id":   utils.PathSearch("user_id", responsiblePersonResp, nil),
+			"user_name": utils.PathSearch("user_name", responsiblePersonResp, nil),
+		},
+	}
+}
+
+func flattenDscAlarmsSourceInstance(respBody interface{}) []interface{} {
+	sourceInstanceResp := utils.PathSearch("source_instance", respBody, nil)
+	if sourceInstanceResp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"instance_id":   utils.PathSearch("instance_id", sourceInstanceResp, nil),
+			"instance_name": utils.PathSearch("instance_name", sourceInstanceResp, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query alarms

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscAlarms_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscAlarms_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscAlarms_basic
=== PAUSE TestAccDataSourceDscAlarms_basic
=== CONT  TestAccDataSourceDscAlarms_basic
--- PASS: TestAccDataSourceDscAlarms_basic (12.36s)
PASS
coverage: 10.3% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       12.471s coverage: 10.3% of statements in ./huaweicloud/services/dsc
```
<img width="1305" height="85" alt="image" src="https://github.com/user-attachments/assets/b62cea24-f2af-4eba-ab18-6bc8f39df535" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
