### PR TITLE
test(accessanalyzer): ignore two not-computed parameter's chagne

### DIFF
--- a/huaweicloud/services/acceptance/accessanalyzer/resource_huaweicloud_access_analyzer_test.go
+++ b/huaweicloud/services/acceptance/accessanalyzer/resource_huaweicloud_access_analyzer_test.go
@@ -109,6 +109,13 @@ resource "huaweicloud_access_analyzer" "test" {
     foo        = "bar_update"
     key_update = "value_update"
   }
+
+  lifecycle {
+    ignore_changes = [
+      last_analyzed_resource,
+      last_resource_analyzed_at,
+    ]
+  }
 }
 `, rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The basic acceptance test report this following error:
<img width="635" height="326" alt="image" src="https://github.com/user-attachments/assets/b656652d-b500-45a1-9a3f-118b595e21dd" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. ignore two not-computed parameter's chagne
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o accessanalyzer -f TestAccAnalyzer
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/accessanalyzer" -v -coverprofile="./huaweicloud/services/acceptance/accessanalyzer/accessanalyzer_coverage.cov" -coverpkg="./huaweicloud/services/accessanalyzer" -run TestAccAnalyzer -timeout 360m -parallel 10
=== RUN   TestAccAnalyzer_basic
=== PAUSE TestAccAnalyzer_basic
=== RUN   TestAccAnalyzer_unused
=== PAUSE TestAccAnalyzer_unused
=== CONT  TestAccAnalyzer_basic
=== CONT  TestAccAnalyzer_unused
--- PASS: TestAccAnalyzer_unused (16.22s)
--- PASS: TestAccAnalyzer_basic (26.24s)
PASS
coverage: 28.7% of statements in ./huaweicloud/services/accessanalyzer
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/accessanalyzer    26.338s coverage: 28.7% of statements in ./huaweicloud/services/accessanalyzer
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
