### PR TITLE
chore(dependency): replace go-cleanhttp with stdlib http client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/chnsz/golangsdk v0.0.0-20260514121205-83ad1d270e52
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-multierror v1.1.2-0.20250313123807-1ee6e1a1957a
 	github.com/hashicorp/go-uuid v1.0.3
@@ -32,6 +31,7 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect

--- a/huaweicloud/helper/internal/vault/pgpkeys/keybase.go
+++ b/huaweicloud/helper/internal/vault/pgpkeys/keybase.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/internal/vault/sdk/jsonutil"
 )
@@ -42,11 +43,18 @@ type keybaseLookupResponse struct {
 // doesn't use their client code due to both the API and the fact that it is
 // considered alpha and probably best not to rely on it.  The keys are returned
 // as base64-encoded strings.
-func FetchKeybasePubkeys(input []string) (map[string]string, error) {
-	client := cleanhttp.DefaultClient()
-	if client == nil {
-		return nil, fmt.Errorf("unable to create an http client")
+func defaultHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
+	transport.MaxIdleConnsPerHost = -1
+	return &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
 	}
+}
+
+func FetchKeybasePubkeys(input []string) (map[string]string, error) {
+	client := defaultHTTPClient()
 
 	if len(input) == 0 {
 		return nil, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove the direct dependency on the EOM library `github.com/hashicorp/go-cleanhttp` and replace it with an equivalent HTTP client implementation using the Go standard library.
`go-cleanhttp` last stable release is v0.5.2 (2021) and is no longer maintained. Analysis showed the provider only referenced it directly in `keybase.go`, used when the IAM Access Key `pgp_key` parameter is prefixed with `keybase:` to fetch public keys from the Keybase API. This is a one-shot, short-lived HTTP request scenario that can be fully replaced with `http.Transport.Clone()` from the standard library.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add `defaultHTTPClient()` using `http.Transport.Clone()` to create an isolated HTTP client
2. Disable keep-alives and set a 30s timeout, matching `cleanhttp.DefaultClient()` behavior
3. Remove the `github.com/hashicorp/go-cleanhttp` import
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV3AccessKey_withPgpKey
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3AccessKey_withPgpKey -timeout 360m -parallel 10
=== RUN   TestAccV3AccessKey_withPgpKey
=== PAUSE TestAccV3AccessKey_withPgpKey
=== CONT  TestAccV3AccessKey_withPgpKey
--- PASS: TestAccV3AccessKey_withPgpKey (18.60s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       18.777s coverage: 3.0% of statements in ./huaweicloud/services/iam
```

```
go test -v ./huaweicloud/helper/encryption/... -run 'TestRetrieveGPGKey_base64PublicKey|TestEncryptValue'
=== RUN   TestRetrieveGPGKey_base64PublicKey
--- PASS: TestRetrieveGPGKey_base64PublicKey (0.00s)
=== RUN   TestEncryptValue
--- PASS: TestEncryptValue (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/encryption     0.069s
```

```
go test -v ./huaweicloud/helper/internal/vault/pgpkeys/...
=== RUN   TestFetchKeybasePubkeys
--- PASS: TestFetchKeybasePubkeys (1.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/internal/vault/pgpkeys 1.798s
```


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
