### PR TITLE
chore(lint): resolve some lint errors

### DIFF
--- a/huaweicloud/common.go
+++ b/huaweicloud/common.go
@@ -13,12 +13,12 @@ import (
 // GetRegion returns the region that was specified in the resource. If a
 // region was not set, the provider-level region is checked. The provider-level
 // region can either be set by the region argument or by HW_REGION_NAME.
-func GetRegion(d *schema.ResourceData, config *config.Config) string {
+func GetRegion(d *schema.ResourceData, cfg *config.Config) string {
 	if v, ok := d.GetOk("region"); ok {
 		return v.(string)
 	}
 
-	return config.Region
+	return cfg.Region
 }
 
 // CheckDeleted checks the error to see if it's a 404 (Not Found) and, if so,

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -262,7 +262,7 @@ func refreshOrderAllResourceStatusFunc(client *golangsdk.ServiceClient, orderId 
 }
 
 func CaseInsensitiveFunc() schema.SchemaDiffSuppressFunc {
-	return func(k, old, new string, d *schema.ResourceData) bool {
+	return func(_, old, new string, _ *schema.ResourceData) bool {
 		return strings.EqualFold(old, new)
 	}
 }

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -47,12 +47,12 @@ func ParseErrorMsg(body []byte) (ErrorResp, error) {
 // GetRegion returns the region that was specified ina the resource. If a
 // region was not set, the provider-level region is checked. The provider-level
 // region can either be set by the region argument or by HW_REGION_NAME.
-func GetRegion(d *schema.ResourceData, config *config.Config) string {
+func GetRegion(d *schema.ResourceData, cfg *config.Config) string {
 	if v, ok := d.GetOk("region"); ok {
 		return v.(string)
 	}
 
-	return config.Region
+	return cfg.Region
 }
 
 // GetEipIDbyAddress returns the EIP ID of address when success.
@@ -121,8 +121,8 @@ func CheckDeletedDiag(d *schema.ResourceData, err error, msg string) diag.Diagno
 }
 
 // UnsubscribePrePaidResource impl the action of unsubscribe resource
-func UnsubscribePrePaidResource(d *schema.ResourceData, config *config.Config, resourceIDs []string) error {
-	bssV2Client, err := config.BssV2Client(GetRegion(d, config))
+func UnsubscribePrePaidResource(d *schema.ResourceData, cfg *config.Config, resourceIDs []string) error {
+	bssV2Client, err := cfg.BssV2Client(GetRegion(d, cfg))
 	if err != nil {
 		return fmt.Errorf("error creating bss V2 client: %s", err)
 	}

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -262,8 +262,8 @@ func refreshOrderAllResourceStatusFunc(client *golangsdk.ServiceClient, orderId 
 }
 
 func CaseInsensitiveFunc() schema.SchemaDiffSuppressFunc {
-	return func(_, old, new string, _ *schema.ResourceData) bool {
-		return strings.EqualFold(old, new)
+	return func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+		return strings.EqualFold(oldVal, newVal)
 	}
 }
 

--- a/huaweicloud/config/auth.go
+++ b/huaweicloud/config/auth.go
@@ -221,7 +221,6 @@ func buildClientByToken(c *Config) error {
 	for _, ao := range []*golangsdk.AuthOptions{&projectAuthOptions, &domainAuthOptions} {
 		ao.IdentityEndpoint = c.IdentityEndpoint
 		ao.TokenID = c.Token
-
 	}
 	return genClients(c, projectAuthOptions, domainAuthOptions)
 }

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -295,7 +295,7 @@ func retryBackoffFunc(ctx context.Context, _ *golangsdk.ErrUnexpectedResponseCod
 			return e
 		}
 	} else {
-		//lintignore:R018
+		// lintignore:R018
 		time.Sleep(sleep)
 	}
 

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -443,7 +443,8 @@ func (c *Config) newServiceClientByName(client *golangsdk.ProviderClient, catalo
 	// Custom Resource-level region only supports AK/SK authentication.
 	// If set it when using non AK/SK authentication, then it must be the same as Provider-level region.
 	if region != c.Region && (c.AccessKey == "" || c.SecretKey == "") {
-		return nil, fmt.Errorf("Resource-level region must be the same as Provider-level region when using non AK/SK authentication if Resource-level region set")
+		return nil, fmt.Errorf("Resource-level region must be the same as Provider-level region when using non AK/SK authentication" +
+			" if Resource-level region set")
 	}
 
 	c.RPLock.Lock()
@@ -580,7 +581,6 @@ func (c *Config) getUserIDbyName(name string) (string, error) {
 
 // loadUserProjects will query the region-projectId pair and store it into RegionProjectIDMap
 func (c *Config) loadUserProjects(client *golangsdk.ProviderClient, region string) error {
-
 	log.Printf("[DEBUG] Load project ID for region: %s", region)
 	domainID := client.DomainID
 	opts := projects.ListOpts{

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -879,11 +879,11 @@ func (c *Config) FwV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("networkv2", region)
 }
 
-func (c *Config) DnsV2Client(region string) (*golangsdk.ServiceClient, error) {
+func (c *Config) DNSV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("dns", region)
 }
 
-func (c *Config) DnsWithRegionClient(region string) (*golangsdk.ServiceClient, error) {
+func (c *Config) DNSWithRegionClient(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("dns_region", region)
 }
 

--- a/huaweicloud/config/config_test.go
+++ b/huaweicloud/config/config_test.go
@@ -35,7 +35,7 @@ func testRequestRetry(t *testing.T, count int) {
 			info.mut.RLock()
 			info.retries++
 			info.mut.RUnlock()
-			//lintignore:R009
+			// lintignore:R009
 			panic(err) // simulate EOF
 		}
 		w.WriteHeader(500)

--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -108,7 +108,7 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 
 		log.Printf("[DEBUG] [%s] connection error, retry number %d: %s", logId, retry, err)
 
-		//lintignore:R018
+		// lintignore:R018
 		time.Sleep(retryTimeout(retry))
 		response, err = lrt.Rt.RoundTrip(request)
 		retry++

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -646,7 +646,6 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 // include computeV1Client,computeV11Client,computeV2Client,autoscalingV1Client,imageV2Client,
 // cceV3Client,cceAddonV3Client,cciV1Client,cciV1BetaClient and FgsV2Client
 func TestAccServiceEndpoints_Compute(t *testing.T) {
-
 	testAccPreCheckServiceEndpoints(t)
 
 	testProvider := Provider()
@@ -774,7 +773,6 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 // include blockStorageV2Client, BlockStorageV21Client, sfsV2Client, sfsV1Client,
 // csbsV1Client, vbsV2Client and cbrV3Client
 func TestAccServiceEndpoints_Storage(t *testing.T) {
-
 	testAccPreCheckServiceEndpoints(t)
 
 	testProvider := Provider()
@@ -856,7 +854,6 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 // TestAccServiceEndpoints_Network test for the endpoints of the clients used in network
 // nolint:gocyclo
 func TestAccServiceEndpoints_Network(t *testing.T) {
-
 	testAccPreCheckServiceEndpoints(t)
 
 	testProvider := Provider()
@@ -1243,7 +1240,6 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 		t.Fatalf("Workspace region endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
 	t.Logf("Workspace region endpoint:\t %s", actualURL)
-
 }
 
 func TestAccServiceEndpoints_Edge(t *testing.T) {

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -950,7 +950,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	compareURL(expectedURL, actualURL, "fw", "v2.0", t)
 
 	// test the endpoint of DNS service
-	serviceClient, err = cfg.DnsV2Client(HW_REGION_NAME)
+	serviceClient, err = cfg.DNSV2Client(HW_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud DNS client: %s", err)
 	}
@@ -962,7 +962,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	t.Logf("DNS endpoint:\t %s", actualURL)
 
 	// test the endpoint of DNS service (with region)
-	serviceClient, err = cfg.DnsWithRegionClient(HW_REGION_NAME)
+	serviceClient, err = cfg.DNSWithRegionClient(HW_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud DNS region client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_compute_keypair_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_keypair_test.go
@@ -62,8 +62,8 @@ func TestAccComputeV2Keypair_privateKey(t *testing.T) {
 }
 
 func testAccCheckComputeV2KeypairDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	computeClient, err := config.ComputeV2Client(HW_REGION_NAME)
+	cfg := testAccProvider.Meta().(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -93,8 +93,8 @@ func testAccCheckComputeV2KeypairExists(n string, kp *keypairs.KeyPair) resource
 			return fmt.Errorf("no ID set for resource %s", n)
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		computeClient, err := config.ComputeV2Client(HW_REGION_NAME)
+		cfg := testAccProvider.Meta().(*config.Config)
+		computeClient, err := cfg.ComputeV2Client(HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating compute client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_test.go
@@ -481,7 +481,7 @@ func TestAccChannel_eipMembers(t *testing.T) {
 		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
 		rName      = "huaweicloud_apig_channel.test"
 		name       = acceptance.RandomAccResourceName()
-		baseConfig = testAccChannel_eipBase(name)
+		baseConfig = testAccChannel_eipBase()
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -537,7 +537,7 @@ func TestAccChannel_eipMembers(t *testing.T) {
 	})
 }
 
-func testAccChannel_eipBase(name string) string {
+func testAccChannel_eipBase() string {
 	return fmt.Sprintf(`
 data "huaweicloud_apig_instances" "test" {
   instance_id = "%[1]s"

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_test.go
@@ -407,8 +407,8 @@ func TestAccCluster_resizePeriod(t *testing.T) {
 }
 
 func testAccCheckClusterDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := cfg.CceV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating CCE v3 client: %s", err)
 	}
@@ -438,8 +438,8 @@ func testAccCheckClusterExists(n string, cluster *clusters.Clusters) resource.Te
 			return fmt.Errorf("resource ID is not set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := cfg.CceV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating CCE v3 client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_namespace_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_namespace_test.go
@@ -111,7 +111,6 @@ func testAccCCENamespaceImportStateIdFunc(name string) resource.ImportStateIdFun
 			return "", fmt.Errorf("resource not found: %s/%s", clusterID, name)
 		}
 		return fmt.Sprintf("%s/%s", clusterID, name), nil
-
 	}
 }
 

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_logstash_pipeline_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_logstash_pipeline_test.go
@@ -50,7 +50,6 @@ func getLogstashPipelineResourceFunc(cfg *config.Config, state *terraform.Resour
 }
 
 func TestAccLogstashPipeline_basic(t *testing.T) {
-
 	var (
 		obj   interface{}
 		name  = acceptance.RandomAccResourceName()

--- a/huaweicloud/services/acceptance/deprecated/data_source_huaweicloud_compute_availability_zones_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/data_source_huaweicloud_compute_availability_zones_v2_test.go
@@ -17,7 +17,8 @@ func TestAccAvailabilityZonesV2_basic(t *testing.T) {
 			{
 				Config: testAccAvailabilityZonesConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.huaweicloud_compute_availability_zones_v2.zones", "names.#", regexp.MustCompile("[1-9]\\d*")),
+					resource.TestMatchResourceAttr("data.huaweicloud_compute_availability_zones_v2.zones", "names.#",
+						regexp.MustCompile("[1-9]\\d*")),
 				),
 			},
 		},

--- a/huaweicloud/services/acceptance/deprecated/data_source_huaweicloud_networking_subnet_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/data_source_huaweicloud_networking_subnet_v2_test.go
@@ -23,7 +23,8 @@ func TestAccNetworkingV2SubnetDataSource_basic(t *testing.T) {
 				Config: testAccHuaweiCloudNetworkingSubnetV2DataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingSubnetV2DataSourceID("data.huaweicloud_networking_subnet_v2.subnet_1"),
-					testAccCheckNetworkingSubnetV2DataSourceGoodNetwork("data.huaweicloud_networking_subnet_v2.subnet_1", "huaweicloud_networking_network_v2.network_1"),
+					testAccCheckNetworkingSubnetV2DataSourceGoodNetwork("data.huaweicloud_networking_subnet_v2.subnet_1",
+						"huaweicloud_networking_network_v2.network_1"),
 					resource.TestCheckResourceAttr(
 						"data.huaweicloud_networking_subnet_v2.subnet_1", "name", "subnet_1"),
 				),
@@ -77,7 +78,8 @@ func TestAccNetworkingV2SubnetDataSource_networkIdAttribute(t *testing.T) {
 				Config: testAccHuaweiCloudNetworkingSubnetV2DataSource_networkIdAttribute,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingSubnetV2DataSourceID("data.huaweicloud_networking_subnet_v2.subnet_1"),
-					testAccCheckNetworkingSubnetV2DataSourceGoodNetwork("data.huaweicloud_networking_subnet_v2.subnet_1", "huaweicloud_networking_network_v2.network_1"),
+					testAccCheckNetworkingSubnetV2DataSourceGoodNetwork("data.huaweicloud_networking_subnet_v2.subnet_1",
+						"huaweicloud_networking_network_v2.network_1"),
 					testAccCheckNetworkingPortV2ID("huaweicloud_networking_port_v2.port_1"),
 				),
 			},

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_apig_vpc_channel_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_apig_vpc_channel_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func getVpcChannelFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+func getVpcChannelFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_blockstorage_volume_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_blockstorage_volume_v2_test.go
@@ -173,7 +173,7 @@ func testAccCheckBlockStorageV2VolumeExists(n string, volume *volumes.Volume) re
 
 func testAccCheckBlockStorageV2VolumeMetadata(
 	volume *volumes.Volume, k string, v string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if volume.Metadata == nil {
 			return errors.New("no metadata")
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_compute_floatingip_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_compute_floatingip_v2_test.go
@@ -38,8 +38,8 @@ func TestAccComputeV2FloatingIP_basic(t *testing.T) {
 }
 
 func testAccCheckComputeV2FloatingIPDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	computeClient, err := config.ComputeV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -69,8 +69,8 @@ func testAccCheckComputeV2FloatingIPExists(n string, kp *floatingips.FloatingIP)
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		computeClient, err := config.ComputeV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		computeClient, err := cfg.ComputeV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating compute client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_compute_secgroup_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_compute_secgroup_v2_test.go
@@ -205,7 +205,7 @@ func testAccCheckComputeV2SecGroupExists(n string, secgroup *secgroups.SecurityG
 }
 
 func testAccCheckComputeV2SecGroupRuleCount(secgroup *secgroups.SecurityGroup, count int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if len(secgroup.Rules) != count {
 			return fmt.Errorf("the security group rule count does not match. Expected %d, got %d", count, len(secgroup.Rules))
 		}
@@ -215,7 +215,7 @@ func testAccCheckComputeV2SecGroupRuleCount(secgroup *secgroups.SecurityGroup, c
 }
 
 func testAccCheckComputeV2SecGroupGroupIDMatch(sg1, sg2 *secgroups.SecurityGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if len(sg2.Rules) == 1 {
 			if sg1.Name != sg2.Rules[0].Group.Name || sg1.TenantID != sg2.Rules[0].Group.TenantID {
 				return fmt.Errorf("%s was not correctly applied to %s", sg1.Name, sg2.Name)

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_compute_secgroup_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_compute_secgroup_v2_test.go
@@ -152,8 +152,8 @@ func TestAccComputeV2SecGroup_timeout(t *testing.T) {
 }
 
 func testAccCheckComputeV2SecGroupDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	computeClient, err := config.ComputeV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -183,8 +183,8 @@ func testAccCheckComputeV2SecGroupExists(n string, secgroup *secgroups.SecurityG
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		computeClient, err := config.ComputeV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		computeClient, err := cfg.ComputeV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating compute client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cs_cluster_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cs_cluster_v1_test.go
@@ -54,8 +54,8 @@ resource "huaweicloud_cs_cluster_v1" "cluster" {
 }
 
 func testAccCheckCsClusterV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := config.CloudStreamV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := cfg.CloudStreamV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating sdk client, err=%s", err)
 	}
@@ -83,8 +83,8 @@ func testAccCheckCsClusterV1Destroy(s *terraform.State) error {
 
 func testAccCheckCsClusterV1Exists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		client, err := config.CloudStreamV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := cfg.CloudStreamV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating sdk client, err=%s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cs_peering_connect_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cs_peering_connect_v1_test.go
@@ -73,8 +73,8 @@ resource "huaweicloud_cs_peering_connect_v1" "peering" {
 }
 
 func testAccCheckCsPeeringConnectV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := config.CloudStreamV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := cfg.CloudStreamV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating sdk client, err=%s", err)
 	}
@@ -102,8 +102,8 @@ func testAccCheckCsPeeringConnectV1Destroy(s *terraform.State) error {
 
 func testAccCheckCsPeeringConnectV1Exists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		client, err := config.CloudStreamV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := cfg.CloudStreamV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating sdk client, err=%s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cs_route_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cs_route_v1_test.go
@@ -81,8 +81,8 @@ resource "huaweicloud_cs_route_v1" "route" {
 }
 
 func testAccCheckCsRouteV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := config.CloudStreamV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := cfg.CloudStreamV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating sdk client, err=%s", err)
 	}
@@ -103,8 +103,8 @@ func testAccCheckCsRouteV1Destroy(s *terraform.State) error {
 
 func testAccCheckCsRouteV1Exists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		client, err := config.CloudStreamV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := cfg.CloudStreamV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating sdk client, err=%s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_csbs_backup_policy_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_csbs_backup_policy_v1_test.go
@@ -72,8 +72,8 @@ func TestAccCSBSBackupPolicyV1_timeout(t *testing.T) {
 }
 
 func testAccCheckCSBSBackupPolicyV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	policyClient, err := config.CsbsV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	policyClient, err := cfg.CsbsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating csbs client: %s", err)
 	}
@@ -103,8 +103,8 @@ func testAccCheckCSBSBackupPolicyV1Exists(n string, policy *policies.BackupPolic
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		policyClient, err := config.CsbsV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		policyClient, err := cfg.CsbsV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating csbs client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_csbs_backup_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_csbs_backup_v1_test.go
@@ -63,8 +63,8 @@ func TestAccCSBSBackupV1_timeout(t *testing.T) {
 }
 
 func testAccCSBSBackupV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	backupClient, err := config.CsbsV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	backupClient, err := cfg.CsbsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating csbs client: %s", err)
 	}
@@ -94,8 +94,8 @@ func testAccCSBSBackupV1Exists(n string, backups *backup.Backup) resource.TestCh
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		backupClient, err := config.CsbsV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		backupClient, err := cfg.CsbsV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating csbs client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cts_tracker_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cts_tracker_v1_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccCTSTrackerV1_basic(t *testing.T) {
-	var tracker tracker.Tracker
+	var obj tracker.Tracker
 	resourceName := "huaweicloud_cts_tracker.tracker"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -27,7 +27,7 @@ func TestAccCTSTrackerV1_basic(t *testing.T) {
 			{
 				Config: testAccCTSTrackerV1_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCTSTrackerV1Exists(resourceName, &tracker),
+					testAccCheckCTSTrackerV1Exists(resourceName, &obj),
 					resource.TestCheckResourceAttr(resourceName, "bucket_name", "tf-test-bucket"),
 					resource.TestCheckResourceAttr(resourceName, "file_prefix_name", "yO8Q"),
 				),
@@ -40,7 +40,7 @@ func TestAccCTSTrackerV1_basic(t *testing.T) {
 			{
 				Config: testAccCTSTrackerV1_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCTSTrackerV1Exists(resourceName, &tracker),
+					testAccCheckCTSTrackerV1Exists(resourceName, &obj),
 					resource.TestCheckResourceAttr(resourceName, "file_prefix_name", "yO8Q1"),
 				),
 			},
@@ -49,8 +49,8 @@ func TestAccCTSTrackerV1_basic(t *testing.T) {
 }
 
 func testAccCheckCTSTrackerV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	ctsClient, err := config.CtsV1Client(config.GetRegion(nil))
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	ctsClient, err := cfg.CtsV1Client(cfg.GetRegion(nil))
 	if err != nil {
 		return fmt.Errorf("error creating CTS client: %s", err)
 	}
@@ -83,8 +83,8 @@ func testAccCheckCTSTrackerV1Exists(n string, trackers *tracker.Tracker) resourc
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		ctsClient, err := config.CtsV1Client(config.GetRegion(nil))
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		ctsClient, err := cfg.CtsV1Client(cfg.GetRegion(nil))
 		if err != nil {
 			return fmt.Errorf("error creating CTS client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_ecs_instance_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_ecs_instance_v1_test.go
@@ -57,8 +57,8 @@ func TestAccEcsV1Instance_basic(t *testing.T) {
 }
 
 func testAccCheckEcsV1InstanceDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	computeClient, err := config.ComputeV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	computeClient, err := cfg.ComputeV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -90,8 +90,8 @@ func testAccCheckEcsV1InstanceExists(n string, instance *cloudservers.CloudServe
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		computeClient, err := config.ComputeV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		computeClient, err := cfg.ComputeV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating compute client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_firewall_group_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_firewall_group_v2_test.go
@@ -201,7 +201,7 @@ func testAccCheckFWFirewallGroupV2Exists(n string, firewall_group *FirewallGroup
 }
 
 func testAccCheckFWFirewallPortCount(firewall_group *FirewallGroup, expected int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if len(firewall_group.PortIDs) != expected {
 			return fmt.Errorf("expected %d Ports, got %d", expected, len(firewall_group.PortIDs))
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_firewall_group_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_firewall_group_v2_test.go
@@ -234,7 +234,7 @@ func testAccCheckFWFirewallGroupV2(n, expectedName, expectedDescription string, 
 			found, err = firewall_groups.Get(fwClient, rs.Primary.ID).Extract()
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					//lintignore:R018
+					// lintignore:R018
 					time.Sleep(time.Second)
 					continue
 				}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_policy_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_policy_v2_test.go
@@ -134,7 +134,7 @@ func testAccCheckFWPolicyV2Exists(n, name, description string, ruleCount int) re
 			found, err = policies.Get(fwClient, rs.Primary.ID).Extract()
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					//lintignore:R018
+					// lintignore:R018
 					time.Sleep(time.Second)
 					continue
 				}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_rule_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_rule_v2_test.go
@@ -156,7 +156,7 @@ func testAccCheckFWRuleV2Exists(n string, expected *rules.Rule) resource.TestChe
 			found, err = rules.Get(fwClient, rs.Primary.ID).Extract()
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					//lintignore:R018
+					// lintignore:R018
 					time.Sleep(time.Second)
 					continue
 				}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_rule_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fw_rule_v2_test.go
@@ -111,8 +111,8 @@ func TestAccFWRuleV2_anyProtocol(t *testing.T) {
 }
 
 func testAccCheckFWRuleV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	fwClient, err := cfg.FwV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -143,8 +143,8 @@ func testAccCheckFWRuleV2Exists(n string, expected *rules.Rule) resource.TestChe
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		fwClient, err := cfg.FwV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating fw client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_v2_test.go
@@ -158,8 +158,8 @@ func TestAccImagesImageV2_timeout(t *testing.T) {
 }
 
 func testAccCheckImagesImageV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	imageClient, err := cfg.ImageV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating IMS client: %s", err)
 	}
@@ -189,8 +189,8 @@ func testAccCheckImagesImageV2Exists(n string, image *images.Image) resource.Tes
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		imageClient, err := cfg.ImageV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating IMS client: %s", err)
 		}
@@ -221,8 +221,8 @@ func testAccCheckImagesImageV2HasTag(n, tag string) resource.TestCheckFunc {
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		imageClient, err := cfg.ImageV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating IMS client: %s", err)
 		}
@@ -257,8 +257,8 @@ func testAccCheckImagesImageV2TagCount(n string, expected int) resource.TestChec
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		imageClient, err := cfg.ImageV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating IMS client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_v2_test.go
@@ -30,8 +30,6 @@ func TestAccImagesImageV2_basic(t *testing.T) {
 						"huaweicloud_images_image_v2.image_1", "name", "Rancher TerraformAccTest"),
 					resource.TestCheckResourceAttr(
 						"huaweicloud_images_image_v2.image_1", "container_format", "bare"),
-					/*resource.TestCheckResourceAttr(
-					"huaweicloud_images_image_v2.image_1", "disk_format", "qcow2"),*/
 					resource.TestCheckResourceAttr(
 						"huaweicloud_images_image_v2.image_1", "schema", "/v2/schemas/image"),
 				),

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_mrs_cluster_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_mrs_cluster_v1_test.go
@@ -41,8 +41,8 @@ func TestAccMRSV1Cluster_basic(t *testing.T) {
 }
 
 func testAccCheckMRSV1ClusterDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	mrsClient, err := config.MrsV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	mrsClient, err := cfg.MrsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating MRS client: %s", err)
 	}
@@ -78,8 +78,8 @@ func testAccCheckMRSV1ClusterExists(n string, clusterGet *cluster.Cluster) resou
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		mrsClient, err := config.MrsV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		mrsClient, err := cfg.MrsV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating MRS client: %s ", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_mrs_job_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_mrs_job_v1_test.go
@@ -36,8 +36,8 @@ func TestAccMRSV1Job_basic(t *testing.T) {
 }
 
 func testAccCheckMRSV1JobDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	mrsClient, err := config.MrsV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	mrsClient, err := cfg.MrsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating MRS client: %s", err)
 	}
@@ -74,8 +74,8 @@ func testAccCheckMRSV1JobExists(n string, jobGet *job.Job) resource.TestCheckFun
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		mrsClient, err := config.MrsV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		mrsClient, err := cfg.MrsV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating MRS client: %s ", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_network_acl_rule_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_network_acl_rule_test.go
@@ -96,8 +96,8 @@ func TestAccNetworkACLRule_anyProtocol(t *testing.T) {
 }
 
 func testAccCheckNetworkACLRuleDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	fwClient, err := cfg.FwV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -128,8 +128,8 @@ func testAccCheckNetworkACLRuleExists(key string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set in %s", key)
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		fwClient, err := cfg.FwV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating fw client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_network_acl_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_network_acl_test.go
@@ -113,8 +113,8 @@ func TestAccNetworkACL_remove(t *testing.T) {
 }
 
 func testAccCheckNetworkACLDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	fwClient, err := cfg.FwV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -145,8 +145,8 @@ func testAccCheckNetworkACLExists(n string, fwGroup *FirewallGroup) resource.Tes
 			return fmt.Errorf("no ID is set in %s", n)
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		fwClient, err := cfg.FwV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating fw client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_floatingip_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_floatingip_v2_test.go
@@ -57,8 +57,8 @@ func TestAccNetworkingV2FloatingIP_fixedip_bind(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2FloatingIPDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating floating IP: %s", err)
 	}
@@ -88,8 +88,8 @@ func testAccCheckNetworkingV2FloatingIPExists(n string, kp *floatingips.Floating
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_floatingip_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_floatingip_v2_test.go
@@ -110,7 +110,7 @@ func testAccCheckNetworkingV2FloatingIPExists(n string, kp *floatingips.Floating
 }
 
 func testAccCheckNetworkingV2FloatingIPBoundToCorrectIP(fip *floatingips.FloatingIP, fixed_ip string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if fip.FixedIP != fixed_ip {
 			return errors.New("the floating IP associated with wrong fixed IP")
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_network_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_network_v2_test.go
@@ -110,8 +110,8 @@ func TestAccNetworkingV2Network_multipleSegmentMappings(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2NetworkDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -141,8 +141,8 @@ func testAccCheckNetworkingV2NetworkExists(n string, network *networks.Network) 
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_port_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_port_v2_test.go
@@ -186,8 +186,8 @@ func TestAccNetworkingV2Port_updateExtraDHCPOpts(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2PortDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -217,8 +217,8 @@ func testAccCheckNetworkingV2PortExists(n string, port *ports.Port) resource.Tes
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_port_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_port_v2_test.go
@@ -239,7 +239,7 @@ func testAccCheckNetworkingV2PortExists(n string, port *ports.Port) resource.Tes
 }
 
 func testAccCheckNetworkingV2PortCountFixedIPs(port *ports.Port, expected int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if len(port.FixedIPs) != expected {
 			return fmt.Errorf("expected %d fixed IPs, got %d", expected, len(port.FixedIPs))
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_router_interface_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_router_interface_v2_test.go
@@ -99,8 +99,8 @@ func TestAccNetworkingV2RouterInterface_timeout(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2RouterInterfaceDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -130,8 +130,8 @@ func testAccCheckNetworkingV2RouterInterfaceExists(n string) resource.TestCheckF
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_router_route_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_router_route_v2_test.go
@@ -81,8 +81,8 @@ func testAccCheckNetworkingV2RouterRouteEmpty(n string) resource.TestCheckFunc {
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}
@@ -115,8 +115,8 @@ func testAccCheckNetworkingV2RouterRouteExists(n string) resource.TestCheckFunc 
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}
@@ -146,8 +146,8 @@ func testAccCheckNetworkingV2RouterRouteExists(n string) resource.TestCheckFunc 
 }
 
 func testAccCheckNetworkingV2RouterRouteDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_router_route_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_router_route_v2_test.go
@@ -161,10 +161,8 @@ func testAccCheckNetworkingV2RouterRouteDestroy(s *terraform.State) error {
 
 		router, err := routers.Get(networkingClient, rs.Primary.Attributes["router_id"]).Extract()
 		if err == nil {
-
 			var rts = router.Routes
 			for _, r := range rts {
-
 				if r.DestinationCIDR == rs.Primary.Attributes["destination_cidr"] && r.NextHop == rs.Primary.Attributes["next_hop"] {
 					routeExists = true
 					break

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_router_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_router_v2_test.go
@@ -88,8 +88,8 @@ func TestAccNetworkingV2Router_timeout(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2RouterDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -119,8 +119,8 @@ func testAccCheckNetworkingV2RouterExists(n string, router *routers.Router) reso
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_subnet_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_networking_subnet_v2_test.go
@@ -131,8 +131,8 @@ func TestAccNetworkingV2Subnet_timeout(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2SubnetDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -162,8 +162,8 @@ func testAccCheckNetworkingV2SubnetExists(n string, subnet *subnets.Subnet) reso
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_oms_task_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_oms_task_v1_test.go
@@ -33,8 +33,8 @@ func TestAccMaasTask_basic(t *testing.T) {
 }
 
 func testAccCheckMaasTaskV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	maasClient, err := config.MaasV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	maasClient, err := cfg.MaasV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating maas client: %s", err)
 	}
@@ -64,8 +64,8 @@ func testAccCheckMaasTaskV1Exists(n string) resource.TestCheckFunc {
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		maasClient, err := config.MaasV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		maasClient, err := cfg.MaasV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating maas client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vbs_backup_policy_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vbs_backup_policy_v2_test.go
@@ -82,8 +82,8 @@ func TestAccVBSBackupPolicyV2_rentention_day(t *testing.T) {
 }
 
 func testAccVBSBackupPolicyV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	vbsClient, err := config.VbsV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating VBS client: %s", err)
 	}
@@ -113,8 +113,8 @@ func testAccVBSBackupPolicyV2Exists(n string, policy *policies.Policy) resource.
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		vbsClient, err := config.VbsV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		vbsClient, err := cfg.VbsV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating VBS client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vbs_backup_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vbs_backup_v2_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccVBSBackupV2_basic(t *testing.T) {
-	var config backups.Backup
+	var obj backups.Backup
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_vbs_backup.backup_1"
 
@@ -28,7 +28,7 @@ func TestAccVBSBackupV2_basic(t *testing.T) {
 			{
 				Config: testAccVBSBackupV2_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVBSBackupV2Exists(resourceName, &config),
+					testAccCheckVBSBackupV2Exists(resourceName, &obj),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 				),
@@ -43,8 +43,8 @@ func TestAccVBSBackupV2_basic(t *testing.T) {
 }
 
 func testAccCheckVBSBackupV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	vbsClient, err := config.VbsV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating VBS client: %s", err)
 	}
@@ -74,8 +74,8 @@ func testAccCheckVBSBackupV2Exists(n string, configs *backups.Backup) resource.T
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		vbsClient, err := config.VbsV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		vbsClient, err := cfg.VbsV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating VBS client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_endpoint_group_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_endpoint_group_v2_test.go
@@ -45,8 +45,8 @@ func TestAccVpnGroupV2_basic(t *testing.T) {
 }
 
 func testAccCheckEndpointGroupV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -76,8 +76,8 @@ func testAccCheckEndpointGroupV2Exists(n string, group *endpointgroups.EndpointG
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_ike_policy_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_ike_policy_v2_test.go
@@ -72,8 +72,8 @@ func TestAccVpnIKEPolicyV2_withLifetime(t *testing.T) {
 }
 
 func testAccCheckIKEPolicyV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -103,8 +103,8 @@ func testAccCheckIKEPolicyV2Exists(n string, policy *ikepolicies.Policy) resourc
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2_test.go
@@ -34,7 +34,8 @@ func TestAccVpnIPSecPolicyV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_ipsec_policy_v2.policy_1", "transform_protocol", &policy.TransformProtocol),
 					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_ipsec_policy_v2.policy_1", "encapsulation_mode", &policy.EncapsulationMode),
 					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_ipsec_policy_v2.policy_1", "auth_algorithm", &policy.AuthAlgorithm),
-					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_ipsec_policy_v2.policy_1", "encryption_algorithm", &policy.EncryptionAlgorithm),
+					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_ipsec_policy_v2.policy_1", "encryption_algorithm",
+						&policy.EncryptionAlgorithm),
 				),
 			},
 			{

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2_test.go
@@ -77,8 +77,8 @@ func TestAccVpnIPSecPolicyV2_withLifetime(t *testing.T) {
 }
 
 func testAccCheckIPSecPolicyV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -108,8 +108,8 @@ func testAccCheckIPSecPolicyV2Exists(n string, policy *ipsecpolicies.Policy) res
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_service_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_service_v2_test.go
@@ -36,8 +36,8 @@ func TestAccVpnServiceV2_basic(t *testing.T) {
 }
 
 func testAccCheckVpnServiceV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -67,8 +67,8 @@ func testAccCheckVpnServiceV2Exists(n string, serv *services.Service) resource.T
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_site_connection_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_vpnaas_site_connection_test.go
@@ -46,8 +46,8 @@ func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
 }
 
 func testAccCheckSiteConnectionV2Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -77,8 +77,8 @@ func testAccCheckSiteConnectionV2Exists(n string, conn *siteconnections.Connecti
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating networking client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
@@ -109,7 +109,7 @@ func TestAccElasticResourcePool_basic(t *testing.T) {
 }
 
 func waitForDeletionCooldownComplete() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		// After elastic resource pool is created, it cannot be deleted within 15 minete.
 		// lintignore:R018
 		time.Sleep(15 * time.Minute)

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinkjar_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinkjar_job_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getDliFlinkJarJobResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DliV1Client(acceptance.HW_REGION_NAME)
+func getDliFlinkJarJobResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Dli v1 client, err=%s", err)
 	}

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinksql_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinksql_job_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getDliFlinkSqlJobResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DliV1Client(acceptance.HW_REGION_NAME)
+func getDliFlinkSqlJobResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Dli v1 client, err=%s", err)
 	}

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getPtrRecord(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.DnsV2Client(acceptance.HW_REGION_NAME)
+	client, err := c.DNSV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DNS client : %s", err)
 	}

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_v2_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_v2_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func getDNSV2RecordsetResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.DnsV2Client(acceptance.HW_REGION_NAME)
+	client, err := c.DNSV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DNS client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_eip_associate_test.go
@@ -116,7 +116,7 @@ func testAccCheckComputeEIPAssociateDestroy(s *terraform.State) error {
 }
 
 func testAccCheckComputeEIPAssociateAssociated(eip *eips.PublicIp, instance *cloudservers.CloudServer) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
 		computeClient, err := cfg.ComputeV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_servergroup_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_servergroup_test.go
@@ -155,7 +155,7 @@ func testAccCheckComputeServerGroupExists(n string, kp *servergroups.ServerGroup
 }
 
 func testAccCheckComputeInstanceInServerGroup(instance *cloudservers.CloudServer, sg *servergroups.ServerGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if len(sg.Members) > 0 {
 			for _, m := range sg.Members {
 				if m == instance.ID {

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_access_key_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_access_key_test.go
@@ -449,7 +449,8 @@ func testAccCheckV3AccessKeyPgpEncryption(resourceName string) resource.TestChec
 
 		gotFingerprint := rs.Primary.Attributes["key_fingerprint"]
 		if gotFingerprint != fingerprint {
-			return fmt.Errorf("The fingerprint of the PGP key used to encrypt the secret is incorrect, want '%v', but got '%v'", fingerprint, gotFingerprint)
+			return fmt.Errorf("The fingerprint of the PGP key used to encrypt the secret is incorrect, want '%v', but got '%v'",
+				fingerprint, gotFingerprint)
 		}
 
 		encryptedSecret := rs.Primary.Attributes["encrypted_secret"]

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
@@ -38,7 +38,6 @@ func getDeviceGroupResourceFunc(cfg *config.Config, state *terraform.ResourceSta
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving IoTDA device group: %s", err)
-
 	}
 
 	return utils.FlattenResponse(getResp)

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_flavors_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_flavors_test.go
@@ -65,10 +65,12 @@ output "charging_modes_validation" {
 }
 
 output "storage_spec_code_validation" {
-  value = !contains([for ios in local.test_results.flavors[*].ios : !contains([for io in ios : io.storage_spec_code == local.test_refer.ios[0].storage_spec_code], false)], false)
+  value = !contains([for ios in local.test_results.flavors[*].ios : !contains([for io in ios : io.storage_spec_code == 
+  local.test_refer.ios[0].storage_spec_code], false)], false)
 }
 
 output "availability_zones_validation" {
-  value = !contains([for ios in local.test_results.flavors[*].ios : !contains([for io in ios : length(setintersection(io.availability_zones, local.test_refer.ios[0].availability_zones)) == length(local.test_refer.ios[0].availability_zones)], false)], false)
+  value = !contains([for ios in local.test_results.flavors[*].ios : !contains([for io in ios : length(setintersection(io.availability_zones,
+  local.test_refer.ios[0].availability_zones)) == length(local.test_refer.ios[0].availability_zones)], false)], false)
 }
 `

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_member_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_member_test.go
@@ -75,8 +75,8 @@ func TestAccLBV2Member_basic(t *testing.T) {
 }
 
 func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	elbClient, err := config.LoadBalancerClient(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	elbClient, err := cfg.LoadBalancerClient(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating ELB client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
@@ -170,7 +170,7 @@ func testAccCheckObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 }
 
 func testAccObsBucketObjectDataSource_content(randInt int) (string, string) {
-	resource := fmt.Sprintf(`
+	resourceScript := fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
   bucket = "tf-acc-test-bucket-%d"
 }
@@ -196,13 +196,13 @@ resource "huaweicloud_obs_bucket_object" "object" {
 data "huaweicloud_obs_bucket_object" "obj" {
   bucket = "tf-acc-test-bucket-%d"
   key    = "test-key-%d"
-}`, resource, randInt, randInt)
+}`, resourceScript, randInt, randInt)
 
-	return resource, dataSource
+	return resourceScript, dataSource
 }
 
 func testAccObsBucketObjectDataSource_source(randInt int, source string) (string, string) {
-	resource := fmt.Sprintf(`
+	resourceScript := fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
   bucket = "tf-acc-test-bucket-%d"
 }
@@ -221,13 +221,13 @@ resource "huaweicloud_obs_bucket_object" "object" {
 data "huaweicloud_obs_bucket_object" "obj" {
   bucket = "tf-acc-test-bucket-%d"
   key    = "test-key-%d"
-}`, resource, randInt, randInt)
+}`, resourceScript, randInt, randInt)
 
-	return resource, dataSource
+	return resourceScript, dataSource
 }
 
 func testAccObsBucketObjectDataSource_allParams(randInt int) (string, string) {
-	resource := fmt.Sprintf(`
+	resourceScript := fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
   bucket = "tf-acc-test-bucket-%d"
 }
@@ -251,7 +251,7 @@ CONTENT
 data "huaweicloud_obs_bucket_object" "obj" {
   bucket = "tf-acc-test-bucket-%d"
   key    = "test-key-%d"
-}`, resource, randInt, randInt)
+}`, resourceScript, randInt, randInt)
 
-	return resource, dataSource
+	return resourceScript, dataSource
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_backup_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_backup_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getBackupResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getBackupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getBackup: Query the RDS manual backup
 	var (
 		getBackupHttpUrl = "v3/{project_id}/backups"
 		getBackupProduct = "rds"
 	)
-	getBackupClient, err := config.NewServiceClient(getBackupProduct, region)
+	getBackupClient, err := cfg.NewServiceClient(getBackupProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Backup Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/rgc/data_source_huaweicloud_rgc_landing_zone_available_updates_test.go
+++ b/huaweicloud/services/acceptance/rgc/data_source_huaweicloud_rgc_landing_zone_available_updates_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccDataSourceLandingZoneAvailableUpdates_basic(t *testing.T) {
-
 	dataSource := "data.huaweicloud_rgc_landing_zone_available_updates.test"
 	dc := acceptance.InitDataSourceCheck(dataSource)
 

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_vip_associate_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_vip_associate_test.go
@@ -52,8 +52,8 @@ func TestAccNetworkingV2VIPAssociate_basic(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2VIPAssociateDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_vip_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_vip_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getNetworkVipResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.NetworkingV1Client(acceptance.HW_REGION_NAME)
+func getNetworkVipResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NetworkingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VPC network v1 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
@@ -150,8 +150,8 @@ func TestAccVpcSubnetV1_dhcp(t *testing.T) {
 }
 
 func testAccCheckVpcSubnetV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	subnetClient, err := config.NetworkingV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	subnetClient, err := cfg.NetworkingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating VPC client: %s", err)
 	}
@@ -181,8 +181,8 @@ func testAccCheckVpcSubnetV1Exists(n string, subnet *subnets.Subnet) resource.Te
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		subnetClient, err := config.NetworkingV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		subnetClient, err := cfg.NetworkingV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating VPC client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
@@ -249,7 +249,6 @@ func TestAccVpcV1_WithEnhancedLocalRoute(t *testing.T) {
 // TestAccVpcV1_WithCustomRegion this case will run a test for resource-level region. Before run this case,
 // you shoule set `HW_CUSTOM_REGION_NAME` in your system and it should be different from `HW_REGION_NAME`.
 func TestAccVpcV1_WithCustomRegion(t *testing.T) {
-
 	vpcName1 := fmt.Sprintf("test_vpc_region_%s", acctest.RandString(5))
 	vpcName2 := fmt.Sprintf("test_vpc_region_%s", acctest.RandString(5))
 

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
@@ -275,8 +275,8 @@ func TestAccVpcV1_WithCustomRegion(t *testing.T) {
 }
 
 func testAccCheckVpcV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	vpcClient, err := config.NetworkingV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	vpcClient, err := cfg.NetworkingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating VPC client: %s", err)
 	}
@@ -306,8 +306,8 @@ func testAccCheckCustomRegionVpcV1Exists(name string, vpc *vpcs.Vpc, region stri
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		vpcClient, err := config.NetworkingV1Client(region)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		vpcClient, err := cfg.NetworkingV1Client(region)
 		if err != nil {
 			return fmt.Errorf("error creating VPC client: %s", err)
 		}
@@ -337,8 +337,8 @@ func testAccCheckVpcV1Exists(n string, vpc *vpcs.Vpc) resource.TestCheckFunc {
 			return errors.New("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		vpcClient, err := config.NetworkingV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		vpcClient, err := cfg.NetworkingV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating VPC client: %s", err)
 		}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_plugin.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_plugin.go
@@ -60,8 +60,8 @@ func ResourcePlugin() *schema.Resource {
 			"content": {
 				Type:     schema.TypeString,
 				Required: true,
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					return utils.JSONStringsEqual(old, new)
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					return utils.JSONStringsEqual(oldVal, newVal)
 				},
 				Description: "The configuration details for plugin.",
 			},

--- a/huaweicloud/services/as/resource_huaweicloud_as_warm_pool.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_warm_pool.go
@@ -245,7 +245,6 @@ func getWarmPool(client *golangsdk.ServiceClient, instanceId string) (interface{
 
 func resourceAsWarmPoolImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
 	[]*schema.ResourceData, error) {
-
 	mErr := multierror.Append(
 		nil,
 		d.Set("scaling_group_id", d.Id()),

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_addon_template.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_addon_template.go
@@ -97,8 +97,8 @@ func dataSourceAddonTemplateRead(_ context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating CCE client : %s", err)
 	}
 	// Get all addon templates by List function
-	cluster_id := d.Get("cluster_id").(string)
-	templateList, err := templates.List(client, cluster_id).Extract()
+	clusterId := d.Get("cluster_id").(string)
+	templateList, err := templates.List(client, clusterId).Extract()
 	if err != nil {
 		return diag.Errorf("unable to retrieve template list: %s", err)
 	}

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_v3.go
@@ -246,7 +246,6 @@ func dataSourceCCEClusterV3Read(_ context.Context, d *schema.ResourceData, meta 
 	// set endpoints
 	var v []map[string]interface{}
 	for _, endpoint := range Cluster.Status.Endpoints {
-
 		mapping := map[string]interface{}{
 			"url":  endpoint.Url,
 			"type": endpoint.Type,

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_v3.go
@@ -270,7 +270,7 @@ func dataSourceCCEClusterV3Read(_ context.Context, d *schema.ResourceData, meta 
 		log.Printf("Error retrieving CCE cluster cert: %s", err)
 	}
 
-	//Set Certificate Clusters
+	// Set Certificate Clusters
 	var clusterList []map[string]interface{}
 	for _, clusterObj := range cert.Clusters {
 		clusterCert := make(map[string]interface{})
@@ -281,7 +281,7 @@ func dataSourceCCEClusterV3Read(_ context.Context, d *schema.ResourceData, meta 
 	}
 	mErr = multierror.Append(mErr, d.Set("certificate_clusters", clusterList))
 
-	//Set Certificate Users
+	// Set Certificate Users
 	var userList []map[string]interface{}
 	for _, userObj := range cert.Users {
 		userCert := make(map[string]interface{})

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_clusters.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_clusters.go
@@ -241,7 +241,6 @@ func dataSourceCCEClustersV3Read(_ context.Context, d *schema.ResourceData, meta
 	clustersToSet := make([]map[string]interface{}, 0, len(refinedClusters))
 
 	for _, v := range refinedClusters {
-
 		ids = append(ids, v.Metadata.Id)
 
 		cluster := map[string]interface{}{
@@ -267,7 +266,6 @@ func dataSourceCCEClustersV3Read(_ context.Context, d *schema.ResourceData, meta
 
 		var endpoints []map[string]interface{}
 		for _, endpoint := range v.Status.Endpoints {
-
 			mapping := map[string]interface{}{
 				"url":  endpoint.Url,
 				"type": endpoint.Type,

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_clusters.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_clusters.go
@@ -294,7 +294,7 @@ func dataSourceCCEClustersV3Read(_ context.Context, d *schema.ResourceData, meta
 			log.Printf("Error retrieving CCE cluster cert: %s", err)
 		}
 
-		//Set Certificate Clusters
+		// Set Certificate Clusters
 		var clusterList []map[string]interface{}
 		for _, clusterObj := range cert.Clusters {
 			clusterCert := make(map[string]interface{})
@@ -305,7 +305,7 @@ func dataSourceCCEClustersV3Read(_ context.Context, d *schema.ResourceData, meta
 		}
 		cluster["certificate_clusters"] = clusterList
 
-		//Set Certificate Users
+		// Set Certificate Users
 		var userList []map[string]interface{}
 		for _, userObj := range cert.Users {
 			userCert := make(map[string]interface{})

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_node_pool_v3.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_node_pool_v3.go
@@ -63,7 +63,7 @@ func DataSourceCCENodePoolV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"labels": { //(k8s_tags)
+			"labels": { // Corresponding Kubernetes labels
 				Type:     schema.TypeMap,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_addon.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_addon.go
@@ -81,7 +81,7 @@ func ResourceAddon() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringIsJSON,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
 								return equal
 							},
@@ -97,7 +97,7 @@ func ResourceAddon() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringIsJSON,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
 								return equal
 							},
@@ -113,7 +113,7 @@ func ResourceAddon() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringIsJSON,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
 								return equal
 							},

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_addon.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_addon.go
@@ -81,8 +81,8 @@ func ResourceAddon() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringIsJSON,
-							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+							DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+								equal, _ := utils.CompareJsonTemplateAreEquivalent(oldVal, newVal)
 								return equal
 							},
 							ExactlyOneOf: []string{"values.0.basic", "values.0.basic_json"},
@@ -97,8 +97,8 @@ func ResourceAddon() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringIsJSON,
-							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+							DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+								equal, _ := utils.CompareJsonTemplateAreEquivalent(oldVal, newVal)
 								return equal
 							},
 							ConflictsWith: []string{"values.0.custom"},
@@ -113,8 +113,8 @@ func ResourceAddon() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringIsJSON,
-							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+							DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+								equal, _ := utils.CompareJsonTemplateAreEquivalent(oldVal, newVal)
 								return equal
 							},
 							ConflictsWith: []string{"values.0.flavor"},

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -705,11 +705,11 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating AOM v1 client: %s", err)
 	}
 
-	authenticating_proxy := make(map[string]string)
+	authenticatingProxy := make(map[string]string)
 	if common.HasFilledOpt(d, "authenticating_proxy_ca") {
-		authenticating_proxy["ca"] = utils.TryBase64EncodeString(d.Get("authenticating_proxy_ca").(string))
-		authenticating_proxy["cert"] = utils.TryBase64EncodeString(d.Get("authenticating_proxy_cert").(string))
-		authenticating_proxy["privateKey"] = utils.TryBase64EncodeString(d.Get("authenticating_proxy_private_key").(string))
+		authenticatingProxy["ca"] = utils.TryBase64EncodeString(d.Get("authenticating_proxy_ca").(string))
+		authenticatingProxy["cert"] = utils.TryBase64EncodeString(d.Get("authenticating_proxy_cert").(string))
+		authenticatingProxy["privateKey"] = utils.TryBase64EncodeString(d.Get("authenticating_proxy_private_key").(string))
 	}
 
 	billingMode := 0
@@ -750,7 +750,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			EniNetwork: buildEniNetworkOpts(d.Get("eni_subnet_id").(string)),
 			Authentication: clusters.AuthenticationSpec{
 				Mode:                d.Get("authentication_mode").(string),
-				AuthenticatingProxy: authenticating_proxy,
+				AuthenticatingProxy: authenticatingProxy,
 			},
 			BillingMode:      billingMode,
 			ExtendParam:      buildResourceClusterExtendParams(d, cfg),

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -862,7 +862,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	diags = append(diags, resourceClusterRead(ctx, d, meta)...)
 
 	return diags
-
 }
 
 func resourceClusterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -1324,7 +1323,6 @@ func getClusterIDFromJob(ctx context.Context, client *golangsdk.ServiceClient, j
 		} else {
 			return "", fmt.Errorf("error waiting for job (%s) to become success: %s", jobID, err)
 		}
-
 	}
 
 	job := v.(*nodes.Job)

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -93,7 +93,7 @@ func ResourceCluster() *schema.Resource {
 
 		CustomizeDiff: config.MergeDefaultTags(),
 
-		//request and response parameters
+		// request and response parameters
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -931,7 +931,7 @@ func resourceClusterRead(_ context.Context, d *schema.ResourceData, meta interfa
 		log.Printf("error retrieving CCE cluster certificate: %s", err)
 	}
 
-	//Set Certificate Clusters
+	// Set Certificate Clusters
 	var clusterList []map[string]interface{}
 	for _, clusterObj := range cert.Clusters {
 		clusterCert := make(map[string]interface{})
@@ -942,7 +942,7 @@ func resourceClusterRead(_ context.Context, d *schema.ResourceData, meta interfa
 	}
 	mErr = multierror.Append(mErr, d.Set("certificate_clusters", clusterList))
 
-	//Set Certificate Users
+	// Set Certificate Users
 	var userList []map[string]interface{}
 	for _, userObj := range cert.Users {
 		userCert := make(map[string]interface{})

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_namespace.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_namespace.go
@@ -201,8 +201,7 @@ func waitForNamepaceDelete(client *golangsdk.ServiceClient, clusterID, name stri
 	}
 }
 
-func resourceCCENamespaceV1Import(context context.Context, d *schema.ResourceData,
-	meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCCENamespaceV1Import(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	cfg := meta.(*config.Config)
 	client, err := cfg.CceV1Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_pvc.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_pvc.go
@@ -141,7 +141,7 @@ func resourcePvcAccessMode(d *schema.ResourceData) []string {
 }
 
 func buildCcePersistentVolumeClaimCreateOpts(d *schema.ResourceData,
-	config *config.Config) (persistentvolumeclaims.CreateOpts, error) {
+	_ *config.Config) (persistentvolumeclaims.CreateOpts, error) {
 	createOpts := persistentvolumeclaims.CreateOpts{
 		ApiVersion: "v1",                    // The value is fixed at v1.
 		Kind:       "PersistentVolumeClaim", // The value is fixed at PersistentVolumeClaim.
@@ -330,8 +330,7 @@ func pvcStateRefreshFunc(c *golangsdk.ServiceClient, clusterId, namespace, id st
 	}
 }
 
-func resourceCcePvcResourceImportState(context context.Context, d *schema.ResourceData,
-	meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCcePvcResourceImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	importedId := d.Id()
 	parts := strings.SplitN(importedId, "/", 3)
 	if len(parts) != 3 {

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_pvc.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_pvc.go
@@ -203,12 +203,12 @@ func resourceCcePersistentVolumeClaimV1Create(ctx context.Context, d *schema.Res
 	return resourceCcePersistentVolumeClaimV1Read(ctx, d, meta)
 }
 
-func saveCcePersistentVolumeClaimState(d *schema.ResourceData, config *config.Config,
+func saveCcePersistentVolumeClaimState(d *schema.ResourceData, cfg *config.Config,
 	resp *persistentvolumeclaims.PersistentVolumeClaim) error {
 	metadata := &resp.Metadata
 
 	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("name", metadata.Name),
 		d.Set("namespace", metadata.Namespace),
 		d.Set("access_modes", resp.Spec.AccessModes),

--- a/huaweicloud/services/cci/resource_huaweicloud_cciv2_persistent_volume_claim.go
+++ b/huaweicloud/services/cci/resource_huaweicloud_cciv2_persistent_volume_claim.go
@@ -230,7 +230,6 @@ func resourceV2PersistentVolumeClaimCreate(ctx context.Context, d *schema.Resour
 }
 
 func buildCreateV2PersistentVolumeClaimParams(d *schema.ResourceData) map[string]interface{} {
-
 	bodyParams := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"namespace":   d.Get("namespace"),

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_domain_name_group.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_domain_name_group.go
@@ -421,7 +421,6 @@ func resourceDomainNameGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 				return diag.FromErr(err)
 			}
 		}
-
 	}
 	return resourceDomainNameGroupRead(ctx, d, meta)
 }

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_firewall.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_firewall.go
@@ -59,23 +59,23 @@ func ResourceFirewall() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
-			customdiff.ValidateChange("east_west_firewall_inspection_cidr", func(_ context.Context, old, new, _ any) error {
+			customdiff.ValidateChange("east_west_firewall_inspection_cidr", func(_ context.Context, oldVal, newVal, _ any) error {
 				// can only update from empty
-				if old.(string) != new.(string) && old.(string) != "" {
+				if oldVal.(string) != newVal.(string) && oldVal.(string) != "" {
 					return fmt.Errorf("east_west_firewall_inspection_cidr can't be updated")
 				}
 				return nil
 			}),
-			customdiff.ValidateChange("east_west_firewall_er_id", func(_ context.Context, old, new, _ any) error {
+			customdiff.ValidateChange("east_west_firewall_er_id", func(_ context.Context, oldVal, newVal, _ any) error {
 				// can only update from empty
-				if old.(string) != new.(string) && old.(string) != "" {
+				if oldVal.(string) != newVal.(string) && oldVal.(string) != "" {
 					return fmt.Errorf("east_west_firewall_er_id can't be updated")
 				}
 				return nil
 			}),
-			customdiff.ValidateChange("east_west_firewall_mode", func(_ context.Context, old, new, _ any) error {
+			customdiff.ValidateChange("east_west_firewall_mode", func(_ context.Context, oldVal, newVal, _ any) error {
 				// can only update from empty
-				if old.(string) != new.(string) && old.(string) != "" {
+				if oldVal.(string) != newVal.(string) && oldVal.(string) != "" {
 					return fmt.Errorf("east_west_firewall_mode can't be updated")
 				}
 				return nil

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_application.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_application.go
@@ -141,7 +141,7 @@ func ResourceAomApplicationCreate(ctx context.Context, d *schema.ResourceData, m
 	return diag.Errorf("error create Application %v. error: %s", opts.Name, string(body))
 }
 
-func ResourceAomApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {
@@ -182,7 +182,7 @@ func ResourceAomApplicationRead(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func ResourceAomApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomApplicationUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {
@@ -214,7 +214,7 @@ func ResourceAomApplicationUpdate(ctx context.Context, d *schema.ResourceData, m
 	return diag.Errorf("error update Application %s:  %s", opts.Name, string(body))
 }
 
-func ResourceAomApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomApplicationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_component.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_component.go
@@ -142,7 +142,7 @@ func ResourceAomComponentCreate(ctx context.Context, d *schema.ResourceData, met
 	return diag.Errorf("error create Component %v. error: %s", opts.Name, string(body))
 }
 
-func ResourceAomComponentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomComponentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {
@@ -182,7 +182,7 @@ func ResourceAomComponentRead(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func ResourceAomComponentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomComponentUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {
@@ -216,7 +216,7 @@ func ResourceAomComponentUpdate(ctx context.Context, d *schema.ResourceData, met
 	return diag.Errorf("error update Component %s:  %s", opts.Name, string(body))
 }
 
-func ResourceAomComponentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomComponentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_environment.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_environment.go
@@ -171,7 +171,7 @@ func ResourceAomEnvironmentCreate(ctx context.Context, d *schema.ResourceData, m
 	return diag.Errorf("error create Environment %v. error: %s", opts.EnvName, string(body))
 }
 
-func ResourceAomEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomEnvironmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {
@@ -223,7 +223,7 @@ func ResourceAomEnvironmentRead(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func ResourceAomEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomEnvironmentUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {
@@ -258,7 +258,7 @@ func ResourceAomEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, m
 	return diag.Errorf("error update Environment %s:  %s", opts.EnvName, string(body))
 }
 
-func ResourceAomEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceAomEnvironmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "cmdb", conf.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_environment.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_environment.go
@@ -291,8 +291,8 @@ func getEnvByName(d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		return diag.Errorf("err creating Client: %s", err)
 	}
 
-	client.WithMethod(httpclient_go.MethodGet).
-		WithUrl("v1/environments/name/" + d.Get("env_name").(string) + "?region=" + conf.GetRegion(d) + "&component_id=" + d.Get("component_id").(string))
+	client.WithMethod(httpclient_go.MethodGet).WithUrl("v1/environments/name/" + d.Get("env_name").(string) + "?region=" + conf.GetRegion(d) +
+		"&component_id=" + d.Get("component_id").(string))
 	response, err := client.Do()
 
 	body, diags := client.CheckDeletedDiag(d, err, response, "error retrieving Environments")

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_resource_relationships.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_resource_relationships.go
@@ -168,7 +168,7 @@ func ResourceResourceCiRelationshipsCreate(ctx context.Context, d *schema.Resour
 	return diag.Errorf("error Associate Resource %v. error: %s", opts, string(body))
 }
 
-func ResourceResourceCiRelationshipsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceResourceCiRelationshipsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(cfg, "cmdb", cfg.GetRegion(d))
 	if err != nil {
@@ -213,7 +213,7 @@ func ResourceResourceCiRelationshipsRead(ctx context.Context, d *schema.Resource
 	return diag.Errorf("error Read Resource fields %v : %s", opts, string(body))
 }
 
-func ResourceResourceCiRelationshipsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ResourceResourceCiRelationshipsDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(cfg, "cmdb", cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script.go
@@ -456,6 +456,6 @@ func resourceScriptDelete(_ context.Context, d *schema.ResourceData, meta interf
 	return nil
 }
 
-func suppressDosOrUnix(_, old, new string, _ *schema.ResourceData) bool {
-	return strings.ReplaceAll(old, "\r\n", "\n") == strings.ReplaceAll(new, "\r\n", "\n")
+func suppressDosOrUnix(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	return strings.ReplaceAll(oldVal, "\r\n", "\n") == strings.ReplaceAll(newVal, "\r\n", "\n")
 }

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_diagnosis_task.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_diagnosis_task.go
@@ -584,13 +584,13 @@ func resourceDianosisReportImportState(_ context.Context, d *schema.ResourceData
 	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }
 
-func suppressTimeDiffs(_, old, new string, _ *schema.ResourceData) bool {
-	oldTime, err := time.Parse(time.RFC3339, old)
+func suppressTimeDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	oldTime, err := time.Parse(time.RFC3339, oldVal)
 	if err != nil {
 		return false
 	}
 
-	newTime, err := time.Parse(time.RFC3339, new)
+	newTime, err := time.Parse(time.RFC3339, newVal)
 	if err != nil {
 		return false
 	}

--- a/huaweicloud/services/ddm/resource_huaweicloud_ddm_schema.go
+++ b/huaweicloud/services/ddm/resource_huaweicloud_ddm_schema.go
@@ -463,7 +463,6 @@ func handleOperationError(err error, operateType string, operateObj string) (boo
 
 func waitForInstanceRunning(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, instanceID string,
 	timeout string) error {
-
 	stateConf := &retry.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"RUNNING"},

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
@@ -699,12 +699,12 @@ func resourceDdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 	return resourceDdsInstanceV3Read(ctx, d, meta)
 }
 
-func isEqualPeriod(old, new string) bool {
-	if len(old) != len(new) {
+func isEqualPeriod(oldVal, newVal string) bool {
+	if len(oldVal) != len(newVal) {
 		return false
 	}
-	oldArray := strings.Split(old, ",")
-	newArray := strings.Split(new, ",")
+	oldArray := strings.Split(oldVal, ",")
+	newArray := strings.Split(newVal, ",")
 	sort.Strings(oldArray)
 	sort.Strings(newArray)
 

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_antiddos_v1.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_antiddos_v1.go
@@ -242,5 +242,4 @@ func dataSourceAntiDdosV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("trigger_http_pps", trigger_http_pps)
 
 	return nil
-
 }

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_antiddos_v1.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_antiddos_v1.go
@@ -156,47 +156,47 @@ func dataSourceAntiDdosV1Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("unable to retrieve the traffic of a specified EIP, defense is not configured: %s", err)
 	}
 
-	period_start := make([]int, 0)
+	periodStart := make([]int, 0)
 	for _, param := range traffic {
-		period_start = append(period_start, param.PeriodStart)
+		periodStart = append(periodStart, param.PeriodStart)
 	}
-	d.Set("period_start", period_start)
+	d.Set("period_start", periodStart)
 
-	bps_in := make([]int, 0)
+	bpsIn := make([]int, 0)
 	for _, param := range traffic {
-		bps_in = append(bps_in, param.BpsIn)
+		bpsIn = append(bpsIn, param.BpsIn)
 	}
-	d.Set("bps_in", bps_in)
+	d.Set("bps_in", bpsIn)
 
-	bps_attack := make([]int, 0)
+	bpsAttack := make([]int, 0)
 	for _, param := range traffic {
-		bps_attack = append(bps_attack, param.BpsAttack)
+		bpsAttack = append(bpsAttack, param.BpsAttack)
 	}
-	d.Set("bps_attack", bps_attack)
+	d.Set("bps_attack", bpsAttack)
 
-	total_bps := make([]int, 0)
+	totalBps := make([]int, 0)
 	for _, param := range traffic {
-		total_bps = append(total_bps, param.TotalBps)
+		totalBps = append(totalBps, param.TotalBps)
 	}
-	d.Set("total_bps", total_bps)
+	d.Set("total_bps", totalBps)
 
-	pps_in := make([]int, 0)
+	ppsIn := make([]int, 0)
 	for _, param := range traffic {
-		pps_in = append(pps_in, param.PpsIn)
+		ppsIn = append(ppsIn, param.PpsIn)
 	}
-	d.Set("pps_in", pps_in)
+	d.Set("pps_in", ppsIn)
 
-	pps_attack := make([]int, 0)
+	ppsAttack := make([]int, 0)
 	for _, param := range traffic {
-		pps_attack = append(pps_attack, param.PpsAttack)
+		ppsAttack = append(ppsAttack, param.PpsAttack)
 	}
-	d.Set("pps_attack", pps_attack)
+	d.Set("pps_attack", ppsAttack)
 
-	total_pps := make([]int, 0)
+	totalPps := make([]int, 0)
 	for _, param := range traffic {
-		total_pps = append(total_pps, param.TotalPps)
+		totalPps = append(totalPps, param.TotalPps)
 	}
-	d.Set("total_pps", total_pps)
+	d.Set("total_pps", totalPps)
 
 	listEventOpts := antiddos.ListLogsOpts{}
 	event, err := antiddos.ListLogs(antiddosClient, ddosStatus.FloatingIpId, listEventOpts).Extract()
@@ -205,41 +205,41 @@ func dataSourceAntiDdosV1Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("unable to retrieve the event of a specified EIP, defense is not configured: %s", err)
 	}
 
-	start_time := make([]int, 0)
+	startTime := make([]int, 0)
 	for _, param := range event {
-		start_time = append(start_time, param.StartTime)
+		startTime = append(startTime, param.StartTime)
 	}
-	d.Set("start_time", start_time)
+	d.Set("start_time", startTime)
 
-	end_time := make([]int, 0)
+	endTime := make([]int, 0)
 	for _, param := range event {
-		end_time = append(end_time, param.EndTime)
+		endTime = append(endTime, param.EndTime)
 	}
-	d.Set("end_time", end_time)
+	d.Set("end_time", endTime)
 
-	cleaning_status := make([]int, 0)
+	cleaningStatus := make([]int, 0)
 	for _, param := range event {
-		cleaning_status = append(cleaning_status, param.Status)
+		cleaningStatus = append(cleaningStatus, param.Status)
 	}
-	d.Set("traffic_cleaning_status", cleaning_status)
+	d.Set("traffic_cleaning_status", cleaningStatus)
 
-	trigger_bps := make([]int, 0)
+	triggerBps := make([]int, 0)
 	for _, param := range event {
-		trigger_bps = append(trigger_bps, param.TriggerBps)
+		triggerBps = append(triggerBps, param.TriggerBps)
 	}
-	d.Set("trigger_bps", trigger_bps)
+	d.Set("trigger_bps", triggerBps)
 
-	trigger_pps := make([]int, 0)
+	triggerPps := make([]int, 0)
 	for _, param := range event {
-		trigger_pps = append(trigger_pps, param.TriggerPps)
+		triggerPps = append(triggerPps, param.TriggerPps)
 	}
-	d.Set("trigger_pps", trigger_pps)
+	d.Set("trigger_pps", triggerPps)
 
-	trigger_http_pps := make([]int, 0)
+	triggerHttpPps := make([]int, 0)
 	for _, param := range event {
-		trigger_http_pps = append(trigger_http_pps, param.TriggerHttpPps)
+		triggerHttpPps = append(triggerHttpPps, param.TriggerHttpPps)
 	}
-	d.Set("trigger_http_pps", trigger_http_pps)
+	d.Set("trigger_http_pps", triggerHttpPps)
 
 	return nil
 }

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_compute_availability_zones_v2.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_compute_availability_zones_v2.go
@@ -36,8 +36,8 @@ func DataSourceComputeAvailabilityZonesV2() *schema.Resource {
 }
 
 func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_csbs_backup_policy_v1.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_csbs_backup_policy_v1.go
@@ -131,8 +131,8 @@ func DataSourceCSBSBackupPolicyV1() *schema.Resource {
 }
 
 func dataSourceCSBSBackupPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	policyClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	policyClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating csbs client: %s", err)
 	}
@@ -178,7 +178,7 @@ func dataSourceCSBSBackupPolicyV1Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("description", backupPolicy.Description)
 	d.Set("provider_id", backupPolicy.ProviderId)
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_csbs_backup_v1.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_csbs_backup_v1.go
@@ -186,8 +186,8 @@ func DataSourceCSBSBackupV1() *schema.Resource {
 }
 
 func dataSourceCSBSBackupV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	backupClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	backupClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating csbs client: %s", err)
 	}
@@ -235,7 +235,7 @@ func dataSourceCSBSBackupV1Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("volume_backups", flattenCSBSVolumeBackups(&backupObject))
 	d.Set("vm_metadata", flattenCSBSVMMetadata(&backupObject))
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_cts_tracker_v1.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_cts_tracker_v1.go
@@ -72,8 +72,8 @@ func DataSourceCTSTrackerV1() *schema.Resource {
 }
 
 func dataSourceCTSTrackerV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	trackerClient, err := config.CtsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	trackerClient, err := cfg.CtsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating cts Client: %s", err)
 	}
@@ -115,7 +115,7 @@ func dataSourceCTSTrackerV1Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("operations", trackers.SimpleMessageNotification.Operations)
 	d.Set("need_notify_user_list", trackers.SimpleMessageNotification.NeedNotifyUserList)
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_dcs_az_v1.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_dcs_az_v1.go
@@ -45,9 +45,9 @@ func DataSourceDcsAZV1() *schema.Resource {
 }
 
 func dataSourceDcsAZV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	dcsV1Client, err := config.DcsV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	dcsV1Client, err := cfg.DcsV1Client(region)
 	if err != nil {
 		return fmt.Errorf("error creating DCS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_dcs_product_v1.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_dcs_product_v1.go
@@ -52,9 +52,9 @@ func DataSourceDcsProductV1() *schema.Resource {
 }
 
 func dataSourceDcsProductV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	dcsV1Client, err := config.DcsV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	dcsV1Client, err := cfg.DcsV1Client(region)
 	if err != nil {
 		return fmt.Errorf("error getting DCS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_dms_az.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_dms_az.go
@@ -49,8 +49,8 @@ func DataSourceDmsAZ() *schema.Resource {
 }
 
 func dataSourceDmsAZRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	dmsV2Client, err := config.DmsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS key client V2: %s", err)
 	}
@@ -62,7 +62,7 @@ func dataSourceDmsAZRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 	log.Printf("[DEBUG] The list of DMS available zones during the API response: %+v", v)
 	var filteredAZs []availablezones.AvailableZone
-	if v.RegionID == config.GetRegion(d) {
+	if v.RegionID == cfg.GetRegion(d) {
 		AZs := v.AvailableZones
 		for _, newAZ := range AZs {
 			if newAZ.ResourceAvailability != "true" || newAZ.SoldOut {

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_networking_network_v2.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_networking_network_v2.go
@@ -64,8 +64,8 @@ func DataSourceNetworkingNetworkV2() *schema.Resource {
 }
 
 func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -127,7 +127,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	d.Set("admin_state_up", strconv.FormatBool(network.AdminStateUp))
 	d.Set("shared", strconv.FormatBool(network.Shared))
 	d.Set("tenant_id", network.TenantID)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_networking_subnet_v2.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_networking_subnet_v2.go
@@ -154,8 +154,8 @@ func DataSourceNetworkingSubnetV2() *schema.Resource {
 
 // nolint:gocyclo
 func dataSourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -240,7 +240,7 @@ func dataSourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("ipv6_ra_mode", subnet.IPv6RAMode)
 	d.Set("gateway_ip", subnet.GatewayIP)
 	d.Set("enable_dhcp", subnet.EnableDHCP)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	err = d.Set("dns_nameservers", subnet.DNSNameservers)
 	if err != nil {

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_networking_subnet_v2.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_networking_subnet_v2.go
@@ -63,7 +63,7 @@ func DataSourceNetworkingSubnetV2() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, result []error) {
+				ValidateFunc: func(v interface{}, _ string) (ws []string, result []error) {
 					value := v.(int)
 					if value != 4 && value != 6 {
 						result = append(result, errors.New("only 4 and 6 are supported values for 'ip_version'"))

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_vbs_backup_policy_v2.go
@@ -98,8 +98,8 @@ func DataSourceVBSBackupPolicyV2() *schema.Resource {
 }
 
 func dataSourceVBSPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating VBS client: %s", err)
 	}
@@ -150,7 +150,7 @@ func dataSourceVBSPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("rentention_num", Policy.ScheduledPolicy.RententionNum)
 	d.Set("start_time", Policy.ScheduledPolicy.StartTime)
 	d.Set("status", Policy.ScheduledPolicy.Status)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	n, err := tags.Get(vbsClient, Policy.ID).Extract()
 	var tag []map[string]interface{}

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_vbs_backup_v2.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_vbs_backup_v2.go
@@ -72,8 +72,8 @@ func DataSourceVBSBackupV2() *schema.Resource {
 }
 
 func dataSourceVBSBackupV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating VBS client: %s", err)
 	}
@@ -113,7 +113,7 @@ func dataSourceVBSBackupV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("size", Backup.Size)
 	d.Set("container", Backup.Container)
 	d.Set("volume_id", Backup.VolumeId)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }

--- a/huaweicloud/services/deprecated/resource_huaweicloud_apig_vpc_channel.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_apig_vpc_channel.go
@@ -234,7 +234,7 @@ func buildVpcChannelHealthConfig(d *schema.ResourceData) (channels.VpcHealthConf
 	return result, nil
 }
 
-func buildVpcChannelMembers(d *schema.ResourceData, config *config.Config) ([]channels.MemberInfo, error) {
+func buildVpcChannelMembers(d *schema.ResourceData, cfg *config.Config) ([]channels.MemberInfo, error) {
 	var (
 		members = d.Get("members").(*schema.Set)
 		mType   = MemberType(d.Get("member_type").(string))
@@ -244,7 +244,7 @@ func buildVpcChannelMembers(d *schema.ResourceData, config *config.Config) ([]ch
 	// Since the API requires that the name must be supported when the member type is 'ecs'.
 	// It is necessary to query the ecs instance information from server to obtain the instance name.
 	// We will cancel this unreasonable parameter configuration in the future.
-	ecsClient, err := config.ComputeV1Client(config.GetRegion(d))
+	ecsClient, err := cfg.ComputeV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return result, fmt.Errorf("error creating ECS v1 client: %s", err)
 	}
@@ -279,7 +279,7 @@ func buildVpcChannelMembers(d *schema.ResourceData, config *config.Config) ([]ch
 	return result, nil
 }
 
-func buildVpcChannelParameters(d *schema.ResourceData, config *config.Config) (channels.ChannelOpts, error) {
+func buildVpcChannelParameters(d *schema.ResourceData, cfg *config.Config) (channels.ChannelOpts, error) {
 	var (
 		mType         = MemberType(d.Get("member_type").(string))
 		algorithmType = AlgorithmType(d.Get("algorithm").(string))
@@ -297,7 +297,7 @@ func buildVpcChannelParameters(d *schema.ResourceData, config *config.Config) (c
 		return opt, fmt.Errorf("wrong member type: %v", mType)
 	}
 	// Backend servers
-	members, err := buildVpcChannelMembers(d, config)
+	members, err := buildVpcChannelMembers(d, cfg)
 	if err != nil {
 		return opt, err
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_apig_vpc_channel.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_apig_vpc_channel.go
@@ -32,12 +32,7 @@ const (
 	AlgorithmTypeWrr AlgorithmType = "WRR"
 	AlgorithmTypeWlc AlgorithmType = "WLC"
 	AlgorithmTypeSh  AlgorithmType = "SH"
-	AlgorithmTypeUri AlgorithmType = "URI hashing"
-
-	ProtocolTypeTcp   ProtocolType = "TCP"
-	ProtocolTypeHttp  ProtocolType = "HTTP"
-	ProtocolTypeHttps ProtocolType = "HTTPS"
-	ProtocolTypeBoth  ProtocolType = "BOTH"
+	AlgorithmTypeURI AlgorithmType = "URI hashing"
 
 	ChannelStatusNormal   ChannelStatus = 1
 	ChannelStatusAbnormal ChannelStatus = 2
@@ -57,7 +52,7 @@ var (
 		AlgorithmTypeWrr: 1,
 		AlgorithmTypeWlc: 2,
 		AlgorithmTypeSh:  3,
-		AlgorithmTypeUri: 4,
+		AlgorithmTypeURI: 4,
 	}
 
 	channelStatus = map[int]string{
@@ -147,7 +142,7 @@ func ResourceApigVpcChannelV2() *schema.Resource {
 					string(AlgorithmTypeWrr),
 					string(AlgorithmTypeWlc),
 					string(AlgorithmTypeSh),
-					string(AlgorithmTypeUri),
+					string(AlgorithmTypeURI),
 				}, false),
 				Description: "The distribution algorithm.",
 			},

--- a/huaweicloud/services/deprecated/resource_huaweicloud_blockstorage_volume_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_blockstorage_volume_v2.go
@@ -132,8 +132,8 @@ func ResourceBlockStorageVolumeV2() *schema.Resource {
 }
 
 func resourceBlockStorageVolumeV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	blockStorageClient, err := cfg.BlockStorageV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating block storage client: %s", err)
 	}
@@ -185,8 +185,8 @@ func resourceBlockStorageVolumeV2Create(d *schema.ResourceData, meta interface{}
 }
 
 func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	blockStorageClient, err := cfg.BlockStorageV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating block storage client: %s", err)
 	}
@@ -205,7 +205,7 @@ func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("snapshot_id", v.SnapshotID)
 	d.Set("source_vol_id", v.SourceVolID)
 	d.Set("volume_type", v.VolumeType)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	// NOTE: This tries to remove system metadata on huawei cloud :(
 	md := make(map[string]string)
@@ -236,8 +236,8 @@ OUTER:
 }
 
 func resourceBlockStorageVolumeV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	blockStorageClient, err := cfg.BlockStorageV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating block storage client: %s", err)
 	}
@@ -285,8 +285,8 @@ func resourceBlockStorageVolumeV2Update(d *schema.ResourceData, meta interface{}
 }
 
 func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	blockStorageClient, err := cfg.BlockStorageV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating block storage client: %s", err)
 	}
@@ -299,7 +299,7 @@ func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}
 	// make sure this volume is detached from all instances before deleting
 	if len(v.Attachments) > 0 {
 		log.Printf("[DEBUG] detaching volumes")
-		computeClient, err := config.ComputeV1Client(config.GetRegion(d))
+		computeClient, err := cfg.ComputeV1Client(cfg.GetRegion(d))
 		if err != nil {
 			return err
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_blockstorage_volume_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_blockstorage_volume_v2.go
@@ -209,12 +209,12 @@ func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) 
 
 	// NOTE: This tries to remove system metadata on huawei cloud :(
 	md := make(map[string]string)
-	var sys_keys = [3]string{"billing", "resourceSpecCode", "resourceType"}
+	var sysKeys = [3]string{"billing", "resourceSpecCode", "resourceType"}
 
 OUTER:
 	for key, val := range v.Metadata {
-		for i := range sys_keys {
-			if key == sys_keys[i] {
+		for i := range sysKeys {
+			if key == sysKeys[i] {
 				continue OUTER
 			}
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_compute_floatingip_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_compute_floatingip_v2.go
@@ -61,8 +61,8 @@ func ResourceComputeFloatingIPV2() *schema.Resource {
 }
 
 func resourceComputeFloatingIPV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -82,8 +82,8 @@ func resourceComputeFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 }
 
 func resourceComputeFloatingIPV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -99,7 +99,7 @@ func resourceComputeFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("instance_id", fip.InstanceID)
 	d.Set("address", fip.IP)
 	d.Set("fixed_ip", fip.FixedIP)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
@@ -123,8 +123,8 @@ func FloatingIPV2StateRefreshFunc(computeClient *golangsdk.ServiceClient, d *sch
 }
 
 func resourceComputeFloatingIPV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_compute_secgroup_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_compute_secgroup_v2.go
@@ -98,8 +98,8 @@ func ResourceComputeSecGroupV2() *schema.Resource {
 }
 
 func resourceComputeSecGroupV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -136,8 +136,8 @@ func resourceComputeSecGroupV2Create(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceComputeSecGroupV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -157,14 +157,14 @@ func resourceComputeSecGroupV2Read(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] rulesToMap(sg.Rules): %+v", rtm)
 	d.Set("rule", rtm)
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -218,8 +218,8 @@ func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceComputeSecGroupV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_cluster_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_cluster_v1.go
@@ -608,7 +608,7 @@ func flattenCsClusterV1UsedSpuNum(d interface{}, arrayIndex map[string]int) (int
 
 func setCsClusterV1States(d *schema.ResourceData, opts map[string]interface{}) error {
 	for k, v := range opts {
-		//lintignore:R001
+		// lintignore:R001
 		if err := d.Set(k, v); err != nil {
 			return fmt.Errorf("error setting CS cluster:%s: %s", k, err)
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_cluster_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_cluster_v1.go
@@ -116,8 +116,8 @@ func resourceCsClusterV1UserInputParams(d *schema.ResourceData) map[string]inter
 }
 
 func resourceCsClusterV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -135,7 +135,7 @@ func resourceCsClusterV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	timeout := d.Timeout(schema.TimeoutCreate)
 
-	obj, err := asyncWaitCsClusterV1Create(d, config, r, client, timeout)
+	obj, err := asyncWaitCsClusterV1Create(d, cfg, r, client, timeout)
 	if err != nil {
 		return err
 	}
@@ -149,8 +149,8 @@ func resourceCsClusterV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCsClusterV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -172,9 +172,9 @@ func resourceCsClusterV1Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCsClusterV1Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
+	cfg := meta.(*config.Config)
 
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -196,8 +196,8 @@ func resourceCsClusterV1Update(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCsClusterV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -220,7 +220,7 @@ func resourceCsClusterV1Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error deleting CS cluster, which ID is %s: %s", d.Id(), r.Err)
 	}
 
-	_, err = asyncWaitCsClusterV1Delete(d, config, r.Body, client, d.Timeout(schema.TimeoutDelete))
+	_, err = asyncWaitCsClusterV1Delete(d, cfg, r.Body, client, d.Timeout(schema.TimeoutDelete))
 	return err
 }
 

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_cluster_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_cluster_v1.go
@@ -15,6 +15,7 @@
 package deprecated
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 	"time"
@@ -22,8 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-
-	"fmt"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -306,7 +305,6 @@ func sendCsClusterV1CreateRequest(params interface{},
 
 func asyncWaitCsClusterV1Create(d *schema.ResourceData, result interface{},
 	client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
-
 	data := make(map[string]interface{})
 	pathParameters := map[string][]string{
 		"cluster_id": []string{"payload", "cluster_id"},
@@ -401,7 +399,6 @@ func sendCsClusterV1UpdateRequest(d *schema.ResourceData, params interface{},
 }
 
 func asyncWaitCsClusterV1Delete(d *schema.ResourceData, client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
-
 	url, err := replaceVars(d, "reserved_cluster/{id}", nil)
 	if err != nil {
 		return nil, err

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_cluster_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_cluster_v1.go
@@ -128,14 +128,14 @@ func resourceCsClusterV1Create(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error building the request body of API(create): %s", err)
 	}
-	r, err := sendCsClusterV1CreateRequest(d, params, client)
+	r, err := sendCsClusterV1CreateRequest(params, client)
 	if err != nil {
 		return fmt.Errorf("error creating CS cluster: %s", err)
 	}
 
 	timeout := d.Timeout(schema.TimeoutCreate)
 
-	obj, err := asyncWaitCsClusterV1Create(d, cfg, r, client, timeout)
+	obj, err := asyncWaitCsClusterV1Create(d, r, client, timeout)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func resourceCsClusterV1Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error deleting CS cluster, which ID is %s: %s", d.Id(), r.Err)
 	}
 
-	_, err = asyncWaitCsClusterV1Delete(d, cfg, r.Body, client, d.Timeout(schema.TimeoutDelete))
+	_, err = asyncWaitCsClusterV1Delete(d, client, d.Timeout(schema.TimeoutDelete))
 	return err
 }
 
@@ -290,7 +290,7 @@ func buildCsClusterV1CreateParameters(opts map[string]interface{}, arrayIndex ma
 	return params, nil
 }
 
-func sendCsClusterV1CreateRequest(d *schema.ResourceData, params interface{},
+func sendCsClusterV1CreateRequest(params interface{},
 	client *golangsdk.ServiceClient) (interface{}, error) {
 	url := client.ServiceURL("reserved_cluster")
 
@@ -304,7 +304,7 @@ func sendCsClusterV1CreateRequest(d *schema.ResourceData, params interface{},
 	return r.Body, nil
 }
 
-func asyncWaitCsClusterV1Create(d *schema.ResourceData, config *config.Config, result interface{},
+func asyncWaitCsClusterV1Create(d *schema.ResourceData, result interface{},
 	client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
 
 	data := make(map[string]interface{})
@@ -400,8 +400,7 @@ func sendCsClusterV1UpdateRequest(d *schema.ResourceData, params interface{},
 	return r.Body, nil
 }
 
-func asyncWaitCsClusterV1Delete(d *schema.ResourceData, config *config.Config, result interface{},
-	client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
+func asyncWaitCsClusterV1Delete(d *schema.ResourceData, client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
 
 	url, err := replaceVars(d, "reserved_cluster/{id}", nil)
 	if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_peering_connect_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_peering_connect_v1.go
@@ -94,8 +94,8 @@ func resourceCsPeeringConnectV1UserInputParams(d *schema.ResourceData) map[strin
 }
 
 func resourceCsPeeringConnectV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	csClient, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	csClient, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -115,7 +115,7 @@ func resourceCsPeeringConnectV1Create(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("error creating CS peering connect: %s", err)
 	}
 
-	networkClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	networkClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -127,7 +127,7 @@ func resourceCsPeeringConnectV1Create(d *schema.ResourceData, meta interface{}) 
 
 	timeout := d.Timeout(schema.TimeoutCreate)
 
-	obj, err := asyncWaitCsPeeringConnectV1Create(d, config, r, csClient, timeout)
+	obj, err := asyncWaitCsPeeringConnectV1Create(d, cfg, r, csClient, timeout)
 	if err != nil {
 		return err
 	}
@@ -141,8 +141,8 @@ func resourceCsPeeringConnectV1Create(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceCsPeeringConnectV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -164,8 +164,8 @@ func resourceCsPeeringConnectV1Read(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceCsPeeringConnectV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -188,7 +188,7 @@ func resourceCsPeeringConnectV1Delete(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("error deleting CS peering connect, which ID is %s: %s", d.Id(), r.Err)
 	}
 
-	_, err = asyncWaitCsPeeringConnectV1Delete(d, config, r.Body, client, d.Timeout(schema.TimeoutDelete))
+	_, err = asyncWaitCsPeeringConnectV1Delete(d, cfg, r.Body, client, d.Timeout(schema.TimeoutDelete))
 	return err
 }
 

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_peering_connect_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_peering_connect_v1.go
@@ -428,7 +428,7 @@ func flattenCsPeeringConnectV1TargetVpcInfo(d interface{}, arrayIndex map[string
 
 func setCsPeeringConnectV1States(d *schema.ResourceData, opts map[string]interface{}) error {
 	for k, v := range opts {
-		//lintignore:R001
+		// lintignore:R001
 		if err := d.Set(k, v); err != nil {
 			return fmt.Errorf("error setting CS peering connect:%s: %s", k, err)
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_peering_connect_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_peering_connect_v1.go
@@ -127,7 +127,7 @@ func resourceCsPeeringConnectV1Create(d *schema.ResourceData, meta interface{}) 
 
 	timeout := d.Timeout(schema.TimeoutCreate)
 
-	obj, err := asyncWaitCsPeeringConnectV1Create(d, cfg, r, csClient, timeout)
+	obj, err := asyncWaitCsPeeringConnectV1Create(d, r, csClient, timeout)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func resourceCsPeeringConnectV1Delete(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("error deleting CS peering connect, which ID is %s: %s", d.Id(), r.Err)
 	}
 
-	_, err = asyncWaitCsPeeringConnectV1Delete(d, cfg, r.Body, client, d.Timeout(schema.TimeoutDelete))
+	_, err = asyncWaitCsPeeringConnectV1Delete(d, client, d.Timeout(schema.TimeoutDelete))
 	return err
 }
 
@@ -246,7 +246,7 @@ func sendCsPeeringConnectV1CreateRequest(d *schema.ResourceData, params interfac
 	return r.Body, nil
 }
 
-func asyncWaitCsPeeringConnectV1Create(d *schema.ResourceData, config *config.Config, result interface{},
+func asyncWaitCsPeeringConnectV1Create(d *schema.ResourceData, result interface{},
 	client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
 
 	data := make(map[string]interface{})
@@ -288,8 +288,7 @@ func asyncWaitCsPeeringConnectV1Create(d *schema.ResourceData, config *config.Co
 	)
 }
 
-func asyncWaitCsPeeringConnectV1Delete(d *schema.ResourceData, config *config.Config, result interface{},
-	client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
+func asyncWaitCsPeeringConnectV1Delete(d *schema.ResourceData, client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
 
 	url, err := replaceVars(d, "reserved_cluster/{cluster_id}/peering/{id}", nil)
 	if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_peering_connect_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_peering_connect_v1.go
@@ -15,6 +15,7 @@
 package deprecated
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 	"time"
@@ -22,8 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-
-	"fmt"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -248,7 +247,6 @@ func sendCsPeeringConnectV1CreateRequest(d *schema.ResourceData, params interfac
 
 func asyncWaitCsPeeringConnectV1Create(d *schema.ResourceData, result interface{},
 	client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
-
 	data := make(map[string]interface{})
 	pathParameters := map[string][]string{
 		"peering_id": []string{"peering", "id"},
@@ -289,7 +287,6 @@ func asyncWaitCsPeeringConnectV1Create(d *schema.ResourceData, result interface{
 }
 
 func asyncWaitCsPeeringConnectV1Delete(d *schema.ResourceData, client *golangsdk.ServiceClient, timeout time.Duration) (interface{}, error) {
-
 	url, err := replaceVars(d, "reserved_cluster/{cluster_id}/peering/{id}", nil)
 	if err != nil {
 		return nil, err

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_route_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_route_v1.go
@@ -252,7 +252,7 @@ func flattenCsRouteV1Options(response map[string]interface{}) (map[string]interf
 
 func setCsRouteV1States(d *schema.ResourceData, opts map[string]interface{}) error {
 	for k, v := range opts {
-		//lintignore:R001
+		// lintignore:R001
 		if err := d.Set(k, v); err != nil {
 			return fmt.Errorf("error setting CS route:%s: %s", k, err)
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_route_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_route_v1.go
@@ -71,8 +71,8 @@ func resourceCsRouteV1UserInputParams(d *schema.ResourceData) map[string]interfa
 }
 
 func resourceCsRouteV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -98,8 +98,8 @@ func resourceCsRouteV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCsRouteV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}
@@ -121,8 +121,8 @@ func resourceCsRouteV1Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCsRouteV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CloudStreamV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.CloudStreamV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating SDK client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cs_route_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cs_route_v1.go
@@ -15,14 +15,13 @@
 package deprecated
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-
-	"fmt"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )

--- a/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_policy_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_policy_v1.go
@@ -151,8 +151,8 @@ func ResourceCSBSBackupPolicyV1() *schema.Resource {
 }
 
 func resourceCSBSBackupPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	policyClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	policyClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 
 	if err != nil {
 		return fmt.Errorf("error creating backup policy client: %s", err)
@@ -198,8 +198,8 @@ func resourceCSBSBackupPolicyCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceCSBSBackupPolicyRead(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	policyClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	policyClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating CSBS client: %s", err)
 	}
@@ -230,14 +230,14 @@ func resourceCSBSBackupPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("provider_id", backupPolicy.ProviderId)
 	d.Set("created_at", backupPolicy.CreatedAt.Format(time.RFC3339))
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceCSBSBackupPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	policyClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	policyClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating CSBS client: %s", err)
 	}
@@ -267,8 +267,8 @@ func resourceCSBSBackupPolicyUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceCSBSBackupPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	policyClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	policyClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating CSBS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_policy_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_policy_v1.go
@@ -147,7 +147,6 @@ func ResourceCSBSBackupPolicyV1() *schema.Resource {
 			},
 		},
 	}
-
 }
 
 func resourceCSBSBackupPolicyCreate(d *schema.ResourceData, meta interface{}) error {
@@ -193,11 +192,9 @@ func resourceCSBSBackupPolicyCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	return resourceCSBSBackupPolicyRead(d, meta)
-
 }
 
 func resourceCSBSBackupPolicyRead(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	policyClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
@@ -307,7 +304,6 @@ func waitForCSBSBackupPolicyActive(policyClient *golangsdk.ServiceClient, policy
 
 func waitForVBSPolicyDelete(policyClient *golangsdk.ServiceClient, policyID string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-
 		r, err := policies.Get(policyClient, policyID).Extract()
 
 		if err != nil {
@@ -376,7 +372,6 @@ func resourceCSBSResourceV1(d *schema.ResourceData) []policies.Resource {
 }
 
 func resourceCSBScheduleUpdateV1(d *schema.ResourceData) []policies.ScheduledOperationToUpdate {
-
 	oldSORaw, newSORaw := d.GetChange("scheduled_operation")
 	oldSOList := oldSORaw.([]interface{})
 	newSOSetList := newSORaw.([]interface{})

--- a/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_v1.go
@@ -206,7 +206,6 @@ func resourceCSBSBackupV1Create(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if query[0].Result {
-
 		createOpts := backup.CreateOpts{
 			BackupName:   d.Get("backup_name").(string),
 			Description:  d.Get("description").(string),
@@ -252,11 +251,9 @@ func resourceCSBSBackupV1Create(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	return resourceCSBSBackupV1Read(d, meta)
-
 }
 
 func resourceCSBSBackupV1Read(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	backupClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
@@ -266,7 +263,6 @@ func resourceCSBSBackupV1Read(d *schema.ResourceData, meta interface{}) error {
 	backupObject, err := backup.Get(backupClient, d.Id()).ExtractBackup()
 
 	if err != nil {
-
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			log.Printf("[WARN] Removing backup %s as it's already gone", d.Id())
 			d.SetId("")
@@ -274,7 +270,6 @@ func resourceCSBSBackupV1Read(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		return fmt.Errorf("error retrieving backup: %s", err)
-
 	}
 
 	d.Set("resource_id", backupObject.ResourceId)
@@ -335,7 +330,6 @@ func waitForCSBSBackupActive(backupClient *golangsdk.ServiceClient, backupId str
 
 func waitForCSBSBackupDelete(backupClient *golangsdk.ServiceClient, backupId string, backupRecordID string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-
 		r, err := backup.Get(backupClient, backupId).ExtractBackup()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
@@ -348,7 +342,6 @@ func waitForCSBSBackupDelete(backupClient *golangsdk.ServiceClient, backupId str
 		err = backup.Delete(backupClient, backupRecordID).Err
 
 		if err != nil {
-
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[INFO] Successfully deleted Backup %s", backupId)
 				return r, "deleted", nil
@@ -409,5 +402,4 @@ func flattenCSBSVMMetadata(backupObject *backup.Backup) []map[string]interface{}
 	vmMetadata = append(vmMetadata, mapping)
 
 	return vmMetadata
-
 }

--- a/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_v1.go
@@ -181,8 +181,8 @@ func ResourceCSBSBackupV1() *schema.Resource {
 }
 
 func resourceCSBSBackupV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	backupClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	backupClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 
 	if err != nil {
 		return fmt.Errorf("error creating CSBS client: %s", err)
@@ -257,8 +257,8 @@ func resourceCSBSBackupV1Create(d *schema.ResourceData, meta interface{}) error 
 
 func resourceCSBSBackupV1Read(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	backupClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	backupClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating CSBS client: %s", err)
 	}
@@ -288,14 +288,14 @@ func resourceCSBSBackupV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("backup_record_id", backupObject.CheckpointId)
 	d.Set("auto_trigger", backupObject.ExtendInfo.AutoTrigger)
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceCSBSBackupV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	backupClient, err := config.CsbsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	backupClient, err := cfg.CsbsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating CSBS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cts_tracker_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cts_tracker_v1.go
@@ -82,7 +82,6 @@ func ResourceCTSTrackerV1() *schema.Resource {
 			},
 		},
 	}
-
 }
 
 func resourceCTSTrackerCreate(d *schema.ResourceData, meta interface{}) error {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cts_tracker_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cts_tracker_v1.go
@@ -86,8 +86,8 @@ func ResourceCTSTrackerV1() *schema.Resource {
 }
 
 func resourceCTSTrackerCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	ctsClient, err := config.CtsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	ctsClient, err := cfg.CtsV1Client(cfg.GetRegion(d))
 
 	if err != nil {
 		return fmt.Errorf("error creating CTS client: %s", err)
@@ -121,8 +121,8 @@ func resourceCTSTrackerCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCTSTrackerRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	ctsClient, err := config.CtsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	ctsClient, err := cfg.CtsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating CTS client: %s", err)
 	}
@@ -155,14 +155,14 @@ func resourceCTSTrackerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("operations", ctsTracker.SimpleMessageNotification.Operations)
 	d.Set("need_notify_user_list", ctsTracker.SimpleMessageNotification.NeedNotifyUserList)
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceCTSTrackerUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	ctsClient, err := config.CtsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	ctsClient, err := cfg.CtsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating CTS client: %s", err)
 	}
@@ -199,8 +199,8 @@ func resourceCTSTrackerUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCTSTrackerDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	ctsClient, err := config.CtsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	ctsClient, err := cfg.CtsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating CTS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cts_tracker_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cts_tracker_v1.go
@@ -115,7 +115,7 @@ func resourceCTSTrackerCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(trackers.TrackerName)
-	//lintignore:R018
+	// lintignore:R018
 	time.Sleep(20 * time.Second)
 	return resourceCTSTrackerRead(d, meta)
 }
@@ -168,7 +168,7 @@ func resourceCTSTrackerUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	var updateOpts tracker.UpdateOptsWithSMN
 
-	//as bucket_name is mandatory while updating tracker
+	// as bucket_name is mandatory while updating tracker
 	updateOpts.BucketName = d.Get("bucket_name").(string)
 
 	updateOpts.SimpleMessageNotification.TopicID = d.Get("topic_id").(string)
@@ -193,7 +193,7 @@ func resourceCTSTrackerUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error updating CTS tracker: %s", err)
 	}
-	//lintignore:R018
+	// lintignore:R018
 	time.Sleep(20 * time.Second)
 	return resourceCTSTrackerRead(d, meta)
 }
@@ -209,7 +209,7 @@ func resourceCTSTrackerDelete(d *schema.ResourceData, meta interface{}) error {
 	if result.Err != nil {
 		return err
 	}
-	//lintignore:R018
+	// lintignore:R018
 	time.Sleep(20 * time.Second)
 	log.Printf("[DEBUG] Successfully deleted CTS tracker %s", d.Id())
 

--- a/huaweicloud/services/deprecated/resource_huaweicloud_dms_group_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_dms_group_v1.go
@@ -134,7 +134,7 @@ func resourceDmsGroupsRead(_ context.Context, d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceDmsGroupsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDmsGroupsDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_dms_group_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_dms_group_v1.go
@@ -66,8 +66,8 @@ func ResourceDmsGroups() *schema.Resource {
 }
 
 func resourceDmsGroupsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
@@ -99,9 +99,9 @@ func resourceDmsGroupsCreate(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceDmsGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
+	cfg := meta.(*config.Config)
 
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS group client: %s", err)
 	}
@@ -135,8 +135,8 @@ func resourceDmsGroupsRead(_ context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceDmsGroupsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_dms_instance_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_dms_instance_v1.go
@@ -229,7 +229,7 @@ func resourceDmsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 	// Store the instance ID now
 	d.SetId(v.InstanceID)
 
-	//set tags
+	// set tags
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
 		dmsV2Client, err := config.DmsV2Client(config.GetRegion(d))
@@ -308,7 +308,7 @@ func resourceDmsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 func resourceDmsInstancesV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 
-	//lintignore:R019
+	// lintignore:R019
 	if d.HasChanges("name", "description", "maintain_begin", "maintain_end", "security_group_id") {
 		dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
 		if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_dms_instance_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_dms_instance_v1.go
@@ -173,8 +173,8 @@ func ResourceDmsInstancesV1() *schema.Resource {
 }
 
 func resourceDmsInstancesV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating DMS client: %s", err)
 	}
@@ -232,7 +232,7 @@ func resourceDmsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 	// set tags
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
-		dmsV2Client, err := config.DmsV2Client(config.GetRegion(d))
+		dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 		if err != nil {
 			return fmt.Errorf("error creating DMS v2 client: %s", err)
 		}
@@ -248,9 +248,9 @@ func resourceDmsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceDmsInstancesV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
+	cfg := meta.(*config.Config)
 
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating DMS client: %s", err)
 	}
@@ -287,7 +287,7 @@ func resourceDmsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("maintain_end", v.MaintainEnd)
 
 	// set tags
-	dmsV2Client, err := config.DmsV2Client(config.GetRegion(d))
+	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating DMS instance v2 client: %s", err)
 	}
@@ -306,11 +306,11 @@ func resourceDmsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceDmsInstancesV1Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
+	cfg := meta.(*config.Config)
 
 	// lintignore:R019
 	if d.HasChanges("name", "description", "maintain_begin", "maintain_end", "security_group_id") {
-		dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+		dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 		if err != nil {
 			return fmt.Errorf("error updating DMS instance client: %s", err)
 		}
@@ -343,7 +343,7 @@ func resourceDmsInstancesV1Update(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("tags") {
-		dmsV2Client, err := config.DmsV2Client(config.GetRegion(d))
+		dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 		if err != nil {
 			return fmt.Errorf("error updating DMS instance v2 client: %s", err)
 		}
@@ -359,8 +359,8 @@ func resourceDmsInstancesV1Update(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceDmsInstancesV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating DMS instance client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_dms_instance_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_dms_instance_v1.go
@@ -179,9 +179,9 @@ func resourceDmsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("error creating DMS client: %s", err)
 	}
 
-	ssl_enable := false
+	sslEnable := false
 	if d.Get("access_user").(string) != "" || d.Get("password").(string) != "" {
-		ssl_enable = true
+		sslEnable = true
 	}
 	createOpts := &instances.CreateOps{
 		Name:            d.Get("name").(string),
@@ -200,7 +200,7 @@ func resourceDmsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 		PartitionNum:    d.Get("partition_num").(int),
 		Specification:   d.Get("specification").(string),
 		StorageSpecCode: d.Get("storage_spec_code").(string),
-		SslEnable:       ssl_enable,
+		SslEnable:       sslEnable,
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -324,16 +324,16 @@ func resourceDmsInstancesV1Update(d *schema.ResourceData, meta interface{}) erro
 			updateOpts.Description = &description
 		}
 		if d.HasChange("maintain_begin") {
-			maintain_begin := d.Get("maintain_begin").(string)
-			updateOpts.MaintainBegin = maintain_begin
+			maintainBegin := d.Get("maintain_begin").(string)
+			updateOpts.MaintainBegin = maintainBegin
 		}
 		if d.HasChange("maintain_end") {
-			maintain_end := d.Get("maintain_end").(string)
-			updateOpts.MaintainEnd = maintain_end
+			maintainEnd := d.Get("maintain_end").(string)
+			updateOpts.MaintainEnd = maintainEnd
 		}
 		if d.HasChange("security_group_id") {
-			security_group_id := d.Get("security_group_id").(string)
-			updateOpts.SecurityGroupID = security_group_id
+			securityGroupId := d.Get("security_group_id").(string)
+			updateOpts.SecurityGroupID = securityGroupId
 		}
 
 		err = instances.Update(dmsV1Client, d.Id(), updateOpts).Err

--- a/huaweicloud/services/deprecated/resource_huaweicloud_dms_queue_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_dms_queue_v1.go
@@ -148,7 +148,7 @@ func resourceDmsQueuesRead(_ context.Context, d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceDmsQueuesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDmsQueuesDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_dms_queue_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_dms_queue_v1.go
@@ -91,8 +91,8 @@ func ResourceDmsQueues() *schema.Resource {
 }
 
 func resourceDmsQueuesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
@@ -120,9 +120,9 @@ func resourceDmsQueuesCreate(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceDmsQueuesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
+	cfg := meta.(*config.Config)
 
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
@@ -149,8 +149,8 @@ func resourceDmsQueuesRead(_ context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceDmsQueuesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	dmsV1Client, err := config.DmsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	dmsV1Client, err := cfg.DmsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DMS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_ecs_auto_recovery_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_ecs_auto_recovery_v1.go
@@ -15,8 +15,8 @@ import (
 )
 
 func resourceECSAutoRecoveryV1Read(d *schema.ResourceData, meta interface{}, instanceID string) (bool, error) {
-	config := meta.(*config.Config)
-	client, err := config.ComputeV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ComputeV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return false, fmt.Errorf("error creating client: %s", err)
 	}
@@ -36,8 +36,8 @@ func resourceECSAutoRecoveryV1Read(d *schema.ResourceData, meta interface{}, ins
 }
 
 func setAutoRecoveryForInstance(d *schema.ResourceData, meta interface{}, instanceID string, ar bool) error {
-	config := meta.(*config.Config)
-	client, err := config.ComputeV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ComputeV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_ecs_auto_recovery_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_ecs_auto_recovery_v1.go
@@ -49,7 +49,7 @@ func setAutoRecoveryForInstance(d *schema.ResourceData, meta interface{}, instan
 	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	log.Printf("[DEBUG] Setting ECS-AutoRecovery for instance:%s with options: %#v", rId, updateOpts)
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.Retry(timeout, func() *retry.RetryError {
 		err := auto_recovery.Update(client, rId, updateOpts)
 		if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_ecs_instance_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_ecs_instance_v1.go
@@ -277,11 +277,11 @@ func resourceEcsInstanceV1Create(d *schema.ResourceData, meta interface{}) error
 			return err
 		}
 
-		resource, err := cloudservers.GetOrderResource(bssV1Client, n.OrderID)
+		resourceId, err := cloudservers.GetOrderResource(bssV1Client, n.OrderID)
 		if err != nil {
 			return err
 		}
-		instance_id = resource.(string)
+		instance_id = resourceId.(string)
 	} else {
 		n, err := cloudservers.Create(computeClient, createOpts).ExtractJobResponse()
 		if err != nil {
@@ -318,8 +318,8 @@ func resourceEcsInstanceV1Create(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceEcsInstanceV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeClient, err := config.ComputeV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeClient, err := cfg.ComputeV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
@@ -367,13 +367,13 @@ func resourceEcsInstanceV1Read(d *schema.ResourceData, meta interface{}) error {
 
 // nolint:gocyclo
 func resourceEcsInstanceV1Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeV2Client, err := config.ComputeV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeV2Client, err := cfg.ComputeV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute v2.1 client: %s", err)
 	}
 
-	computeV1Client, err := config.ComputeV1Client(config.GetRegion(d))
+	computeV1Client, err := cfg.ComputeV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute v1 client: %s", err)
 	}
@@ -475,7 +475,7 @@ func resourceEcsInstanceV1Update(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("tags") {
-		ecsClient, err := config.ComputeV1Client(config.GetRegion(d))
+		ecsClient, err := cfg.ComputeV1Client(cfg.GetRegion(d))
 		if err != nil {
 			return fmt.Errorf("error creating compute v1 client: %s", err)
 		}
@@ -499,14 +499,14 @@ func resourceEcsInstanceV1Update(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceEcsInstanceV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	computeV1Client, err := config.ComputeV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	computeV1Client, err := cfg.ComputeV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating compute client: %s", err)
 	}
 
 	if d.Get("charging_mode") == "prePaid" {
-		bssV1Client, err := config.BssV1Client(config.GetRegion(d))
+		bssV1Client, err := cfg.BssV1Client(cfg.GetRegion(d))
 		if err != nil {
 			return fmt.Errorf("error creating BSS V1 client: %s", err)
 		}
@@ -619,20 +619,20 @@ func resourceInstanceDataVolumesV1(d *schema.ResourceData) []cloudservers.DataVo
 
 func resourceInstanceSecGroupsV1(d *schema.ResourceData) []cloudservers.SecurityGroup {
 	rawSecGroups := d.Get("security_groups").(*schema.Set).List()
-	secgroups := make([]cloudservers.SecurityGroup, len(rawSecGroups))
+	securityGroups := make([]cloudservers.SecurityGroup, len(rawSecGroups))
 	for i, raw := range rawSecGroups {
-		secgroups[i] = cloudservers.SecurityGroup{
+		securityGroups[i] = cloudservers.SecurityGroup{
 			ID: raw.(string),
 		}
 	}
-	return secgroups
+	return securityGroups
 }
 
 func flattenInstanceNicsV1(
 	d *schema.ResourceData, meta interface{}, addresses map[string][]cloudservers.Address) []map[string]interface{} {
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		log.Printf("Error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_ecs_instance_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_ecs_instance_v1.go
@@ -630,7 +630,6 @@ func resourceInstanceSecGroupsV1(d *schema.ResourceData) []cloudservers.Security
 
 func flattenInstanceNicsV1(
 	d *schema.ResourceData, meta interface{}, addresses map[string][]cloudservers.Address) []map[string]interface{} {
-
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_ecs_instance_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_ecs_instance_v1.go
@@ -262,7 +262,7 @@ func resourceEcsInstanceV1Create(d *schema.ResourceData, meta interface{}) error
 	// Add password here so it wouldn't go in the above log entry
 	createOpts.AdminPass = d.Get("password").(string)
 
-	var instance_id string
+	var instanceId string
 	if d.Get("charging_mode") == "prePaid" {
 		bssV1Client, err := cfg.BssV1Client(cfg.GetRegion(d))
 		if err != nil {
@@ -281,7 +281,7 @@ func resourceEcsInstanceV1Create(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return err
 		}
-		instance_id = resourceId.(string)
+		instanceId = resourceId.(string)
 	} else {
 		n, err := cloudservers.Create(computeClient, createOpts).ExtractJobResponse()
 		if err != nil {
@@ -296,18 +296,18 @@ func resourceEcsInstanceV1Create(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return err
 		}
-		instance_id = entity.(string)
+		instanceId = entity.(string)
 	}
 
-	if instance_id != "" {
-		d.SetId(instance_id)
+	if instanceId != "" {
+		d.SetId(instanceId)
 
 		if common.HasFilledOpt(d, "auto_recovery") {
 			ar := d.Get("auto_recovery").(bool)
 			log.Printf("[DEBUG] Set auto recovery of instance to %t", ar)
-			err = setAutoRecoveryForInstance(d, meta, instance_id, ar)
+			err = setAutoRecoveryForInstance(d, meta, instanceId, ar)
 			if err != nil {
-				log.Printf("[WARN] Error setting auto recovery of instance:%s, err=%s", instance_id, err)
+				log.Printf("[WARN] Error setting auto recovery of instance:%s, err=%s", instanceId, err)
 			}
 		}
 
@@ -584,12 +584,12 @@ func resourceInstanceNicsV1(d *schema.ResourceData) []cloudservers.Nic {
 }
 
 func resourceInstanceRootVolumeV1(d *schema.ResourceData) cloudservers.RootVolume {
-	disk_type := d.Get("system_disk_type").(string)
-	if disk_type == "" {
-		disk_type = "GPSSD"
+	diskType := d.Get("system_disk_type").(string)
+	if diskType == "" {
+		diskType = "GPSSD"
 	}
 	volRequest := cloudservers.RootVolume{
-		VolumeType: disk_type,
+		VolumeType: diskType,
 		Size:       d.Get("system_disk_size").(int),
 	}
 	return volRequest

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fw_firewall_group_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fw_firewall_group_v2.go
@@ -125,26 +125,26 @@ func resourceFWFirewallGroupV2Create(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Create firewall group: %#v", createOpts)
 
-	firewall_group, err := firewall_groups.Create(fwClient, createOpts).Extract()
+	firewallGroup, err := firewall_groups.Create(fwClient, createOpts).Extract()
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[DEBUG] Firewall group created: %#v", firewall_group)
+	log.Printf("[DEBUG] Firewall group created: %#v", firewallGroup)
 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
-		Refresh:    waitForFirewallGroupActive(fwClient, firewall_group.ID),
+		Refresh:    waitForFirewallGroupActive(fwClient, firewallGroup.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      0,
 		MinTimeout: 2 * time.Second,
 	}
 
 	_, err = stateConf.WaitForStateContext(context.Background())
-	log.Printf("[DEBUG] Firewall group (%s) is active.", firewall_group.ID)
+	log.Printf("[DEBUG] Firewall group (%s) is active.", firewallGroup.ID)
 
-	d.SetId(firewall_group.ID)
+	d.SetId(firewallGroup.ID)
 
 	return resourceFWFirewallGroupV2Read(d, meta)
 }
@@ -158,21 +158,21 @@ func resourceFWFirewallGroupV2Read(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
 
-	var firewall_group FirewallGroup
-	err = firewall_groups.Get(fwClient, d.Id()).ExtractInto(&firewall_group)
+	var firewallGroup FirewallGroup
+	err = firewall_groups.Get(fwClient, d.Id()).ExtractInto(&firewallGroup)
 	if err != nil {
 		return common.CheckDeleted(d, err, "firewall")
 	}
 
-	log.Printf("[DEBUG] Read firewall group %s: %#v", d.Id(), firewall_group)
+	log.Printf("[DEBUG] Read firewall group %s: %#v", d.Id(), firewallGroup)
 
-	d.Set("name", firewall_group.Name)
-	d.Set("description", firewall_group.Description)
-	d.Set("ingress_policy_id", firewall_group.IngressPolicyID)
-	d.Set("egress_policy_id", firewall_group.EgressPolicyID)
-	d.Set("admin_state_up", firewall_group.AdminStateUp)
-	d.Set("tenant_id", firewall_group.TenantID)
-	if err := d.Set("ports", firewall_group.PortIDs); err != nil {
+	d.Set("name", firewallGroup.Name)
+	d.Set("description", firewallGroup.Description)
+	d.Set("ingress_policy_id", firewallGroup.IngressPolicyID)
+	d.Set("egress_policy_id", firewallGroup.EgressPolicyID)
+	d.Set("admin_state_up", firewallGroup.AdminStateUp)
+	d.Set("tenant_id", firewallGroup.TenantID)
+	if err := d.Set("ports", firewallGroup.PortIDs); err != nil {
 		return fmt.Errorf("error saving ports to state for firewall group (%s): %s", d.Id(), err)
 	}
 	d.Set("region", cfg.GetRegion(d))

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fw_firewall_group_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fw_firewall_group_v2.go
@@ -87,7 +87,6 @@ func ResourceFWFirewallGroupV2() *schema.Resource {
 }
 
 func resourceFWFirewallGroupV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -182,7 +181,6 @@ func resourceFWFirewallGroupV2Read(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceFWFirewallGroupV2Update(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -288,7 +286,6 @@ func resourceFWFirewallGroupV2Delete(d *schema.ResourceData, meta interface{}) e
 }
 
 func waitForFirewallGroupActive(fwClient *golangsdk.ServiceClient, id string) retry.StateRefreshFunc {
-
 	return func() (interface{}, string, error) {
 		var fw FirewallGroup
 
@@ -301,7 +298,6 @@ func waitForFirewallGroupActive(fwClient *golangsdk.ServiceClient, id string) re
 }
 
 func waitForFirewallGroupDeletion(fwClient *golangsdk.ServiceClient, id string) retry.StateRefreshFunc {
-
 	return func() (interface{}, string, error) {
 		fw, err := firewall_groups.Get(fwClient, id).Extract()
 		log.Printf("[DEBUG] Got firewall group %s => %#v", id, fw)

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fw_firewall_group_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fw_firewall_group_v2.go
@@ -88,8 +88,8 @@ func ResourceFWFirewallGroupV2() *schema.Resource {
 
 func resourceFWFirewallGroupV2Create(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -153,8 +153,8 @@ func resourceFWFirewallGroupV2Create(d *schema.ResourceData, meta interface{}) e
 func resourceFWFirewallGroupV2Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about firewall: %s", d.Id())
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -176,15 +176,15 @@ func resourceFWFirewallGroupV2Read(d *schema.ResourceData, meta interface{}) err
 	if err := d.Set("ports", firewall_group.PortIDs); err != nil {
 		return fmt.Errorf("error saving ports to state for firewall group (%s): %s", d.Id(), err)
 	}
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceFWFirewallGroupV2Update(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -249,8 +249,8 @@ func resourceFWFirewallGroupV2Update(d *schema.ResourceData, meta interface{}) e
 func resourceFWFirewallGroupV2Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy firewall group: %s", d.Id())
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fw_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fw_policy_v2.go
@@ -78,8 +78,8 @@ func ResourceFWPolicyV2() *schema.Resource {
 }
 
 func resourceFWPolicyV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -129,8 +129,8 @@ func resourceFWPolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 func resourceFWPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about firewall policy: %s", d.Id())
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -150,14 +150,14 @@ func resourceFWPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("rules", policy.Rules); err != nil {
 		return fmt.Errorf("error saving rules to state for firewall policy (%s): %s", d.Id(), err)
 	}
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceFWPolicyV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -198,8 +198,8 @@ func resourceFWPolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 func resourceFWPolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy firewall policy: %s", d.Id())
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fw_rule_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fw_rule_v2.go
@@ -92,8 +92,8 @@ func ResourceFWRuleV2() *schema.Resource {
 
 func resourceFWRuleV2Create(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -137,8 +137,8 @@ func resourceFWRuleV2Create(d *schema.ResourceData, meta interface{}) error {
 func resourceFWRuleV2Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about firewall rule: %s", d.Id())
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -166,14 +166,14 @@ func resourceFWRuleV2Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("protocol", rule.Protocol)
 	}
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceFWRuleV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -232,8 +232,8 @@ func resourceFWRuleV2Update(d *schema.ResourceData, meta interface{}) error {
 func resourceFWRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy firewall rule: %s", d.Id())
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fw_rule_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fw_rule_v2.go
@@ -91,7 +91,6 @@ func ResourceFWRuleV2() *schema.Resource {
 }
 
 func resourceFWRuleV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
@@ -230,7 +230,7 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error while uploading file %s: %s", imgFilePath, res.Err)
 	}
 
-	//wait for active
+	// wait for active
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{string(images.ImageStatusQueued), string(images.ImageStatusSaving)},
 		Target:     []string{string(images.ImageStatusActive)},

--- a/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
@@ -175,8 +175,8 @@ func ResourceImagesImageV2() *schema.Resource {
 }
 
 func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	imageClient, err := config.ImageV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	imageClient, err := cfg.ImageV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating image client: %s", err)
 	}
@@ -248,9 +248,9 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	imageClient, err := config.ImageV2Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	imageClient, err := cfg.ImageV2Client(region)
 	if err != nil {
 		return fmt.Errorf("error creating image client: %s", err)
 	}
@@ -291,8 +291,8 @@ func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceImagesImageV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	imageClient, err := config.ImageV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	imageClient, err := cfg.ImageV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating image client: %s", err)
 	}
@@ -329,8 +329,8 @@ func resourceImagesImageV2Update(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceImagesImageV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	imageClient, err := config.ImageV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	imageClient, err := cfg.ImageV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating image client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
@@ -212,7 +212,7 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error opening file for Image: %s", err)
 
 	}
-	fileSize, fileChecksum, err := resourceImagesImageV2FileProps(imgFilePath)
+	fileSize, _, err := resourceImagesImageV2FileProps(imgFilePath)
 	if err != nil {
 		return fmt.Errorf("error getting file props: %s", err)
 	}
@@ -234,7 +234,7 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{string(images.ImageStatusQueued), string(images.ImageStatusSaving)},
 		Target:     []string{string(images.ImageStatusActive)},
-		Refresh:    resourceImagesImageV2RefreshFunc(imageClient, d.Id(), fileSize, fileChecksum),
+		Refresh:    resourceImagesImageV2RefreshFunc(imageClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -485,7 +485,7 @@ func resourceImagesImageV2File(d *schema.ResourceData) (string, error) {
 	}
 }
 
-func resourceImagesImageV2RefreshFunc(client *golangsdk.ServiceClient, id string, fileSize int64, checksum string) retry.StateRefreshFunc {
+func resourceImagesImageV2RefreshFunc(client *golangsdk.ServiceClient, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		img, err := images.Get(client, id).Extract()
 		if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
@@ -210,7 +210,6 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 	imgFilePath, err := resourceImagesImageV2File(d)
 	if err != nil {
 		return fmt.Errorf("error opening file for Image: %s", err)
-
 	}
 	fileSize, _, err := resourceImagesImageV2FileProps(imgFilePath)
 	if err != nil {
@@ -426,7 +425,6 @@ func resourceImagesImageV2FileProps(filename string) (int64, string, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return -1, "", fmt.Errorf("error opening file for Image: %s", err)
-
 	}
 	defer file.Close()
 

--- a/huaweicloud/services/deprecated/resource_huaweicloud_mrs_cluster_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_mrs_cluster_v1.go
@@ -368,10 +368,10 @@ func getAllClusterComponents(d *schema.ResourceData) []cluster.ComponentOpts {
 	components := d.Get("component_list").(*schema.Set)
 	for _, v := range components.List() {
 		component := v.(map[string]interface{})
-		component_name := component["component_name"].(string)
+		componentName := component["component_name"].(string)
 
 		v := cluster.ComponentOpts{
-			ComponentName: component_name,
+			ComponentName: componentName,
 		}
 		componentOpts = append(componentOpts, v)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_mrs_cluster_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_mrs_cluster_v1.go
@@ -423,14 +423,14 @@ func ClusterStateRefreshFunc(client *golangsdk.ServiceClient, clusterID string) 
 }
 
 func resourceClusterV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
-	client, err := config.MrsV1Client(region)
+	client, err := cfg.MrsV1Client(region)
 	if err != nil {
 		return fmt.Errorf("error creating MRS client: %s", err)
 	}
-	vpcClient, err := config.NetworkingV1Client(region)
+	vpcClient, err := cfg.NetworkingV1Client(region)
 	if err != nil {
 		return fmt.Errorf("error creating VPC client: %s", err)
 	}
@@ -514,9 +514,9 @@ func resourceClusterV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceClusterV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.MrsV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.MrsV1Client(region)
 	if err != nil {
 		return fmt.Errorf("error creating MRS client: %s", err)
 	}
@@ -630,8 +630,8 @@ func resourceClusterV1Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceClusterV1Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.MrsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.MrsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating MRS client: %s", err)
 	}
@@ -646,8 +646,8 @@ func resourceClusterV1Update(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceClusterV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.MrsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.MrsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating MRS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_mrs_job_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_mrs_job_v1.go
@@ -234,7 +234,7 @@ func resourceMRSJobV1Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting MRS Job %s", rId)
 
 	timeout := d.Timeout(schema.TimeoutDelete)
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.Retry(timeout, func() *retry.RetryError {
 		err := job.Delete(client, rId).ExtractErr()
 		if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_mrs_job_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_mrs_job_v1.go
@@ -134,8 +134,8 @@ func JobStateRefreshFunc(client *golangsdk.ServiceClient, jobID string) retry.St
 }
 
 func resourceMRSJobV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.MrsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.MrsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating MRS client: %s", err)
 	}
@@ -180,9 +180,9 @@ func resourceMRSJobV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceMRSJobV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.MrsV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.MrsV1Client(region)
 	if err != nil {
 		return fmt.Errorf("error creating MRS client: %s", err)
 	}
@@ -224,8 +224,8 @@ func resourceMRSJobV1Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceMRSJobV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.MrsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.MrsV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_network_acl.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_network_acl.go
@@ -409,7 +409,6 @@ func getGWPortFromSubnet(config *config.Config, subnetID string) (string, error)
 	// list all ports in the subnet
 	listOpts := ports.ListOpts{
 		NetworkID: subnetID,
-		//Status:    "ACTIVE",
 	}
 	allPages, err := ports.List(networkingClient, listOpts).AllPages()
 	if err != nil {
@@ -494,7 +493,7 @@ func updateNetworkACLPolicyRules(d *schema.ResourceData, client *golangsdk.Servi
 			return fmt.Errorf("error creating firewall policy: %s", err)
 		}
 
-		//lintignore:R001
+		// lintignore:R001
 		d.Set(policyKey, policy.ID)
 	}
 

--- a/huaweicloud/services/deprecated/resource_huaweicloud_network_acl.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_network_acl.go
@@ -98,8 +98,8 @@ func resourceNetworkACLCreate(d *schema.ResourceData, meta interface{}) error {
 	var portIds []string
 	var inboundPolicyID, outboundPolicyID string
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -125,7 +125,7 @@ func resourceNetworkACLCreate(d *schema.ResourceData, meta interface{}) error {
 	subnetsRaw := d.Get("subnets").(*schema.Set).List()
 	if len(subnetsRaw) > 0 {
 		for _, v := range subnetsRaw {
-			port, err := getGWPortFromSubnet(config, v.(string))
+			port, err := getGWPortFromSubnet(cfg, v.(string))
 			if err != nil {
 				return err
 			}
@@ -228,8 +228,8 @@ func resourceNetworkACLCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNetworkACLRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -255,8 +255,8 @@ func resourceNetworkACLRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNetworkACLUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -292,7 +292,7 @@ func resourceNetworkACLUpdate(d *schema.ResourceData, meta interface{}) error {
 		// get port Ids from subnets
 		subnetsRaw := d.Get("subnets").(*schema.Set).List()
 		for _, v := range subnetsRaw {
-			port, err := getGWPortFromSubnet(config, v.(string))
+			port, err := getGWPortFromSubnet(cfg, v.(string))
 			if err != nil {
 				return err
 			}
@@ -338,8 +338,8 @@ func resourceNetworkACLUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceNetworkACLDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy firewall group: %s", d.Id())
 
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -385,15 +385,15 @@ func resourceNetworkACLDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func getGWPortFromSubnet(config *config.Config, subnetID string) (string, error) {
+func getGWPortFromSubnet(cfg *config.Config, subnetID string) (string, error) {
 	var gatewayIP string
 	var gatewayPort string
 
-	subnetClient, err := config.NetworkingV1Client(config.Region)
+	subnetClient, err := cfg.NetworkingV1Client(cfg.Region)
 	if err != nil {
 		return "", fmt.Errorf("error creating vpc client: %s", err)
 	}
-	networkingClient, err := config.NetworkingV2Client(config.Region)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.Region)
 	if err != nil {
 		return "", fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_network_acl_rule.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_network_acl_rule.go
@@ -92,8 +92,8 @@ func ResourceNetworkACLRule() *schema.Resource {
 }
 
 func resourceNetworkACLRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -128,8 +128,8 @@ func resourceNetworkACLRuleCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceNetworkACLRuleRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -161,8 +161,8 @@ func resourceNetworkACLRuleRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceNetworkACLRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}
@@ -219,8 +219,8 @@ func resourceNetworkACLRuleUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceNetworkACLRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	fwClient, err := config.FwV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	fwClient, err := cfg.FwV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating fw client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_floatingip_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_floatingip_v2.go
@@ -86,8 +86,8 @@ func ResourceNetworkingFloatingIPV2() *schema.Resource {
 }
 
 func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating network client: %s", err)
 	}
@@ -129,8 +129,8 @@ func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 }
 
 func resourceNetworkFloatingIPV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating network client: %s", err)
 	}
@@ -146,14 +146,14 @@ func resourceNetworkFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("tenant_id", floatingIP.TenantID)
 	d.Set("pool", PoolName)
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceNetworkFloatingIPV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating network client: %s", err)
 	}
@@ -176,8 +176,8 @@ func resourceNetworkFloatingIPV2Update(d *schema.ResourceData, meta interface{})
 }
 
 func resourceNetworkFloatingIPV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating network client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_network_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_network_v2.go
@@ -97,8 +97,8 @@ func ResourceNetworkingNetworkV2() *schema.Resource {
 }
 
 func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -169,8 +169,8 @@ func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{})
 }
 
 func resourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -186,14 +186,14 @@ func resourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("admin_state_up", strconv.FormatBool(n.AdminStateUp))
 	d.Set("shared", strconv.FormatBool(n.Shared))
 	d.Set("tenant_id", n.TenantID)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceNetworkingNetworkV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -234,8 +234,8 @@ func resourceNetworkingNetworkV2Update(d *schema.ResourceData, meta interface{})
 }
 
 func resourceNetworkingNetworkV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_port_v2.go
@@ -168,8 +168,8 @@ func ResourceNetworkingPortV2() *schema.Resource {
 }
 
 func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -255,8 +255,8 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -306,14 +306,14 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	d.Set("allowed_address_pairs", pairs)
 	d.Set("extra_dhcp_option", flattenNetworkingPortDHCPOptsV2(p.ExtraDHCPOptsExt))
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -427,8 +427,8 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceNetworkingPortV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_interface_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_interface_v2.go
@@ -60,8 +60,8 @@ func ResourceNetworkingRouterInterfaceV2() *schema.Resource {
 }
 
 func resourceNetworkingRouterInterfaceV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -97,8 +97,8 @@ func resourceNetworkingRouterInterfaceV2Create(d *schema.ResourceData, meta inte
 }
 
 func resourceNetworkingRouterInterfaceV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -127,14 +127,14 @@ func resourceNetworkingRouterInterfaceV2Read(d *schema.ResourceData, meta interf
 		d.Set("subnet_id", n.FixedIPs[0].SubnetID)
 	}
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceNetworkingRouterInterfaceV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_route_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_route_v2.go
@@ -58,8 +58,8 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 	var destCidr string = d.Get("destination_cidr").(string)
 	var nextHop string = d.Get("next_hop").(string)
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -116,8 +116,8 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 
 	routerId := d.Get("router_id").(string)
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -165,7 +165,7 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
@@ -176,9 +176,9 @@ func resourceNetworkingRouterRouteV2Delete(d *schema.ResourceData, meta interfac
 	config.MutexKV.Lock(routerId)
 	defer config.MutexKV.Unlock(routerId)
 
-	config := meta.(*config.Config)
+	cfg := meta.(*config.Config)
 
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_route_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_route_v2.go
@@ -50,7 +50,6 @@ func ResourceNetworkingRouterRouteV2() *schema.Resource {
 }
 
 func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	routerId := d.Get("router_id").(string)
 	config.MutexKV.Lock(routerId)
 	defer config.MutexKV.Unlock(routerId)
@@ -79,7 +78,6 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 
 	var rts []routers.Route = n.Routes
 	for _, r := range rts {
-
 		if r.DestinationCIDR == destCidr && r.NextHop == nextHop {
 			routeExists = true
 			break
@@ -87,7 +85,6 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 	}
 
 	if !routeExists {
-
 		if destCidr != "" && nextHop != "" {
 			r := routers.Route{DestinationCIDR: destCidr, NextHop: nextHop}
 			log.Printf(
@@ -104,7 +101,6 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("error updating Neutron Router: %s", err)
 		}
 		d.SetId(fmt.Sprintf("%s-route-%s-%s", routerId, destCidr, nextHop))
-
 	} else {
 		log.Printf("[DEBUG] Router %s has route already", routerId)
 	}
@@ -113,7 +109,6 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 }
 
 func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{}) error {
-
 	routerId := d.Get("router_id").(string)
 
 	cfg := meta.(*config.Config)
@@ -157,7 +152,6 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 	d.Set("destination_cidr", "")
 
 	for _, r := range n.Routes {
-
 		if r.DestinationCIDR == destCidr && r.NextHop == nextHop {
 			d.Set("destination_cidr", destCidr)
 			d.Set("next_hop", nextHop)
@@ -171,7 +165,6 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 }
 
 func resourceNetworkingRouterRouteV2Delete(d *schema.ResourceData, meta interface{}) error {
-
 	routerId := d.Get("router_id").(string)
 	config.MutexKV.Lock(routerId)
 	defer config.MutexKV.Unlock(routerId)
@@ -201,7 +194,6 @@ func resourceNetworkingRouterRouteV2Delete(d *schema.ResourceData, meta interfac
 	var newRts []routers.Route
 
 	for _, r := range oldRts {
-
 		if r.DestinationCIDR != destCidr || r.NextHop != nextHop {
 			newRts = append(newRts, r)
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_v2.go
@@ -98,8 +98,8 @@ func ResourceNetworkingRouterV2() *schema.Resource {
 }
 
 func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -176,8 +176,8 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -198,7 +198,7 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("admin_state_up", n.AdminStateUp)
 	d.Set("distributed", n.Distributed)
 	d.Set("tenant_id", n.TenantID)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	// Gateway settings
 	d.Set("external_network_id", n.GatewayInfo.NetworkID)
@@ -224,8 +224,8 @@ func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) 
 	config.MutexKV.Lock(routerId)
 	defer config.MutexKV.Unlock(routerId)
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -293,8 +293,8 @@ func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceNetworkingRouterV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_subnet_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_subnet_v2.go
@@ -149,8 +149,8 @@ func ResourceNetworkingSubnetV2() *schema.Resource {
 }
 
 func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -213,8 +213,8 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -271,14 +271,14 @@ func resourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) er
 		d.Set("no_gateway", false)
 	}
 
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceNetworkingSubnetV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -332,8 +332,8 @@ func resourceNetworkingSubnetV2Update(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceNetworkingSubnetV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_oms_task_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_oms_task_v1.go
@@ -212,8 +212,8 @@ func getTriggerConditions(v []interface{}) []string {
 }
 
 func resourceMaasTaskV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	maasClient, err := config.MaasV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	maasClient, err := cfg.MaasV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating maas client: %s", err)
 	}
@@ -260,8 +260,8 @@ func resourceMaasTaskV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceMaasTaskV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	maasClient, err := config.MaasV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	maasClient, err := cfg.MaasV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating maas client: %s", err)
 	}
@@ -302,8 +302,8 @@ func resourceMaasTaskV1Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceMaasTaskV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	maasClient, err := config.MaasV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	maasClient, err := cfg.MaasV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating maas client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -178,11 +178,9 @@ func resourceVBSBackupPolicyV2Create(d *schema.ResourceData, meta interface{}) e
 	}
 
 	return resourceVBSBackupPolicyV2Read(d, meta)
-
 }
 
 func resourceVBSBackupPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -355,7 +353,6 @@ func resourceVBSBackupPolicyV2Delete(d *schema.ResourceData, meta interface{}) e
 	if delete.Err != nil {
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			log.Printf("[INFO] Successfully deleted VBS Backup Policy %s", d.Id())
-
 		}
 		if _, ok := err.(golangsdk.ErrDefault409); ok {
 			log.Printf("[INFO] Error deleting VBS Backup Policy %s", d.Id())

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -117,8 +117,8 @@ func ResourceVBSBackupPolicyV2() *schema.Resource {
 }
 
 func resourceVBSBackupPolicyV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 
 	if err != nil {
 		return fmt.Errorf("error creating VBS client: %s", err)
@@ -183,14 +183,14 @@ func resourceVBSBackupPolicyV2Create(d *schema.ResourceData, meta interface{}) e
 
 func resourceVBSBackupPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating VBS client: %s", err)
 	}
 
 	PolicyOpts := policies.ListOpts{ID: d.Id()}
-	policies, err := policies.List(vbsClient, PolicyOpts)
+	policyList, err := policies.List(vbsClient, PolicyOpts)
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			d.SetId("")
@@ -200,7 +200,7 @@ func resourceVBSBackupPolicyV2Read(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error retrieving backup policy: %s", err)
 	}
 
-	n := policies[0]
+	n := policyList[0]
 
 	d.Set("name", n.Name)
 	d.Set("start_time", n.ScheduledPolicy.StartTime)
@@ -236,8 +236,8 @@ func resourceVBSBackupPolicyV2Read(d *schema.ResourceData, meta interface{}) err
 
 // nolint:gocyclo
 func resourceVBSBackupPolicyV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error updating VBS client: %s", err)
 	}
@@ -345,8 +345,8 @@ func resourceVBSBackupPolicyV2Update(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceVBSBackupPolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating VBS client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -307,10 +307,10 @@ func resourceVBSBackupPolicyV2Update(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("resources") {
-		old, new := d.GetChange("resources")
+		oldVal, newVal := d.GetChange("resources")
 
 		// disassociate old volumes from backup policy
-		removeResources := buildDisassociateResource(old.([]interface{}))
+		removeResources := buildDisassociateResource(oldVal.([]interface{}))
 		if len(removeResources) > 0 {
 			opts := policies.DisassociateOpts{
 				Resources: removeResources,
@@ -324,7 +324,7 @@ func resourceVBSBackupPolicyV2Update(d *schema.ResourceData, meta interface{}) e
 		}
 
 		// associate new volumes to backup policy
-		addResources := buildAssociateResource(new.([]interface{}))
+		addResources := buildAssociateResource(newVal.([]interface{}))
 		if len(addResources) > 0 {
 			opts := policies.AssociateOpts{
 				PolicyID:  d.Id(),
@@ -349,8 +349,8 @@ func resourceVBSBackupPolicyV2Delete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error creating VBS client: %s", err)
 	}
 
-	delete := policies.Delete(vbsClient, d.Id())
-	if delete.Err != nil {
+	respBody := policies.Delete(vbsClient, d.Id())
+	if respBody.Err != nil {
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			log.Printf("[INFO] Successfully deleted VBS Backup Policy %s", d.Id())
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -267,7 +267,7 @@ func resourceVBSBackupPolicyV2Update(d *schema.ResourceData, meta interface{}) e
 		updateOpts.ScheduledPolicy.WeekFrequency = weeks
 	}
 
-	//lintignore:R019
+	// lintignore:R019
 	if d.HasChanges("name", "start_time", "retain_first_backup", "rentention_num",
 		"rentention_day", "status", "frequency", "week_frequency") {
 		if d.HasChange("name") {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_v2.go
@@ -129,8 +129,8 @@ func resourceVBSBackupTagsV2(d *schema.ResourceData) []backups.Tag {
 }
 
 func resourceVBSBackupV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating vbs client: %s", err)
 	}
@@ -165,8 +165,8 @@ func resourceVBSBackupV2Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceVBSBackupV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating VBS client: %s", err)
 	}
@@ -186,14 +186,14 @@ func resourceVBSBackupV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("object_count", n.ObjectCount)
 	d.Set("created_at", n.CreatedAt.Format(time.RFC3339))
 	d.Set("volume_id", n.VolumeId)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceVBSBackupV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	vbsClient, err := config.VbsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vbsClient, err := cfg.VbsV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating VBS: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpc_route_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpc_route_v2.go
@@ -64,8 +64,8 @@ func ResourceVPCRouteV2() *schema.Resource {
 }
 
 func resourceVpcRouteV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vpcRouteClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 
 	if err != nil {
 		return diag.Errorf("error creating vpc route client: %s", err)
@@ -94,8 +94,8 @@ func resourceVpcRouteV2Create(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceVpcRouteV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vpcRouteClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Vpc route client: %s", err)
 	}
@@ -114,15 +114,15 @@ func resourceVpcRouteV2Read(_ context.Context, d *schema.ResourceData, meta inte
 	d.Set("nexthop", n.NextHop)
 	d.Set("destination", n.Destination)
 	d.Set("vpc_id", n.VPC_ID)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceVpcRouteV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
-	config := meta.(*config.Config)
-	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	vpcRouteClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating vpc route: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpc_route_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpc_route_v2.go
@@ -90,7 +90,6 @@ func resourceVpcRouteV2Create(ctx context.Context, d *schema.ResourceData, meta 
 	d.SetId(n.RouteID)
 
 	return resourceVpcRouteV2Read(ctx, d, meta)
-
 }
 
 func resourceVpcRouteV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -120,7 +119,6 @@ func resourceVpcRouteV2Read(_ context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceVpcRouteV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	cfg := meta.(*config.Config)
 	vpcRouteClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -147,7 +145,6 @@ func resourceVpcRouteV2Delete(ctx context.Context, d *schema.ResourceData, meta 
 
 func waitForVpcRouteDelete(vpcRouteClient *golangsdk.ServiceClient, routeId string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-
 		r, err := routes.Get(vpcRouteClient, routeId).Extract()
 
 		if err != nil {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_endpoint_group_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_endpoint_group_v2.go
@@ -79,8 +79,8 @@ func ResourceVpnEndpointGroupV2() *schema.Resource {
 
 func resourceVpnEndpointGroupV2Create(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -136,8 +136,8 @@ func resourceVpnEndpointGroupV2Create(d *schema.ResourceData, meta interface{}) 
 func resourceVpnEndpointGroupV2Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about group: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -154,15 +154,15 @@ func resourceVpnEndpointGroupV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("tenant_id", group.TenantID)
 	d.Set("type", group.Type)
 	d.Set("endpoints", group.Endpoints)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceVpnEndpointGroupV2Update(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -216,8 +216,8 @@ func resourceVpnEndpointGroupV2Update(d *schema.ResourceData, meta interface{}) 
 func resourceVpnEndpointGroupV2Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy group: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_endpoint_group_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_endpoint_group_v2.go
@@ -78,7 +78,6 @@ func ResourceVpnEndpointGroupV2() *schema.Resource {
 }
 
 func resourceVpnEndpointGroupV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -160,7 +159,6 @@ func resourceVpnEndpointGroupV2Read(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceVpnEndpointGroupV2Update(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -243,7 +241,6 @@ func resourceVpnEndpointGroupV2Delete(d *schema.ResourceData, meta interface{}) 
 }
 
 func waitForEndpointGroupDeletion(networkingClient *golangsdk.ServiceClient, id string) retry.StateRefreshFunc {
-
 	return func() (interface{}, string, error) {
 		group, err := endpointgroups.Get(networkingClient, id).Extract()
 		log.Printf("[DEBUG] Got group %s => %#v", id, group)

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ike_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ike_policy_v2.go
@@ -418,7 +418,6 @@ func resourceIKEPolicyV2LifetimeCreateOpts(d *schema.Set) ikepolicies.LifetimeCr
 		lifetimeCreateOpts.Value = value
 	}
 	return lifetimeCreateOpts
-
 }
 
 func resourceIKEPolicyV2LifetimeUpdateOpts(d *schema.Set) ikepolicies.LifetimeUpdateOpts {
@@ -433,5 +432,4 @@ func resourceIKEPolicyV2LifetimeUpdateOpts(d *schema.Set) ikepolicies.LifetimeUp
 		lifetimeUpdateOpts.Value = value
 	}
 	return lifetimeUpdateOpts
-
 }

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ike_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ike_policy_v2.go
@@ -108,8 +108,8 @@ func ResourceVpnIKEPolicyV2() *schema.Resource {
 }
 
 func resourceVpnIKEPolicyV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -162,8 +162,8 @@ func resourceVpnIKEPolicyV2Create(d *schema.ResourceData, meta interface{}) erro
 func resourceVpnIKEPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about IKE policy: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -183,7 +183,7 @@ func resourceVpnIKEPolicyV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("pfs", policy.PFS)
 	d.Set("phase1_negotiation_mode", policy.Phase1NegotiationMode)
 	d.Set("ike_version", policy.IKEVersion)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	// Set the lifetime
 	var lifetimeMap map[string]interface{}
@@ -200,8 +200,8 @@ func resourceVpnIKEPolicyV2Read(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceVpnIKEPolicyV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -275,8 +275,8 @@ func resourceVpnIKEPolicyV2Update(d *schema.ResourceData, meta interface{}) erro
 func resourceVpnIKEPolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy IKE policy: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
@@ -348,7 +348,6 @@ func resourceIPSecPolicyV2TransformProtocol(trp string) ipsecpolicies.TransformP
 		protocol = ipsecpolicies.TransformProtocolAHESP
 	}
 	return protocol
-
 }
 
 func resourceIPSecPolicyV2PFS(pfsString string) ipsecpolicies.PFS {
@@ -362,7 +361,6 @@ func resourceIPSecPolicyV2PFS(pfsString string) ipsecpolicies.PFS {
 		pfs = ipsecpolicies.PFSGroup14
 	}
 	return pfs
-
 }
 
 func resourceIPSecPolicyV2EncryptionAlgorithm(encryptionAlgo string) ipsecpolicies.EncryptionAlgorithm {
@@ -445,5 +443,4 @@ func resourceIPSecPolicyV2LifetimeUpdateOpts(d *schema.Set) ipsecpolicies.Lifeti
 		lifetimeUpdateOpts.Value = value
 	}
 	return lifetimeUpdateOpts
-
 }

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
@@ -109,8 +109,8 @@ func ResourceVpnIPSecPolicyV2() *schema.Resource {
 }
 
 func resourceVpnIPSecPolicyV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -164,8 +164,8 @@ func resourceVpnIPSecPolicyV2Create(d *schema.ResourceData, meta interface{}) er
 func resourceVpnIPSecPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about IPSec policy: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -185,7 +185,7 @@ func resourceVpnIPSecPolicyV2Read(d *schema.ResourceData, meta interface{}) erro
 	d.Set("transform_protocol", policy.TransformProtocol)
 	d.Set("pfs", policy.PFS)
 	d.Set("auth_algorithm", policy.AuthAlgorithm)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	// Set the lifetime
 	var lifetimeMap map[string]interface{}
@@ -202,8 +202,8 @@ func resourceVpnIPSecPolicyV2Read(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceVpnIPSecPolicyV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -280,8 +280,8 @@ func resourceVpnIPSecPolicyV2Update(d *schema.ResourceData, meta interface{}) er
 func resourceVpnIPSecPolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy IPSec policy: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_service_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_service_v2.go
@@ -93,7 +93,6 @@ func ResourceVpnServiceV2() *schema.Resource {
 }
 
 func resourceVpnServiceV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -174,7 +173,6 @@ func resourceVpnServiceV2Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceVpnServiceV2Update(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -263,7 +261,6 @@ func resourceVpnServiceV2Delete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func waitForServiceDeletion(networkingClient *golangsdk.ServiceClient, id string) retry.StateRefreshFunc {
-
 	return func() (interface{}, string, error) {
 		serv, err := services.Get(networkingClient, id).Extract()
 		log.Printf("[DEBUG] Got service %s => %#v", id, serv)

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_service_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_service_v2.go
@@ -94,8 +94,8 @@ func ResourceVpnServiceV2() *schema.Resource {
 
 func resourceVpnServiceV2Create(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -146,8 +146,8 @@ func resourceVpnServiceV2Create(d *schema.ResourceData, meta interface{}) error 
 func resourceVpnServiceV2Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about service: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -168,15 +168,15 @@ func resourceVpnServiceV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status", service.Status)
 	d.Set("external_v6_ip", service.ExternalV6IP)
 	d.Set("external_v4_ip", service.ExternalV4IP)
-	d.Set("region", config.GetRegion(d))
+	d.Set("region", cfg.GetRegion(d))
 
 	return nil
 }
 
 func resourceVpnServiceV2Update(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -236,8 +236,8 @@ func resourceVpnServiceV2Update(d *schema.ResourceData, meta interface{}) error 
 func resourceVpnServiceV2Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy service: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_site_connection.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_site_connection.go
@@ -154,7 +154,6 @@ func ResourceVpnSiteConnectionV2() *schema.Resource {
 }
 
 func resourceVpnSiteConnectionV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -293,7 +292,6 @@ func resourceVpnSiteConnectionV2Read(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceVpnSiteConnectionV2Update(d *schema.ResourceData, meta interface{}) error {
-
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -440,7 +438,6 @@ func resourceVpnSiteConnectionV2Delete(d *schema.ResourceData, meta interface{})
 }
 
 func waitForSiteConnectionDeletion(networkingClient *golangsdk.ServiceClient, id string) retry.StateRefreshFunc {
-
 	return func() (interface{}, string, error) {
 		conn, err := siteconnections.Get(networkingClient, id).Extract()
 		log.Printf("[DEBUG] Got site connection %s => %#v", id, conn)

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_site_connection.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_site_connection.go
@@ -155,8 +155,8 @@ func ResourceVpnSiteConnectionV2() *schema.Resource {
 
 func resourceVpnSiteConnectionV2Create(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -235,8 +235,8 @@ func resourceVpnSiteConnectionV2Create(d *schema.ResourceData, meta interface{})
 func resourceVpnSiteConnectionV2Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about site connection: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -294,8 +294,8 @@ func resourceVpnSiteConnectionV2Read(d *schema.ResourceData, meta interface{}) e
 
 func resourceVpnSiteConnectionV2Update(d *schema.ResourceData, meta interface{}) error {
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -413,8 +413,8 @@ func resourceVpnSiteConnectionV2Update(d *schema.ResourceData, meta interface{})
 func resourceVpnSiteConnectionV2Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy service: %s", d.Id())
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_site_connection.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_site_connection.go
@@ -261,10 +261,9 @@ func resourceVpnSiteConnectionV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("vpnservice_id", conn.VPNServiceID)
 	d.Set("local_ep_group_id", conn.LocalEPGroupID)
 	d.Set("ipsecpolicy_id", conn.IPSecPolicyID)
-	// Do not set psk here as the response value is not same with the requested
-	//d.Set("psk", conn.PSK)
 	d.Set("mtu", conn.MTU)
 	d.Set("peer_cidrs", conn.PeerCIDRs)
+	// Do not set `psk` parameter here as the response value is not same with the requested
 
 	// Set the dpd
 	var dpdMap map[string]interface{}

--- a/huaweicloud/services/deprecated/transport.go
+++ b/huaweicloud/services/deprecated/transport.go
@@ -115,10 +115,8 @@ func convertToInt(v interface{}) (int64, error) {
 
 	if i, ok := v.(int); ok {
 		return int64(i), nil
-
 	} else if i, ok := v.(float64); ok {
 		return int64(i), nil
-
 	} else if i, ok := v.(float32); ok {
 		return int64(i), nil
 	}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flinkjar_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flinkjar_job.go
@@ -335,8 +335,8 @@ func resourceFlinkJarJobCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if runtimConfig, ok := d.GetOk("runtime_config"); ok {
-		config := utils.ExpandResourceTags(runtimConfig.(map[string]interface{}))
-		configStr, err := json.Marshal(config)
+		cfg := utils.ExpandResourceTags(runtimConfig.(map[string]interface{}))
+		configStr, err := json.Marshal(cfg)
 		if err != nil {
 			log.Printf("[ERROR] error marshaling runtime config: %s", err)
 		}
@@ -711,8 +711,8 @@ func updateFlinkJarJobWithStop(ctx context.Context, client *golangsdk.ServiceCli
 		}
 
 		if runtimConfig, ok := d.GetOk("runtime_config"); ok {
-			config := utils.ExpandResourceTags(runtimConfig.(map[string]interface{}))
-			configStr, err := json.Marshal(config)
+			cfg := utils.ExpandResourceTags(runtimConfig.(map[string]interface{}))
+			configStr, err := json.Marshal(cfg)
 			if err != nil {
 				log.Printf("[ERROR] error marshaling runtime config: %s", err)
 			}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
@@ -385,7 +385,7 @@ func addTagsToResource(cfg *config.Config, region string, d *schema.ResourceData
 	return nil
 }
 
-func resourceFlinkSqlJobRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFlinkSqlJobRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.DliV1Client(region)
@@ -497,7 +497,7 @@ func getSteramGraphById(client *golangsdk.ServiceClient, d *schema.ResourceData,
 }
 
 // This API is used to cancel a submitted job. If execution of a job completes or fails, this job cannot be canceled.
-func resourceFlinkSqlJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFlinkSqlJobDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.DliV1Client(region)

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
@@ -299,8 +299,8 @@ func resourceFlinkSqlJobCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if runtimConfig, ok := d.GetOk("runtime_config"); ok {
-		config := utils.ExpandResourceTags(runtimConfig.(map[string]interface{}))
-		configStr, err := json.Marshal(config)
+		cfg := utils.ExpandResourceTags(runtimConfig.(map[string]interface{}))
+		configStr, err := json.Marshal(cfg)
 		if err != nil {
 			log.Printf("[ERROR] error marshaling runtime config: %s", err)
 		}
@@ -723,8 +723,8 @@ func updateFlinkSqlJobWithStop(ctx context.Context, client *golangsdk.ServiceCli
 		}
 
 		if runtimConfig, ok := d.GetOk("runtime_config"); ok {
-			config := utils.ExpandResourceTags(runtimConfig.(map[string]interface{}))
-			configStr, err := json.Marshal(config)
+			cfg := utils.ExpandResourceTags(runtimConfig.(map[string]interface{}))
+			configStr, err := json.Marshal(cfg)
 			if err != nil {
 				log.Printf("[ERROR] error marshaling runtime config: %s", err)
 			}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_permission.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_permission.go
@@ -97,7 +97,6 @@ func resourceDliPermissionCreate(ctx context.Context, d *schema.ResourceData, me
 		if rst != nil && !rst.IsSuccess {
 			return diag.Errorf("error granting permission in DLI: %s", rst.Message)
 		}
-
 	} else {
 		opts := auth.GrantDataPermissionOpts{
 			UserName: userName,

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
@@ -123,8 +123,8 @@ func getIOByType(d *schema.ResourceData, productIOs []products.IO) []products.IO
 	return productIOs
 }
 
-func getProducts(config *config.Config, region, engine string) (*products.GetResponse, error) {
-	dmsV2Client, err := config.DmsV2Client(region)
+func getProducts(cfg *config.Config, region, engine string) (*products.GetResponse, error) {
+	dmsV2Client, err := cfg.DmsV2Client(region)
 	if err != nil {
 		return nil, fmt.Errorf("error getting DMS product client V2: %s", err)
 	}

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
@@ -128,12 +128,12 @@ func getProducts(config *config.Config, region, engine string) (*products.GetRes
 	if err != nil {
 		return nil, fmt.Errorf("error getting DMS product client V2: %s", err)
 	}
-	v, err := products.Get(dmsV2Client, engine) //nolint: staticcheck
+	v, err := products.Get(dmsV2Client, engine) // nolint: staticcheck
 	return v, err
 }
 
 // Currently the complex is 37 and will be repaired later.
-func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { //nolint: gocyclo
+func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nolint: gocyclo
 	cfg := meta.(*config.Config)
 
 	instanceEngine := d.Get("engine").(string)

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
@@ -95,7 +95,7 @@ func ResourcePtrRecord() *schema.Resource {
 func resourcePtrRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	dnsClient, err := cfg.DnsV2Client(region)
+	dnsClient, err := cfg.DNSV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -163,7 +163,7 @@ func resourcePtrRecordRead(_ context.Context, d *schema.ResourceData, meta inter
 		region      = conf.GetRegion(d)
 		ptrRecordId = d.Id()
 	)
-	dnsClient, err := conf.DnsV2Client(region)
+	dnsClient, err := conf.DNSV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -208,7 +208,7 @@ func resourcePtrRecordUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		region      = conf.GetRegion(d)
 		ptrRecordId = d.Id()
 	)
-	dnsClient, err := conf.DnsV2Client(region)
+	dnsClient, err := conf.DNSV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -248,7 +248,7 @@ func resourcePtrRecordDelete(ctx context.Context, d *schema.ResourceData, meta i
 		conf        = meta.(*config.Config)
 		ptrRecordId = d.Id()
 	)
-	dnsClient, err := conf.DnsV2Client(conf.GetRegion(d))
+	dnsClient, err := conf.DNSV2Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
@@ -362,7 +362,7 @@ func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interfa
 	var client *golangsdk.ServiceClient
 	var zoneInfo *zones.Zone
 	// Firstly, try to ues the DNS global endpoint
-	client, err := conf.DnsV2Client(region)
+	client, err := conf.DNSV2Client(region)
 	if err != nil {
 		return nil, "", golangsdk.ErrDefault400{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
@@ -378,7 +378,7 @@ func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interfa
 
 		// try to ues the DNS region endpoint
 		var clientErr error
-		client, clientErr = conf.DnsWithRegionClient(region)
+		client, clientErr = conf.DNSWithRegionClient(region)
 		if clientErr != nil {
 			// it looks tricky as we return the fetching error rather than clientErr
 			return nil, "", err

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
@@ -259,7 +259,7 @@ func resourceDNSZoneCreate(ctx context.Context, d *schema.ResourceData, meta int
 	region := cfg.GetRegion(d)
 	var dnsClient *golangsdk.ServiceClient
 
-	dnsClient, err := cfg.DnsV2Client(region)
+	dnsClient, err := cfg.DNSV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -273,7 +273,7 @@ func resourceDNSZoneCreate(ctx context.Context, d *schema.ResourceData, meta int
 			return diag.Errorf("the argument (router) is required when creating DNS private zone")
 		}
 		// update the endpoint with region when creating private zone
-		dnsClient, err = cfg.DnsWithRegionClient(cfg.GetRegion(d))
+		dnsClient, err = cfg.DNSWithRegionClient(cfg.GetRegion(d))
 		if err != nil {
 			return diag.Errorf("error creating DNS region client: %s", err)
 		}
@@ -402,7 +402,7 @@ func resourceDNSZoneRead(_ context.Context, d *schema.ResourceData, meta interfa
 	region := conf.GetRegion(d)
 
 	// we can not get the corresponding client by zone type in import scene
-	dnsClient, err := conf.DnsV2Client(region)
+	dnsClient, err := conf.DNSV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -414,7 +414,7 @@ func resourceDNSZoneRead(_ context.Context, d *schema.ResourceData, meta interfa
 		// an error occurred while fetching the zone with DNS global endpoint
 		// try to fetch it again with DNS region endpoint
 		var clientErr error
-		dnsClient, clientErr = conf.DnsWithRegionClient(conf.GetRegion(d))
+		dnsClient, clientErr = conf.DNSWithRegionClient(conf.GetRegion(d))
 		if clientErr != nil {
 			// it looks tricky as we return the fetching error rather than clientErr
 			return common.CheckDeletedDiag(d, err, "zone")
@@ -538,7 +538,7 @@ func resourceDNSZoneUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	region := conf.GetRegion(d)
 	var dnsClient *golangsdk.ServiceClient
 
-	dnsClient, err := conf.DnsV2Client(region)
+	dnsClient, err := conf.DNSV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -552,7 +552,7 @@ func resourceDNSZoneUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			return diag.Errorf("the argument (router) is required when updating DNS private zone")
 		}
 		// update the endpoint with region when creating private zone
-		dnsClient, err = conf.DnsWithRegionClient(conf.GetRegion(d))
+		dnsClient, err = conf.DNSWithRegionClient(conf.GetRegion(d))
 		if err != nil {
 			return diag.Errorf("error creating DNS region client: %s", err)
 		}
@@ -758,9 +758,9 @@ func resourceDNSZoneDelete(ctx context.Context, d *schema.ResourceData, meta int
 	zoneType := d.Get("zone_type").(string)
 	// update the endpoint with region when creating private zone
 	if zoneType == "private" {
-		dnsClient, err = conf.DnsWithRegionClient(conf.GetRegion(d))
+		dnsClient, err = conf.DNSWithRegionClient(conf.GetRegion(d))
 	} else {
-		dnsClient, err = conf.DnsV2Client(conf.GetRegion(d))
+		dnsClient, err = conf.DNSV2Client(conf.GetRegion(d))
 	}
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -606,9 +606,9 @@ func updateEipConfig(vpcV1Client *golangsdk.ServiceClient, d *schema.ResourceDat
 func updateEipPortId(vpcV1Client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	resourceId := d.Id()
 	timeout := d.Timeout(schema.TimeoutUpdate)
-	old, new := d.GetChange("publicip.0.port_id")
-	oldPort := old.(string)
-	newPort := new.(string)
+	oldVal, newVal := d.GetChange("publicip.0.port_id")
+	oldPort := oldVal.(string)
+	newPort := newVal.(string)
 
 	if oldPort != "" {
 		err := unbindPort(vpcV1Client, resourceId, oldPort, timeout)
@@ -657,9 +657,9 @@ func buildUpdatePublicipBodyParams(d *schema.ResourceData) map[string]interface{
 }
 
 func updateEipBandwidth(vpcV1Client *golangsdk.ServiceClient, cfg *config.Config, d *schema.ResourceData) error {
-	old, new := d.GetChange("bandwidth")
-	oldRaw := old.([]interface{})
-	newRaw := new.([]interface{})
+	oldVal, newVal := d.GetChange("bandwidth")
+	oldRaw := oldVal.([]interface{})
+	newRaw := newVal.([]interface{})
 	// Bandwidth blocks are required and must be present.
 	oldMap := oldRaw[0].(map[string]interface{})
 	newMap := newRaw[0].(map[string]interface{})

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_loadbalancers_by_tags.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_loadbalancers_by_tags.go
@@ -216,7 +216,6 @@ func dataSourceElbLoadbalancersByTagsRead(_ context.Context, d *schema.ResourceD
 	}
 
 	for {
-
 		if tagsAction == "filter" {
 			requestBody["offset"] = offset
 		}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -64,23 +64,23 @@ func ResourceLoadBalancerV3() *schema.Resource {
 
 		CustomizeDiff: customdiff.All(
 			config.FlexibleForceNew(loadBalancerNonUpdatableParams),
-			customdiff.ValidateChange("charging_mode", func(_ context.Context, old, new, _ any) error {
+			customdiff.ValidateChange("charging_mode", func(_ context.Context, oldVal, newVal, _ any) error {
 				// can only update from postPaid
-				if old.(string) != new.(string) && (old.(string) == "prePaid") {
+				if oldVal.(string) != newVal.(string) && (oldVal.(string) == "prePaid") {
 					return fmt.Errorf("charging_mode can only be updated from postPaid to prePaid")
 				}
 				return nil
 			}),
-			customdiff.ValidateChange("period_unit", func(_ context.Context, old, new, _ any) error {
+			customdiff.ValidateChange("period_unit", func(_ context.Context, oldVal, newVal, _ any) error {
 				// can only update from empty
-				if old.(string) != new.(string) && old.(string) != "" {
+				if oldVal.(string) != newVal.(string) && oldVal.(string) != "" {
 					return fmt.Errorf("period_unit can only be updated when changing charging_mode to prePaid")
 				}
 				return nil
 			}),
-			customdiff.ValidateChange("period", func(_ context.Context, old, new, _ any) error {
+			customdiff.ValidateChange("period", func(_ context.Context, oldVal, newVal, _ any) error {
 				// can only update from empty
-				if old.(int) != new.(int) && old.(int) != 0 {
+				if oldVal.(int) != newVal.(int) && oldVal.(int) != 0 {
 					return fmt.Errorf("period can only be updated when changing charging_mode to prePaid")
 				}
 				return nil

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_alarms.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_alarms.go
@@ -100,7 +100,6 @@ func buildAlarmsParams(d *schema.ResourceData) string {
 }
 
 func listAlarms(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
-
 	var (
 		httpUrl = "v3/{project_id}/alarm-history-record?limit={limit}"
 		result  = make([]interface{}, 0)

--- a/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -152,7 +152,7 @@ func ResourceGeminiDBInstanceV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, _, new string, _ *schema.ResourceData) bool {
 								return new == "GeminiDB-Cassandra"
 							},
 						},

--- a/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -152,8 +152,8 @@ func ResourceGeminiDBInstanceV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-							DiffSuppressFunc: func(_, _, new string, _ *schema.ResourceData) bool {
-								return new == "GeminiDB-Cassandra"
+							DiffSuppressFunc: func(_, _, newVal string, _ *schema.ResourceData) bool {
+								return newVal == "GeminiDB-Cassandra"
 							},
 						},
 						"storage_engine": {

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
@@ -119,8 +119,8 @@ func ResourceV3Provider() *schema.Resource {
 						"signing_key": {
 							Type:     schema.TypeString,
 							Required: true,
-							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+							DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+								equal, _ := utils.CompareJsonTemplateAreEquivalent(oldVal, newVal)
 								return equal
 							},
 							Description: `The public key used to sign the ID token of the OpenID Connect

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
@@ -119,7 +119,7 @@ func ResourceV3Provider() *schema.Resource {
 						"signing_key": {
 							Type:     schema.TypeString,
 							Required: true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
 								return equal
 							},

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_role.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_role.go
@@ -52,8 +52,8 @@ func ResourceV3Role() *schema.Resource {
 				Required:     true,
 				Description:  `The content of the custom policy, in JSON format.`,
 				ValidateFunc: validation.StringIsJSON,
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					equal, _ := utils.CompareJsonTemplateAreEquivalent(oldVal, newVal)
 					return equal
 				},
 			},

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_role.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_role.go
@@ -52,7 +52,7 @@ func ResourceV3Role() *schema.Resource {
 				Required:     true,
 				Description:  `The content of the custom policy, in JSON format.`,
 				ValidateFunc: validation.StringIsJSON,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
 					return equal
 				},

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_trust_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_trust_agency.go
@@ -56,8 +56,8 @@ func ResourceV3TrustAgency() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					equal, _ := utils.CompareJsonTemplateAreEquivalent(oldVal, newVal)
 					return equal
 				},
 				Description: `The trust policy of the trust agency.`,

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_custom_policy_attachment.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_custom_policy_attachment.go
@@ -51,7 +51,7 @@ func ResourceCustomPolicyAttachment() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `Specifies the custom policy to attach to a permission set.`,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
 					return equal
 				},

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_custom_policy_attachment.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_custom_policy_attachment.go
@@ -51,8 +51,8 @@ func ResourceCustomPolicyAttachment() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `Specifies the custom policy to attach to a permission set.`,
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					equal, _ := utils.CompareJsonTemplateAreEquivalent(oldVal, newVal)
 					return equal
 				},
 			},

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_custom_role_attachment.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_custom_role_attachment.go
@@ -51,8 +51,8 @@ func ResourceCustomRoleAttachment() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `Specifies the custom role to attach to a permission set.`,
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					equal, _ := utils.CompareJsonTemplateAreEquivalent(oldVal, newVal)
 					return equal
 				},
 			},

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_custom_role_attachment.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_custom_role_attachment.go
@@ -51,7 +51,7 @@ func ResourceCustomRoleAttachment() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `Specifies the custom role to attach to a permission set.`,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
 					return equal
 				},

--- a/huaweicloud/services/iec/resource_huaweicloud_iec_network_acl_rule.go
+++ b/huaweicloud/services/iec/resource_huaweicloud_iec_network_acl_rule.go
@@ -310,13 +310,13 @@ func getFirewallRuleEntity(fwPolicy firewalls.RespPolicyEntity, ruleID string) f
 	return firewalls.RespFirewallRulesEntity{}
 }
 
-func getNewFirewallRuleID(old []string, new []string) string {
+func getNewFirewallRuleID(oldVals []string, newVals []string) string {
 	ruleMap := make(map[string]int)
-	for _, v := range old {
+	for _, v := range oldVals {
 		ruleMap[v] = 1
 	}
 
-	for _, v := range new {
+	for _, v := range newVals {
 		if ruleMap[v] == 0 {
 			return v
 		}

--- a/huaweicloud/services/ims/resource_huaweicloud_images_image_copy.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_images_image_copy.go
@@ -392,7 +392,6 @@ func resourceImsImageCopyCreate(ctx context.Context, d *schema.ResourceData, met
 		if jobId == "" {
 			return diag.Errorf("error creating IMS image copy within region: job ID is not found in API response")
 		}
-
 	} else {
 		createPath := client.Endpoint + crossRegionCopyHttpUrl
 		createPath = strings.ReplaceAll(createPath, "{image_id}", sourceImageId)

--- a/huaweicloud/services/internal/httpclient-go/signer.go
+++ b/huaweicloud/services/internal/httpclient-go/signer.go
@@ -37,7 +37,8 @@ func CanonicalRequest(r *http.Request, signedHeaders []string) (string, error) {
 			return "", err
 		}
 	}
-	return fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", r.Method, CanonicalURI(r), CanonicalQueryString(r), CanonicalHeaders(r, signedHeaders), strings.Join(signedHeaders, ";"), hexencode), err
+	return fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", r.Method, CanonicalURI(r), CanonicalQueryString(r),
+		CanonicalHeaders(r, signedHeaders), strings.Join(signedHeaders, ";"), hexencode), err
 }
 
 //nolint:unused

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_permissions.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_permissions.go
@@ -146,7 +146,7 @@ func updateKafkaPermissions(client *golangsdk.ServiceClient, instanceId string, 
 	return err
 }
 
-func resourceDmsKafkaPermissionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDmsKafkaPermissionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_user.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_user.go
@@ -215,7 +215,7 @@ func buildUpdateDmsKafkaUserBodyParams(d *schema.ResourceData) map[string]interf
 	return bodyParams
 }
 
-func resourceDmsKafkaUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDmsKafkaUserDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/lb/lb_v2_shared.go
+++ b/huaweicloud/services/lb/lb_v2_shared.go
@@ -70,7 +70,6 @@ func resourceLBV2ListenerRefreshFunc(networkingClient *golangsdk.ServiceClient, 
 
 func waitForLBV2LoadBalancer(ctx context.Context, networkingClient *golangsdk.ServiceClient,
 	id string, target string, pending []string, timeout time.Duration) error {
-
 	log.Printf("[DEBUG] Waiting for loadbalancer %s to become %s", id, target)
 
 	stateConf := &retry.StateChangeConf{

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_certificate.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_certificate.go
@@ -259,7 +259,7 @@ func buildUpdateCertificateBodyParams(d *schema.ResourceData) map[string]interfa
 	return bodyParams
 }
 
-func resourceCertificateV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCertificateV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_l7policy.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_l7policy.go
@@ -300,7 +300,7 @@ func resourceL7PolicyV2Update(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[DEBUG] Updating L7 Policy %s with options: %#v", d.Id(), updateOpts)
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err = l7policies.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -351,7 +351,7 @@ func resourceL7PolicyV2Delete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[DEBUG] Attempting to delete L7 Policy %s", d.Id())
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err = l7policies.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_l7rule.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_l7rule.go
@@ -284,7 +284,7 @@ func resourceL7RuleV2Update(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Updating L7 Rule %s with options: %#v", d.Id(), updateOpts)
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err := l7policies.UpdateRule(lbClient, l7policyID, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -343,7 +343,7 @@ func resourceL7RuleV2Delete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Attempting to delete L7 Rule %s", d.Id())
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err = l7policies.DeleteRule(lbClient, l7policyID, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
@@ -222,7 +222,7 @@ func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Updating member %s with options: %#v", d.Id(), updateOpts)
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err = pools.UpdateMember(lbClient, poolID, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -259,7 +259,7 @@ func resourceMemberV2Delete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Attempting to delete member %s", d.Id())
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err = pools.DeleteMember(lbClient, poolID, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_pool.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_pool.go
@@ -322,7 +322,7 @@ func resourcePoolV2Update(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG] Updating pool %s with options: %#v", d.Id(), updateOpts)
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err = pools.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -366,7 +366,7 @@ func resourcePoolV2Delete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG] Attempting to delete pool %s", d.Id())
-	//lintignore:R006
+	// lintignore:R006
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err = pools.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_access_rule.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_access_rule.go
@@ -275,6 +275,6 @@ func resourceAomMappingRuleUpdate(_ context.Context, d *schema.ResourceData, met
 	return diag.Errorf("error update AomMappingRule %s:  %s", opts.RuleName, string(body))
 }
 
-func SuppressCaseDiffs(_, old, new string, _ *schema.ResourceData) bool {
-	return strings.Split(old, "_")[0] == strings.Split(new, "_")[0]
+func SuppressCaseDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	return strings.Split(oldVal, "_")[0] == strings.Split(newVal, "_")[0]
 }

--- a/huaweicloud/services/meeting/config.go
+++ b/huaweicloud/services/meeting/config.go
@@ -193,13 +193,13 @@ func getMeetingToken(conf *config.Config, opt AuthOpts) (string, error) {
 
 func buildAuthorization(username, password string) string {
 	authInfo := []byte(username + ":" + password)
-	auth := "Basic " + base64.StdEncoding.EncodeToString(authInfo)
-	return auth
+	authHeader := "Basic " + base64.StdEncoding.EncodeToString(authInfo)
+	return authHeader
 }
 
 // buildAppAccessToken returns a authorization string according to the SP/Administrator account informations.
 // Note: make sure the number is not a negative integer or a big integer.
-func buildAppAuthorization(appId, appKey, corpInfo, userId string, validPeriod int) (auth, nonce string, expireTime int) {
+func buildAppAuthorization(appId, appKey, corpInfo, userId string, validPeriod int) (authorization, nonce string, expireTime int) {
 	nonce = utils.RandomString(64)
 	duration := validPeriod * 60 * 60
 	expireTime = int(time.Now().Unix()) + duration
@@ -212,7 +212,7 @@ func buildAppAuthorization(appId, appKey, corpInfo, userId string, validPeriod i
 	if err != nil {
 		log.Printf("[ERROR] Failed to build app authorization: %v", err)
 	}
-	auth = fmt.Sprintf("%s signature=%s", BasicAlgorithm, hex.EncodeToString(hmac256))
+	authorization = fmt.Sprintf("%s signature=%s", BasicAlgorithm, hex.EncodeToString(hmac256))
 	return
 }
 

--- a/huaweicloud/services/meeting/resource_huaweicloud_meeting_admin_assignment.go
+++ b/huaweicloud/services/meeting/resource_huaweicloud_meeting_admin_assignment.go
@@ -146,7 +146,7 @@ func resourceAdminAssignmentDelete(_ context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceAdminAssignmentImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData,
+func resourceAdminAssignmentImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
 	var mErr *multierror.Error
 	parts := strings.Split(d.Id(), "/")

--- a/huaweicloud/services/meeting/resource_huaweicloud_meeting_conference.go
+++ b/huaweicloud/services/meeting/resource_huaweicloud_meeting_conference.go
@@ -729,7 +729,7 @@ func buildHistoryConferenceGetOpts(uuid, userId, token string) conferences.GetHi
 
 func buildHistoryConferenceListOpts(userId, startTime, token string, duration int) (conferences.ListHistoryOpts,
 	error) {
-	tm, err := time.Parse(standardTimeFormat, startTime)
+	nanoTimestamp, err := time.Parse(standardTimeFormat, startTime)
 	if err != nil {
 		return conferences.ListHistoryOpts{}, nil
 	}
@@ -737,8 +737,8 @@ func buildHistoryConferenceListOpts(userId, startTime, token string, duration in
 		UserUUID: userId,
 		// The time range here refers to the time range when the meeting starts, the actual start time depends on when
 		// the meeting is used.
-		StartDate: int(tm.Unix()) * 1000, //ms
-		EndDate:   (int(tm.Unix()) + duration*60) * 1000,
+		StartDate: int(nanoTimestamp.Unix()) * 1000,
+		EndDate:   (int(nanoTimestamp.Unix()) + duration*60) * 1000,
 		Limit:     500,
 		Token:     token,
 	}, nil

--- a/huaweicloud/services/meeting/resource_huaweicloud_meeting_conference.go
+++ b/huaweicloud/services/meeting/resource_huaweicloud_meeting_conference.go
@@ -1139,7 +1139,7 @@ func resourceConferenceDelete(_ context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func resourceConferenceImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData,
+func resourceConferenceImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
 	var mErr *multierror.Error
 	parts := strings.Split(d.Id(), "/")

--- a/huaweicloud/services/meeting/resource_huaweicloud_meeting_user.go
+++ b/huaweicloud/services/meeting/resource_huaweicloud_meeting_user.go
@@ -382,7 +382,7 @@ func resourceUserDelete(_ context.Context, d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func resourceUserManagementImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData,
+func resourceUserManagementImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
 	var mErr *multierror.Error
 	parts := strings.Split(d.Id(), "/")

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_model.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_model.go
@@ -146,8 +146,8 @@ func ResourceModelartsModel() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					return utils.JSONStringsEqual(old, new)
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					return utils.JSONStringsEqual(oldVal, newVal)
 				},
 				Description: `The model configuration file.`,
 			},

--- a/huaweicloud/services/mpc/resource_huaweicloud_mpc_transcoding_template.go
+++ b/huaweicloud/services/mpc/resource_huaweicloud_mpc_transcoding_template.go
@@ -32,7 +32,7 @@ func ResourceTranscodingTemplate() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		//request and response parameters
+		// request and response parameters
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/mpc/resource_huaweicloud_mpc_transcoding_template_group.go
+++ b/huaweicloud/services/mpc/resource_huaweicloud_mpc_transcoding_template_group.go
@@ -32,7 +32,7 @@ func ResourceTranscodingTemplateGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		//request and response parameters
+		// request and response parameters
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_job.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_job.go
@@ -496,7 +496,7 @@ func setMRSJobProperties(d *schema.ResourceData, resp string) error {
 
 func setMRSTimeProperties(d *schema.ResourceData, key string, value int) error {
 	keyTime := time.Unix(int64(value), 0)
-	//lintignore:R001
+	// lintignore:R001
 	return d.Set(key, keyTime.Format(time.RFC3339))
 }
 

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -596,7 +596,6 @@ func resourceObsBucketUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		if err := resourceObsBucketEnterpriseProjectIdUpdate(ctx, d, conf, obsClient, region); err != nil {
 			return diag.FromErr(err)
 		}
-
 	}
 
 	if d.HasChange("user_domain_names") {
@@ -953,7 +952,6 @@ func resourceObsBucketQuotaUpdate(obsClient *obs.ObsClient, d *schema.ResourceDa
 	}
 
 	return nil
-
 }
 
 // nolint:gocyclo

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -867,7 +867,7 @@ func resourceObsBucketVersioningUpdate(obsClient *obs.ObsClient, d *schema.Resou
 	return nil
 }
 
-func resourceObsBucketEncryptionUpdate(config *config.Config, obsClient *obs.ObsClient, d *schema.ResourceData) error {
+func resourceObsBucketEncryptionUpdate(_ *config.Config, obsClient *obs.ObsClient, d *schema.ResourceData) error {
 	bucket := d.Get("bucket").(string)
 
 	if d.Get("encryption").(bool) {

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_policy.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_policy.go
@@ -46,7 +46,7 @@ func ResourcePolicy() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `The policy text content to be added to the new policy.`,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
 					return equal
 				},

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_policy.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_policy.go
@@ -46,8 +46,8 @@ func ResourcePolicy() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `The policy text content to be added to the new policy.`,
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+				DiffSuppressFunc: func(_, oldRaw, newRaw string, _ *schema.ResourceData) bool {
+					equal, _ := utils.CompareJsonTemplateAreEquivalent(oldRaw, newRaw)
 					return equal
 				},
 			},

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_storage_types.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_storage_types.go
@@ -78,7 +78,7 @@ func StoragetypeStorageTypeSchema() *schema.Resource {
 	return &sc
 }
 
-func resourceStoragetypeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceStoragetypeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
@@ -285,7 +285,7 @@ func createBackupWaitingForStateCompleted(ctx context.Context, d *schema.Resourc
 	return err
 }
 
-func resourceBackupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBackupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -496,7 +496,7 @@ func deleteBackupWaitingForStateCompleted(ctx context.Context, d *schema.Resourc
 	return err
 }
 
-func backupImportState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func backupImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid format specified for import id, must be <instance_id>/<backup_id>")

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
@@ -502,8 +502,8 @@ func backupImportState(_ context.Context, d *schema.ResourceData, _ interface{})
 		return nil, fmt.Errorf("invalid format specified for import id, must be <instance_id>/<backup_id>")
 	}
 	instanceId := parts[0]
-	backup_id := parts[1]
-	d.SetId(backup_id)
+	backupId := parts[1]
+	d.SetId(backupId)
 	d.Set("instance_id", instanceId)
 	return []*schema.ResourceData{d}, nil
 }

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
@@ -149,7 +149,7 @@ func resourceBackupCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			200,
 		},
 	}
-	createBackupOpt.JSONBody = utils.RemoveNil(buildCreateBackupBodyParams(d, cfg))
+	createBackupOpt.JSONBody = utils.RemoveNil(buildCreateBackupBodyParams(d))
 	var createBackupResp *http.Response
 	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		createBackupResp, err = createBackupClient.Request("POST", createBackupPath, &createBackupOpt)
@@ -184,7 +184,7 @@ func resourceBackupCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return resourceBackupRead(ctx, d, meta)
 }
 
-func buildCreateBackupBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateBackupBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"name":        utils.ValueIgnoreEmpty(d.Get("name")),
 		"instance_id": utils.ValueIgnoreEmpty(d.Get("instance_id")),

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
@@ -574,9 +574,9 @@ func resourceRdsReadReplicaInstanceUpdate(ctx context.Context, d *schema.Resourc
 	return resourceRdsReadReplicaInstanceRead(ctx, d, meta)
 }
 
-func updateRdsInstanceAutoRenew(d *schema.ResourceData, config *config.Config) error {
+func updateRdsInstanceAutoRenew(d *schema.ResourceData, cfg *config.Config) error {
 	if d.HasChange("auto_renew") {
-		bssClient, err := config.BssV2Client(config.GetRegion(d))
+		bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
 		if err != nil {
 			return fmt.Errorf("error creating BSS V2 client: %s", err)
 		}

--- a/huaweicloud/services/rgc/resource_huaweicloud_rgc_best_practice.go
+++ b/huaweicloud/services/rgc/resource_huaweicloud_rgc_best_practice.go
@@ -139,7 +139,6 @@ func resourceBestPracticeRead(_ context.Context, d *schema.ResourceData, meta in
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
-
 }
 
 func resourceBestPracticeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {

--- a/huaweicloud/services/rgc/resource_huaweicloud_rgc_landing_zone.go
+++ b/huaweicloud/services/rgc/resource_huaweicloud_rgc_landing_zone.go
@@ -19,7 +19,13 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var landingZoneNonUpdatableParams = []string{"home_region", "organization_structure_type", "deny_ungoverned_regions", "kms_key_id", "organization_structure_type"}
+var landingZoneNonUpdatableParams = []string{
+	"home_region",
+	"organization_structure_type",
+	"deny_ungoverned_regions",
+	"kms_key_id",
+	"organization_structure_type",
+}
 
 // @API RGC POST /v1/landing-zone/setup
 // @API RGC GET /v1/landing-zone/status

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_application.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_application.go
@@ -107,10 +107,10 @@ func createEnvironmentVariables(client *golangsdk.ServiceClient, appId string, e
 		}
 
 		envId := envMap["id"].(string)
-		config := applications.Configuration{
+		cfg := applications.Configuration{
 			EnvVariables: variables,
 		}
-		if _, err := applications.UpdateConfig(client, appId, envId, config); err != nil {
+		if _, err := applications.UpdateConfig(client, appId, envId, cfg); err != nil {
 			return err
 		}
 	}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component_instance.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component_instance.go
@@ -931,19 +931,19 @@ func buildConfigurationStructure(configs []interface{}) (instances.Configuration
 		return instances.Configuration{}, nil
 	}
 
-	config := configs[0].(map[string]interface{})
-	probe, err := buildProbeStructure(config["probe"].([]interface{}))
+	cfg := configs[0].(map[string]interface{})
+	probe, err := buildProbeStructure(cfg["probe"].([]interface{}))
 	if err != nil {
 		return instances.Configuration{}, err
 	}
 
 	return instances.Configuration{
-		EnvVariables:          buildEnvVariables(config["env_variable"].(*schema.Set)),
-		Storages:              buildStoragesList(config["storage"].(*schema.Set)),
-		Strategy:              buildStrategyStructure(config["strategy"].([]interface{})),
-		Lifecycle:             buildLifecycleStructure(config["lifecycle"].([]interface{})),
-		LogCollectionPolicies: buildLogCollectionPoliciesStructure(config["log_collection_policy"].(*schema.Set)),
-		Scheduler:             buildSchedulerStructure(config["scheduler"].([]interface{})),
+		EnvVariables:          buildEnvVariables(cfg["env_variable"].(*schema.Set)),
+		Storages:              buildStoragesList(cfg["storage"].(*schema.Set)),
+		Strategy:              buildStrategyStructure(cfg["strategy"].([]interface{})),
+		Lifecycle:             buildLifecycleStructure(cfg["lifecycle"].([]interface{})),
+		LogCollectionPolicies: buildLogCollectionPoliciesStructure(cfg["log_collection_policy"].(*schema.Set)),
+		Scheduler:             buildSchedulerStructure(cfg["scheduler"].([]interface{})),
 		Probe:                 probe,
 	}, nil
 }

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_server_template.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_server_template.go
@@ -161,7 +161,6 @@ func buildNicsOpts(client *golangsdk.ServiceClient, nics []string) ([]templates.
 				Cidr: rst.CIDR,
 			}
 		}
-
 	}
 	return request, nil
 }
@@ -194,7 +193,6 @@ func buildSecGroupOpts(client *golangsdk.ServiceClient, sgs []string) ([]templat
 				Name: rst.Name,
 			}
 		}
-
 	}
 	return request, nil
 }

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_server_template.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_server_template.go
@@ -284,11 +284,11 @@ func resourceServerTemplateCreate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func flattenSubnetIDs(nics []templates.NicObject) []string {
-	subnets := make([]string, len(nics))
+	subnetIds := make([]string, len(nics))
 	for i, nic := range nics {
-		subnets[i] = nic.Id
+		subnetIds[i] = nic.Id
 	}
-	return subnets
+	return subnetIds
 }
 
 func flattenSecGroupIDs(groups []templates.SgObject) []string {

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_task.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_task.go
@@ -948,7 +948,7 @@ func buildUpdateTaskSpeedLimitBodyParams(rawParams []interface{}) map[string]int
 	return bodyParams
 }
 
-func resourceMigrateTaskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMigrateTaskDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	smsClient, err := cfg.SmsV3Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/tms/resource_huaweicloud_tms_resource_tags.go
+++ b/huaweicloud/services/tms/resource_huaweicloud_tms_resource_tags.go
@@ -81,10 +81,10 @@ func buildResourcesInfo(resources []interface{}) []tags.Resource {
 
 	result := make([]tags.Resource, len(resources))
 	for i, val := range resources {
-		resource := val.(map[string]interface{})
+		resourceMap := val.(map[string]interface{})
 		result[i] = tags.Resource{
-			ResourceType: resource["resource_type"].(string),
-			ResourceId:   resource["resource_id"].(string),
+			ResourceType: resourceMap["resource_type"].(string),
+			ResourceId:   resourceMap["resource_id"].(string),
 		}
 	}
 	return result
@@ -215,11 +215,11 @@ func GetResourceTags(client *golangsdk.ServiceClient, d *schema.ResourceData) ([
 	// Check whether all tagged resources contain the expected tags correctly. If not, inconsistent tags information
 	// will be printed in the log.
 	for _, val := range resources {
-		resource := val.(map[string]interface{})
-		resourceId := resource["resource_id"].(string)
+		resourceMap := val.(map[string]interface{})
+		resourceId := resourceMap["resource_id"].(string)
 		opts := tags.QueryOpts{
 			ResourceId:   resourceId,
-			ResourceType: resource["resource_type"].(string),
+			ResourceType: resourceMap["resource_type"].(string),
 			ProjectId:    projectId,
 		}
 		resp, err := tags.Get(client, opts)

--- a/huaweicloud/services/vod/resource_huaweicloud_vod_media_asset.go
+++ b/huaweicloud/services/vod/resource_huaweicloud_vod_media_asset.go
@@ -42,7 +42,7 @@ func ResourceMediaAsset() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Second),
 		},
 
-		//request and response parameters
+		// request and response parameters
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/vod/resource_huaweicloud_vod_media_category.go
+++ b/huaweicloud/services/vod/resource_huaweicloud_vod_media_category.go
@@ -32,7 +32,7 @@ func ResourceMediaCategory() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		//request and response parameters
+		// request and response parameters
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/vod/resource_huaweicloud_vod_transcoding_template_group.go
+++ b/huaweicloud/services/vod/resource_huaweicloud_vod_transcoding_template_group.go
@@ -31,7 +31,7 @@ func ResourceTranscodingTemplateGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		//request and response parameters
+		// request and response parameters
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/vod/resource_huaweicloud_vod_watermark_template.go
+++ b/huaweicloud/services/vod/resource_huaweicloud_vod_watermark_template.go
@@ -39,7 +39,7 @@ func ResourceWatermarkTemplate() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		//request and response parameters
+		// request and response parameters
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
@@ -155,7 +155,7 @@ func getNetworkingPortOpts(d *schema.ResourceData) ports.ListOpts {
 	return listOpts
 }
 
-func dataSourceNetworkingPortV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceNetworkingPortV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_route_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_route_ids.go
@@ -63,7 +63,6 @@ func dataSourceVpcRouteIdsV2Read(d *schema.ResourceData, meta interface{}) error
 
 	for _, route := range refinedRoutes {
 		listRoutes = append(listRoutes, route.RouteID)
-
 	}
 
 	d.SetId(d.Get("vpc_id").(string))

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
@@ -193,7 +193,7 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] Retrieved subnets using given filter: %+v", subnetList)
 
-	var subnets []map[string]interface{}
+	var subnetInfos []map[string]interface{}
 	tagFilter := d.Get("tags").(map[string]interface{})
 	var ids []string
 	for _, item := range subnetList {
@@ -229,12 +229,12 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 			log.Printf("[WARN] error query tags of subnets (%s): %s", item.ID, err)
 		}
 
-		subnets = append(subnets, subnet)
+		subnetInfos = append(subnetInfos, subnet)
 		ids = append(ids, item.ID)
 	}
-	log.Printf("[DEBUG] Subnets List after filter, count=%d :%+v", len(subnets), subnets)
+	log.Printf("[DEBUG] Subnets List after filter, count=%d :%+v", len(subnetInfos), subnetInfos)
 
-	mErr := d.Set("subnets", subnets)
+	mErr := d.Set("subnets", subnetInfos)
 	if mErr != nil {
 		return diag.Errorf("set subnets err:%s", mErr)
 	}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
@@ -133,7 +133,7 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 
 	log.Printf("[DEBUG] retrieved VPC using given filter: %+v", vpcList)
 
-	var vpcs []map[string]interface{}
+	var vpcInfos []map[string]interface{}
 	tagFilter := d.Get("tags").(map[string]interface{})
 	var ids []string
 	for _, vpcResource := range vpcList {
@@ -169,12 +169,12 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 		}
 		vpc["secondary_cidrs"] = utils.PathSearch("vpc.extend_cidrs", res, nil)
 
-		vpcs = append(vpcs, vpc)
+		vpcInfos = append(vpcInfos, vpc)
 		ids = append(ids, vpcResource.ID)
 	}
-	log.Printf("[DEBUG] VPC List after filter, count: %d vpcs: %+v", len(vpcs), vpcs)
+	log.Printf("[DEBUG] VPC List after filter, count: %d vpcs: %+v", len(vpcInfos), vpcInfos)
 
-	mErr := d.Set("vpcs", vpcs)
+	mErr := d.Set("vpcs", vpcInfos)
 	if mErr != nil {
 		return diag.Errorf("set vpcs err: %s", mErr)
 	}

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup.go
@@ -451,8 +451,8 @@ func resourceNetworkingSecGroupUpdate(ctx context.Context, d *schema.ResourceDat
 	return resourceNetworkingSecGroupRead(ctx, d, meta)
 }
 
-func resourceNetworkingSecGroupUpdateV2(d *schema.ResourceData, config *config.Config, region string) error {
-	v2Client, err := config.NetworkingV2Client(region)
+func resourceNetworkingSecGroupUpdateV2(d *schema.ResourceData, cfg *config.Config, region string) error {
+	v2Client, err := cfg.NetworkingV2Client(region)
 	if err != nil {
 		return fmt.Errorf("error creating networking v2 client: %s", err)
 	}

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
@@ -142,8 +142,8 @@ func resourceNetworkingVIPAssociateV2Create(ctx context.Context, d *schema.Resou
 	}
 
 	portids := resourceNetworkingPortIDs(d)
-	if diag := updateNetworkingVIPAssociate(networkingClient, vipID, portids); diag != nil {
-		return diag
+	if diags := updateNetworkingVIPAssociate(networkingClient, vipID, portids); diags != nil {
+		return diags
 	}
 
 	// set id
@@ -166,8 +166,8 @@ func resourceNetworkingVIPAssociateV2Update(ctx context.Context, d *schema.Resou
 	}
 
 	portids := resourceNetworkingPortIDs(d)
-	if diag := updateNetworkingVIPAssociate(networkingClient, vipID, portids); diag != nil {
-		return diag
+	if diags := updateNetworkingVIPAssociate(networkingClient, vipID, portids); diags != nil {
+		return diags
 	}
 
 	return resourceNetworkingVIPAssociateV2Read(ctx, d, meta)

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
@@ -173,7 +173,7 @@ func resourceNetworkingVIPAssociateV2Update(ctx context.Context, d *schema.Resou
 	return resourceNetworkingVIPAssociateV2Read(ctx, d, meta)
 }
 
-func resourceNetworkingVIPAssociateV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkingVIPAssociateV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -255,7 +255,7 @@ func resourceNetworkingVIPAssociateV2Delete(_ context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceNetworkingVIPAssociateV2Import(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceNetworkingVIPAssociateV2Import(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid format specified for import id, must be <vip_id>/<port_id>," +

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -439,7 +439,6 @@ func waitForVpcActive(vpcClient *golangsdk.ServiceClient, vpcId string) retry.St
 
 func waitForVpcDelete(vpcClient *golangsdk.ServiceClient, vpcId string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-
 		r, err := vpcs.Get(vpcClient, vpcId).Extract()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
@@ -146,7 +146,6 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	return resourceVpcRouteTableRead(ctx, d, meta)
-
 }
 
 func resourceVpcRouteTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
@@ -197,9 +197,9 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 		changed = true
 		routesOpts := map[string][]routetables.RouteOpts{}
 
-		old, new := d.GetChange("route")
-		addRaws := new.(*schema.Set).Difference(old.(*schema.Set))
-		delRaws := old.(*schema.Set).Difference(new.(*schema.Set))
+		oldVal, newVal := d.GetChange("route")
+		addRaws := newVal.(*schema.Set).Difference(oldVal.(*schema.Set))
+		delRaws := oldVal.(*schema.Set).Difference(newVal.(*schema.Set))
 
 		var filteredMod []interface{}
 
@@ -291,9 +291,9 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if d.HasChange("subnets") {
-		old, new := d.GetChange("subnets")
-		associateRaws := new.(*schema.Set).Difference(old.(*schema.Set))
-		disassociateRaws := old.(*schema.Set).Difference(new.(*schema.Set))
+		oldVal, newVal := d.GetChange("subnets")
+		associateRaws := newVal.(*schema.Set).Difference(oldVal.(*schema.Set))
+		disassociateRaws := oldVal.(*schema.Set).Difference(newVal.(*schema.Set))
 
 		disassociateSubnets := utils.ExpandToStringList(disassociateRaws.List())
 		if len(disassociateSubnets) > 0 {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -75,7 +75,7 @@ func buildSubnetDNSList(d *schema.ResourceData, cfg *config.Config, region strin
 	// public DNS: 8.8.8.8(google-public-dns-a.google.com) and 114.114.114.114(China)
 	publicDNSList := []string{"8.8.8.8", "114.114.114.114"}
 
-	dnsClient, err := cfg.DnsWithRegionClient(region)
+	dnsClient, err := cfg.DNSWithRegionClient(region)
 	if err != nil {
 		log.Printf("[WARN] cannot generate DNS client, use %v as the DNS list", publicDNSList)
 		return publicDNSList

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -349,8 +349,8 @@ func resourceVpcSubnetCreate(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 // GetVpcSubnetById is a method to obtain subnet informations from special region through subnet ID.
-func GetVpcSubnetById(config *config.Config, region, networkId string) (*subnets.Subnet, error) {
-	subnetClient, err := config.NetworkingV1Client(region)
+func GetVpcSubnetById(cfg *config.Config, region, networkId string) (*subnets.Subnet, error) {
+	subnetClient, err := cfg.NetworkingV1Client(region)
 	if err != nil {
 		return nil, err
 	}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -345,7 +345,6 @@ func resourceVpcSubnetCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	return resourceVpcSubnetRead(ctx, d, cfg)
-
 }
 
 // GetVpcSubnetById is a method to obtain subnet informations from special region through subnet ID.
@@ -487,7 +486,6 @@ func resourceVpcSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceVpcSubnetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	cfg := meta.(*config.Config)
 	subnetClient, err := cfg.NetworkingV1Client(cfg.GetRegion(d))
 	if err != nil {
@@ -535,7 +533,6 @@ func waitForVpcSubnetActive(subnetClient *golangsdk.ServiceClient, vpcId string)
 
 func waitForVpcSubnetDelete(subnetClient *golangsdk.ServiceClient, vpcId string, subnetId string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-
 		r, err := subnets.Get(subnetClient, subnetId).Extract()
 
 		if err != nil {

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_pool.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_pool.go
@@ -1064,7 +1064,6 @@ func getDesktopPoolDataVolumesDiff(d *schema.ResourceData, oldDataVolumes []inte
 			}
 			oldDataVolumesCopy = append(oldDataVolumesCopy[:idx], oldDataVolumesCopy[idx+1:]...)
 		}
-
 	}
 
 	rmVolumes = oldDataVolumesCopy

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
@@ -178,7 +178,7 @@ func parseUserAccountExpires(expires int) string {
 	return utils.FormatTimeStampRFC3339(int64(expires/1000), false, RFC3339NoT)
 }
 
-func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	client, err := conf.WorkspaceV2Client(region)
@@ -253,7 +253,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return resourceUserRead(ctx, d, meta)
 }
 
-func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := conf.WorkspaceV2Client(conf.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/utils/resource_diff.go
+++ b/huaweicloud/utils/resource_diff.go
@@ -30,7 +30,7 @@ func ComposeAnySchemaDiffSuppressFunc(fs ...schema.SchemaDiffSuppressFunc) schem
 	}
 }
 
-func SuppressEquivalentAwsPolicyDiffs(_, old, new string, d *schema.ResourceData) bool {
+func SuppressEquivalentAwsPolicyDiffs(_, old, new string, _ *schema.ResourceData) bool {
 	equivalent, err := awspolicy.PoliciesAreEquivalent(old, new)
 	if err != nil {
 		return false
@@ -40,7 +40,7 @@ func SuppressEquivalentAwsPolicyDiffs(_, old, new string, d *schema.ResourceData
 }
 
 // Suppress all changes
-func SuppressDiffAll(k, old, new string, d *schema.ResourceData) bool {
+func SuppressDiffAll(_, _, _ string, _ *schema.ResourceData) bool {
 	return true
 }
 
@@ -53,12 +53,12 @@ func SuppressCaseDiffs() schema.SchemaDiffSuppressFunc {
 }
 
 // Suppress changes if we get a computed min_disk_gb if value is unspecified (default 0)
-func SuppressMinDisk(k, old, new string, d *schema.ResourceData) bool {
+func SuppressMinDisk(_, old, new string, _ *schema.ResourceData) bool {
 	return new == "0" || old == new
 }
 
 // Suppress changes if we get a base64 format or plaint text user_data
-func SuppressUserData(k, old, new string, d *schema.ResourceData) bool {
+func SuppressUserData(_, old, new string, _ *schema.ResourceData) bool {
 	// user_data is in base64 format
 	if HashAndHexEncode(old) == new {
 		return true
@@ -78,7 +78,7 @@ func SuppressTrimSpace(_, old, new string, _ *schema.ResourceData) bool {
 	return strings.TrimSpace(old) == strings.TrimSpace(new)
 }
 
-func SuppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {
+func SuppressLBWhitelistDiffs(_, old, new string, _ *schema.ResourceData) bool {
 	if len(old) != len(new) {
 		return false
 	}
@@ -90,7 +90,7 @@ func SuppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {
 	return reflect.DeepEqual(old_array, new_array)
 }
 
-func SuppressSnatFiplistDiffs(k, old, new string, d *schema.ResourceData) bool {
+func SuppressSnatFiplistDiffs(_, old, new string, _ *schema.ResourceData) bool {
 	if len(old) != len(new) {
 		return false
 	}
@@ -103,11 +103,11 @@ func SuppressSnatFiplistDiffs(k, old, new string, d *schema.ResourceData) bool {
 }
 
 // Suppress changes if we get a string with or without new line
-func SuppressNewLineDiffs(k, old, new string, d *schema.ResourceData) bool {
+func SuppressNewLineDiffs(_, old, new string, _ *schema.ResourceData) bool {
 	return strings.Trim(old, "\n") == strings.Trim(new, "\n")
 }
 
-func SuppressVersionDiffs(k, old, new string, d *schema.ResourceData) bool {
+func SuppressVersionDiffs(_, old, new string, _ *schema.ResourceData) bool {
 	oldArray := regexp.MustCompile(`[\.\-]+`).Split(old, -1)
 	newArray := regexp.MustCompile(`[\.\-]+`).Split(new, -1)
 	if len(newArray) > len(oldArray) {

--- a/huaweicloud/utils/resource_diff.go
+++ b/huaweicloud/utils/resource_diff.go
@@ -30,7 +30,7 @@ func ComposeAnySchemaDiffSuppressFunc(fs ...schema.SchemaDiffSuppressFunc) schem
 	}
 }
 
-func SuppressEquivalentAwsPolicyDiffs(k, old, new string, d *schema.ResourceData) bool {
+func SuppressEquivalentAwsPolicyDiffs(_, old, new string, d *schema.ResourceData) bool {
 	equivalent, err := awspolicy.PoliciesAreEquivalent(old, new)
 	if err != nil {
 		return false

--- a/huaweicloud/utils/resource_diff.go
+++ b/huaweicloud/utils/resource_diff.go
@@ -82,24 +82,24 @@ func SuppressLBWhitelistDiffs(_, oldVal, newVal string, _ *schema.ResourceData) 
 	if len(oldVal) != len(newVal) {
 		return false
 	}
-	old_array := strings.Split(oldVal, ",")
-	new_array := strings.Split(newVal, ",")
-	sort.Strings(old_array)
-	sort.Strings(new_array)
+	oldArray := strings.Split(oldVal, ",")
+	newArray := strings.Split(newVal, ",")
+	sort.Strings(oldArray)
+	sort.Strings(newArray)
 
-	return reflect.DeepEqual(old_array, new_array)
+	return reflect.DeepEqual(oldArray, newArray)
 }
 
 func SuppressSnatFiplistDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
 	if len(oldVal) != len(newVal) {
 		return false
 	}
-	old_array := strings.Split(oldVal, ",")
-	new_array := strings.Split(newVal, ",")
-	sort.Strings(old_array)
-	sort.Strings(new_array)
+	oldArray := strings.Split(oldVal, ",")
+	newArray := strings.Split(newVal, ",")
+	sort.Strings(oldArray)
+	sort.Strings(newArray)
 
-	return reflect.DeepEqual(old_array, new_array)
+	return reflect.DeepEqual(oldArray, newArray)
 }
 
 // Suppress changes if we get a string with or without new line

--- a/huaweicloud/utils/resource_diff.go
+++ b/huaweicloud/utils/resource_diff.go
@@ -30,8 +30,8 @@ func ComposeAnySchemaDiffSuppressFunc(fs ...schema.SchemaDiffSuppressFunc) schem
 	}
 }
 
-func SuppressEquivalentAwsPolicyDiffs(_, old, new string, _ *schema.ResourceData) bool {
-	equivalent, err := awspolicy.PoliciesAreEquivalent(old, new)
+func SuppressEquivalentAwsPolicyDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	equivalent, err := awspolicy.PoliciesAreEquivalent(oldVal, newVal)
 	if err != nil {
 		return false
 	}
@@ -53,20 +53,20 @@ func SuppressCaseDiffs() schema.SchemaDiffSuppressFunc {
 }
 
 // Suppress changes if we get a computed min_disk_gb if value is unspecified (default 0)
-func SuppressMinDisk(_, old, new string, _ *schema.ResourceData) bool {
-	return new == "0" || old == new
+func SuppressMinDisk(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	return newVal == "0" || oldVal == newVal
 }
 
 // Suppress changes if we get a base64 format or plaint text user_data
-func SuppressUserData(_, old, new string, _ *schema.ResourceData) bool {
+func SuppressUserData(_, oldVal, newVal string, _ *schema.ResourceData) bool {
 	// user_data is in base64 format
-	if HashAndHexEncode(old) == new {
+	if HashAndHexEncode(oldVal) == newVal {
 		return true
 	}
 
 	// user_data is plaint text
-	if plaint, err := base64.StdEncoding.DecodeString(old); err == nil {
-		if HashAndHexEncode(string(plaint)) == new {
+	if plaint, err := base64.StdEncoding.DecodeString(oldVal); err == nil {
+		if HashAndHexEncode(string(plaint)) == newVal {
 			return true
 		}
 	}
@@ -74,28 +74,28 @@ func SuppressUserData(_, old, new string, _ *schema.ResourceData) bool {
 	return false
 }
 
-func SuppressTrimSpace(_, old, new string, _ *schema.ResourceData) bool {
-	return strings.TrimSpace(old) == strings.TrimSpace(new)
+func SuppressTrimSpace(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	return strings.TrimSpace(oldVal) == strings.TrimSpace(newVal)
 }
 
-func SuppressLBWhitelistDiffs(_, old, new string, _ *schema.ResourceData) bool {
-	if len(old) != len(new) {
+func SuppressLBWhitelistDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	if len(oldVal) != len(newVal) {
 		return false
 	}
-	old_array := strings.Split(old, ",")
-	new_array := strings.Split(new, ",")
+	old_array := strings.Split(oldVal, ",")
+	new_array := strings.Split(newVal, ",")
 	sort.Strings(old_array)
 	sort.Strings(new_array)
 
 	return reflect.DeepEqual(old_array, new_array)
 }
 
-func SuppressSnatFiplistDiffs(_, old, new string, _ *schema.ResourceData) bool {
-	if len(old) != len(new) {
+func SuppressSnatFiplistDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	if len(oldVal) != len(newVal) {
 		return false
 	}
-	old_array := strings.Split(old, ",")
-	new_array := strings.Split(new, ",")
+	old_array := strings.Split(oldVal, ",")
+	new_array := strings.Split(newVal, ",")
 	sort.Strings(old_array)
 	sort.Strings(new_array)
 
@@ -103,13 +103,13 @@ func SuppressSnatFiplistDiffs(_, old, new string, _ *schema.ResourceData) bool {
 }
 
 // Suppress changes if we get a string with or without new line
-func SuppressNewLineDiffs(_, old, new string, _ *schema.ResourceData) bool {
-	return strings.Trim(old, "\n") == strings.Trim(new, "\n")
+func SuppressNewLineDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	return strings.Trim(oldVal, "\n") == strings.Trim(newVal, "\n")
 }
 
-func SuppressVersionDiffs(_, old, new string, _ *schema.ResourceData) bool {
-	oldArray := regexp.MustCompile(`[\.\-]+`).Split(old, -1)
-	newArray := regexp.MustCompile(`[\.\-]+`).Split(new, -1)
+func SuppressVersionDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	oldArray := regexp.MustCompile(`[\.\-]+`).Split(oldVal, -1)
+	newArray := regexp.MustCompile(`[\.\-]+`).Split(newVal, -1)
 	if len(newArray) > len(oldArray) {
 		return false
 	}
@@ -152,12 +152,12 @@ func CompareJsonTemplateAreEquivalent(tem1, tem2 string) (bool, error) {
 	return equal, nil
 }
 
-func SuppressStringSepratedByCommaDiffs(_, old, new string, _ *schema.ResourceData) bool {
-	if len(old) != len(new) {
+func SuppressStringSepratedByCommaDiffs(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	if len(oldVal) != len(newVal) {
 		return false
 	}
-	oldArray := strings.Split(old, ",")
-	newArray := strings.Split(new, ",")
+	oldArray := strings.Split(oldVal, ",")
+	newArray := strings.Split(newVal, ",")
 	sort.Strings(oldArray)
 	sort.Strings(newArray)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Correct incorrect comment formatting (comment-spacings)
2. Resolve revive import-shadowing lint errors by renaming conflict variables (import-shadowing)
   + Variable names cannot be the same as imported package names.

3. Replace unused input parameters with underscore (_).
4. Adjust line length、empty lines and sort package imports
   + Line breaks for lines exceeding 150 characters
   + Remove extra blank lines
   + Sort imported packages in the order: standard library packages, third-party library packages, local project packages 

5. Rename variables shadowing built-in identifiers
   + Rename local variables that conflict with Go built-in functions (new, delete) to resolve revive redefines-builtin-id warnings.

6. Correcting non-standard variables and methods naming.
   - Convert snake_case variable names to camelCase
   - Standardize abbreviations like DNS, HTTP, URL


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
