### PR TITLE
feat(TaurusDB): taurusdb_proxy support setting dns

### DIFF
--- a/docs/resources/taurusdb_proxy.md
+++ b/docs/resources/taurusdb_proxy.md
@@ -106,6 +106,10 @@ The following arguments are supported:
   `300` IP addresses or CIDR blocks can be added.
   The [access_control_ip_list](#access_control_ip_list_struct) structure is documented below.
 
+* `dns_name_prefix` - (Optional, String) Specifies the prefix of the private domain name for the proxy. If specified,
+  a private domain name will be applied for the proxy and updated to the specified prefix. If this parameter is changed
+  to an empty string, the private domain name will be deleted.
+
 <a name="node_weight_struct"></a>
 The `master_node_weight` and `readonly_nodes_weight` block supports:
 
@@ -149,6 +153,8 @@ In addition to all arguments above, the following attributes are exported:
 * `current_version` - Indicates the current version of the proxy.
 
 * `can_upgrade` - Indicates whether the proxy can be upgrade.
+
+* `dns_name` - Indicates the private domain name of the proxy.
 
 <a name="nodes_struct"></a>
 The `nodes` block supports:

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_proxy_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_proxy_test.go
@@ -109,6 +109,8 @@ func TestAccTaurusDBMySQLProxy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "access_control_ip_list.0.ip", "3.3.3.3"),
 					resource.TestCheckResourceAttr(resourceName, "access_control_ip_list.0.description",
 						"test description"),
+					resource.TestCheckResourceAttr(resourceName, "dns_name_prefix", "tftestdnsname"),
+					resource.TestCheckResourceAttrSet(resourceName, "dns_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "address"),
 					resource.TestCheckResourceAttrSet(resourceName, "current_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "can_upgrade"),
@@ -151,6 +153,8 @@ func TestAccTaurusDBMySQLProxy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "access_control_ip_list.0.ip", "4.4.4.4"),
 					resource.TestCheckResourceAttr(resourceName, "access_control_ip_list.0.description",
 						"test description update"),
+					resource.TestCheckResourceAttr(resourceName, "dns_name_prefix", "tftestdnsnameupdate"),
+					resource.TestCheckResourceAttrSet(resourceName, "dns_name"),
 				),
 			},
 			{
@@ -198,7 +202,7 @@ resource "huaweicloud_taurusdb_instance" "test" {
   enterprise_project_id    = "0"
   master_availability_zone = data.huaweicloud_availability_zones.test.names[0]
   availability_zone_mode   = "multi"
-  read_replicas            = 4
+  read_replicas            = 1
 }
 
 data "huaweicloud_taurusdb_proxy_flavors" "test" {
@@ -231,6 +235,7 @@ resource "huaweicloud_taurusdb_proxy" "test" {
   connection_pool_type     = "SESSION"
   open_access_control      = true
   access_control_type      = "white"
+  dns_name_prefix          = "tftestdnsname"
 
   access_control_ip_list {
     ip          = "3.3.3.3"
@@ -276,6 +281,7 @@ resource "huaweicloud_taurusdb_proxy" "test" {
   connection_pool_type     = "CLOSED"
   open_access_control      = false
   access_control_type      = "black"
+  dns_name_prefix          = "tftestdnsnameupdate"
 
   access_control_ip_list {
     ip          = "4.4.4.4"
@@ -326,6 +332,7 @@ resource "huaweicloud_taurusdb_proxy" "test" {
   connection_pool_type     = "CLOSED"
   open_access_control      = false
   access_control_type      = "black"
+  dns_name_prefix          = ""
 
   access_control_ip_list {
     ip          = "4.4.4.4"

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_proxy.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_proxy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances"
 	"github.com/chnsz/golangsdk/pagination"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -42,6 +43,10 @@ import (
 // @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/{engine_name}/proxy-version
 // @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/configurations
 // @API TaurusDB DELETE /v3/{project_id}/instances/{instance_id}/proxy
+// @API TaurusDB POST /v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/dns
+// @API TaurusDB PUT /v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/dns
+// @API TaurusDB DELETE /v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/dns
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}
 func ResourceTaurusDBProxy() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceGaussDBProxyCreate,
@@ -181,6 +186,10 @@ func ResourceTaurusDBProxy() *schema.Resource {
 				Elem:         gaussDBMysqlProxyAccessControlIpListSchema(),
 				RequiredWith: []string{"access_control_type"},
 			},
+			"dns_name_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -200,6 +209,10 @@ func ResourceTaurusDBProxy() *schema.Resource {
 			},
 			"can_upgrade": {
 				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"dns_name": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -369,6 +382,18 @@ func resourceGaussDBProxyCreate(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
+	if _, ok := d.GetOk("dns_name_prefix"); ok {
+		// The creation API will create a dns with random prefix, use update API to modify the prefix
+		err = createProxyDNSName(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		err = updateProxyDNSName(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceGaussDBProxyRead(ctx, d, meta)
 }
 
@@ -484,6 +509,17 @@ func resourceGaussDBProxyRead(_ context.Context, d *schema.ResourceData, meta in
 			d.Set("access_control_ip_list", accessControlIpList),
 		)
 	}
+
+	dnsName := utils.PathSearch("proxy.dns_name", proxy, "").(string)
+	dnsNamePrefix := ""
+	if dnsName != "" {
+		dnsNamePrefix = strings.Split(dnsName, ".")[0]
+	}
+
+	mErr = multierror.Append(mErr,
+		d.Set("dns_name", dnsName),
+		d.Set("dns_name_prefix", dnsNamePrefix),
+	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
@@ -796,6 +832,13 @@ func resourceGaussDBProxyUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	if d.HasChanges("access_control_type", "access_control_ip_list") {
 		err = updateGaussDBMySQLAccessControlRule(d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("dns_name_prefix") {
+		err = updateProxyDNSNamePrefix(ctx, d, client)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -1454,4 +1497,132 @@ func resourceGaussDBMySQLProxyImportState(_ context.Context, d *schema.ResourceD
 	)
 
 	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}
+
+func createProxyDNSName(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/dns"
+	)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+	createPath = strings.ReplaceAll(createPath, "{proxy_id}", d.Id())
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return fmt.Errorf("error creating TaurusDB proxy DNS name: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return errors.New("error creating TaurusDB proxy DNS name: job_id is not found in API response")
+	}
+
+	return checkGaussDBMySQLProxyJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+}
+
+func updateProxyDNSName(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/dns"
+	)
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{proxy_id}", d.Id())
+
+	// Get vpc_id from instance details
+	instanceId := d.Get("instance_id").(string)
+	instance, err := instances.Get(client, instanceId).Extract()
+	if err != nil {
+		return fmt.Errorf("error retrieving TaurusDB instance (%s) for VPC ID: %s", instanceId, err)
+	}
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	updateOpt.JSONBody = map[string]interface{}{
+		"new_dns_name": d.Get("dns_name_prefix").(string),
+		"vpc_id":       instance.VpcId,
+	}
+
+	updateResp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating TaurusDB proxy DNS name: %s", err)
+	}
+
+	updateRespBody, err := utils.FlattenResponse(updateResp)
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", updateRespBody, "").(string)
+	if jobId == "" {
+		return errors.New("error updating TaurusDB proxy DNS name: job_id is not found in API response")
+	}
+
+	return checkGaussDBMySQLProxyJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+}
+
+func updateProxyDNSNamePrefix(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	oldPrefix, newPrefix := d.GetChange("dns_name_prefix")
+
+	// If new dns_name_prefix is empty, delete the DNS name
+	if newPrefix.(string) == "" {
+		return deleteProxyDNSName(ctx, d, client)
+	}
+
+	// If old dns_name_prefix is empty, need to create first then update
+	if oldPrefix.(string) == "" {
+		err := createProxyDNSName(ctx, d, client)
+		if err != nil {
+			return err
+		}
+		return updateProxyDNSName(ctx, d, client)
+	}
+
+	// Otherwise, just update the DNS name
+	return updateProxyDNSName(ctx, d, client)
+}
+
+func deleteProxyDNSName(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/dns"
+	)
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Get("instance_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{proxy_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	deleteResp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return fmt.Errorf("error deleting TaurusDB proxy DNS name: %s", err)
+	}
+
+	deleteRespBody, err := utils.FlattenResponse(deleteResp)
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", deleteRespBody, "").(string)
+	if jobId == "" {
+		return errors.New("error deleting TaurusDB proxy DNS name: job_id is not found in API response")
+	}
+
+	return checkGaussDBMySQLProxyJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutUpdate))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
taurusdb_proxy support setting dns
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
taurusdb_proxy support setting dns
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
