### PR TITLE
feat(GaussDB): add data source to get the list of database versions

### DIFF
--- a/docs/data-sources/gaussdb_datastore_versions.md
+++ b/docs/data-sources/gaussdb_datastore_versions.md
@@ -1,0 +1,67 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_datastore_versions"
+description: |-
+  Use this data source to get the list of database versions within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_datastore_versions
+
+Use this data source to get the list of database versions within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_gaussdb_datastore_versions" "test" {}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the ID of the data source.
+
+* `database_versions` - Indicates the list of database versions.
+
+  The [database_versions](#database_versions_struct) structure is documented below.
+
+<a name="database_versions_struct"></a>
+The `database_versions` block supports:
+
+* `software_version` - Indicates the three-digit DB engine version.
+
+* `hotfixes` - Indicates the hot patch information corresponding to the three-digit DB engine version.
+
+  The [hotfixes](#hotfixes_struct) structure is documented below.
+
+<a name="hotfixes_struct"></a>
+The `hotfixes` block supports:
+
+* `version` - Indicates the hot patch version.
+
+* `create_time` - Indicates the creation time of the hot patch. The value is a UNIX timestamp in milliseconds.
+
+* `deploy_modes` - Indicates the deployment model information of the instance for which the hot patch can be installed.
+
+  The [deploy_modes](#deploy_modes_struct) structure is documented below.
+
+<a name="deploy_modes_struct"></a>
+The `deploy_modes` block supports:
+
+* `default_upgrade` - Indicates the Default patch fix policy.
+  + **true**: You do not need to select the hot patch version to be installed.
+  The current hot patch is installed by default.
+  + **false**: You need to select the hot patch version to be installed.
+
+* `update_time` - Indicates the modify time of the hot patch installation policy.
+  The value is a UNIX timestamp in milliseconds.
+
+* `mode` - Indicates the deployment model of the instance for which the patch can be installed.
+  + **distributed**: The deployment model can be either independent or combined (basic edition).
+  + **centralization_standard**: The deployment model can be centralized.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1585,6 +1585,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_instance_auto_enlarge_policy":    gaussdb.DataSourceGaussDBInstanceAutoEnlargePolicy(),
 			"huaweicloud_gaussdb_storage_types":                   gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastore_instances":             gaussdb.DataSourceDatastoreInstances(),
+			"huaweicloud_gaussdb_datastore_versions":              gaussdb.DataSourceDatastoreVersions(),
 			"huaweicloud_gaussdb_datastores":                      gaussdb.DataSourceGaussDbDatastores(),
 			"huaweicloud_gaussdb_flavors":                         gaussdb.DataSourceGaussDbFlavors(),
 			"huaweicloud_gaussdb_available_flavors":               gaussdb.DataSourceGaussDbAvailableFlavors(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_datastore_versions_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_datastore_versions_test.go
@@ -1,0 +1,42 @@
+package gaussdb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDatastoreVersions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_gaussdb_datastore_versions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDatastoreVersions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.0.software_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.0.hotfixes.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.0.hotfixes.0.version"),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.0.hotfixes.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.0.hotfixes.0.deploy_modes.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.0.hotfixes.0.deploy_modes.0.default_upgrade"),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.0.hotfixes.0.deploy_modes.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "database_versions.0.hotfixes.0.deploy_modes.0.mode"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceDatastoreVersions_basic = `data "huaweicloud_gaussdb_datastore_versions" "test" {}`

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_datastore_versions.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_datastore_versions.go
@@ -1,0 +1,207 @@
+package gaussdb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3.2/{project_id}/datastore/versions
+func DataSourceDatastoreVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDatastoreVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"database_versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"software_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hotfixes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"create_time": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"deploy_modes": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"default_upgrade": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"update_time": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"mode": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listDatastoreVersions(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v3.2/{project_id}/datastore/versions?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", listPath, offset)
+		listResp, err := client.Request("GET", currentPath, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return nil, err
+		}
+
+		versions := utils.PathSearch("database_versions", resp, make([]interface{}, 0)).([]interface{})
+		result = append(result, versions...)
+		if len(versions) < limit {
+			break
+		}
+
+		offset += len(versions)
+	}
+
+	return result, nil
+}
+
+func dataSourceDatastoreVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	databaseVersions, err := listDatastoreVersions(client)
+	if err != nil {
+		return diag.Errorf("error retrieving GaussDB datastore versions: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("database_versions", flattenDatastoreVersions(databaseVersions)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDatastoreVersions(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"software_version": utils.PathSearch("software_version", v, nil),
+			"hotfixes": flattenDatastoreVersionsHotfixes(
+				utils.PathSearch("hotfixes", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenDatastoreVersionsHotfixes(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"version":     utils.PathSearch("version", v, nil),
+			"create_time": utils.PathSearch("create_time", v, nil),
+			"deploy_modes": flattenDatastoreVersionsDeployModes(
+				utils.PathSearch("deploy_modes", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenDatastoreVersionsDeployModes(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"default_upgrade": utils.PathSearch("default_upgrade", v, nil),
+			"update_time":     utils.PathSearch("update_time", v, nil),
+			"mode":            utils.PathSearch("mode", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get the list of database versions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get the list of database versions.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccDataSourceDatastoreVersions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccDataSourceDatastoreVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDatastoreVersions_basic
=== PAUSE TestAccDataSourceDatastoreVersions_basic
=== CONT  TestAccDataSourceDatastoreVersions_basic
--- PASS: TestAccDataSourceDatastoreVersions_basic (15.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   15.714s
```
<img width="1043" height="17" alt="image" src="https://github.com/user-attachments/assets/6b8fc294-5c52-460e-9e7b-93b3ce510759" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
