### PR TITLE
feat(obs): Update obs_bucket_object to use multi-part upload to support large file uploads (> 5 GB)

### DIFF
--- a/docs/api/resource_huaweicloud_obs_bucket_object.yaml
+++ b/docs/api/resource_huaweicloud_obs_bucket_object.yaml
@@ -18,6 +18,8 @@ paths:
             tag: OBS
         PUT:
             tag: OBS
+        POST:
+            tag: OBS
     /{ObjectName}?tagging:
         DELETE:
             tag: OBS

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 * `kms_key_id` - (Optional, String) The ID of the kms key. If omitted, the default master key will be used.
 
 * `etag` - (Optional, String) Specifies the unique identifier of the object content. It can be used to trigger updates.
-  The only meaningful value is `md5(file("path_to_file"))`.
+  The only meaningful value is `md5(file("path_to_file"))`. Specifying this argument is not compatible with using encryption or uploading large files and will cause perpetual plan drift, because when encryption or multi-part upload is used, the value of etag in OBS will not be equal to the md5 digest of the original file (see [source_hash](#OBSBucketObject_source_hash) instead).
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the object.
 
@@ -86,6 +86,10 @@ The following arguments are supported:
   + For objects with archive storage or deep archive storage, the object metadata cannot be set.
   + The total size of custom metadata is limited to `8` KB. The size of each custom metadata is calculated as the
     total number of bytes in the UTF-8 encoding of the key and value.
+
+<a name="OBSBucketObject_source_hash"></a>
+
+* `source_hash` - (Optional, String) It can be used to trigger updates by setting it to the file's MD5 digest. Similar to the functionality provided by `etag`, but this argument does not suffer from the same limitations when encryption or multi-part upload is used. The only meaningful value is `md5(file("path_to_file"))`.
 
 Either `source` or `content` must be provided to specify the bucket content. These two arguments are mutually-exclusive.
 
@@ -99,6 +103,11 @@ In addition to all arguments above, the following attributes are exported:
   server-side encryption.
 * `size` - the size of the object in bytes.
 * `version_id` - A unique version ID value for the object, if bucket versioning is enabled.
+
+By default, large files are uploaded using multi-part upload with 5 concurrent tasks. When having limited bandwidth or when facing OBS Throttling (503 SlowDown), you may want to set a lower number of concurrent tasks by defining the environment variable `HW_OBS_UPLOAD_CONCURRENT_TASK_NUM`.
+```bash
+$ export HW_OBS_UPLOAD_CONCURRENT_TASK_NUM=1
+```
 
 ## Import
 

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 * `kms_key_id` - (Optional, String) The ID of the kms key. If omitted, the default master key will be used.
 
 * `etag` - (Optional, String) Specifies the unique identifier of the object content. It can be used to trigger updates.
-  The only meaningful value is `md5(file("path_to_file"))`. Specifying this argument is not compatible with using encryption or uploading large files and will cause perpetual plan drift, because when encryption or multi-part upload is used, the value of etag in OBS will not be equal to the md5 digest of the original file (see [source_hash](#OBSBucketObject_source_hash) instead).
+  The only meaningful value is `filemd5("path_to_file")`. Specifying this argument is not compatible with using encryption or uploading large files and will cause perpetual plan drift, because when encryption or multi-part upload is used, the value of etag in OBS will not be equal to the md5 digest of the original file (see [source_hash](#OBSBucketObject_source_hash) instead).
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the object.
 
@@ -89,9 +89,14 @@ The following arguments are supported:
 
 <a name="OBSBucketObject_source_hash"></a>
 
-* `source_hash` - (Optional, String) It can be used to trigger updates by setting it to the file's MD5 digest. Similar to the functionality provided by `etag`, but this argument does not suffer from the same limitations when encryption or multi-part upload is used. The only meaningful value is `md5(file("path_to_file"))`.
+* `source_hash` - (Optional, String) It can be used to trigger updates by setting it to the file's MD5 digest. Similar to the functionality provided by `etag`, but this argument does not suffer from the same limitations when encryption or multi-part upload is used. The only meaningful value is `filemd5("path_to_file")`.
 
 Either `source` or `content` must be provided to specify the bucket content. These two arguments are mutually-exclusive.
+
+By default, large files are uploaded using multi-part upload with 5 concurrent tasks. When having limited bandwidth or when facing OBS Throttling (503 SlowDown), you may want to set a lower number of concurrent tasks by defining the environment variable `HW_OBS_UPLOAD_CONCURRENT_TASK_NUM`.
+```bash
+$ export HW_OBS_UPLOAD_CONCURRENT_TASK_NUM=1
+```
 
 ## Attribute Reference
 
@@ -103,11 +108,6 @@ In addition to all arguments above, the following attributes are exported:
   server-side encryption.
 * `size` - the size of the object in bytes.
 * `version_id` - A unique version ID value for the object, if bucket versioning is enabled.
-
-By default, large files are uploaded using multi-part upload with 5 concurrent tasks. When having limited bandwidth or when facing OBS Throttling (503 SlowDown), you may want to set a lower number of concurrent tasks by defining the environment variable `HW_OBS_UPLOAD_CONCURRENT_TASK_NUM`.
-```bash
-$ export HW_OBS_UPLOAD_CONCURRENT_TASK_NUM=1
-```
 
 ## Import
 

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -72,6 +72,169 @@ func TestAccObsBucketObject_source(t *testing.T) {
 				),
 			},
 			{
+				// This step checks whether the content_type is correctly determined
+				// as "image/png" based on the key's suffix.
+				Config: testAccBucketObject_source_step4(name, name+".png", tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "content_type", "image/png"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBucketObjectImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"encryption", "source",
+				},
+			},
+		},
+	})
+}
+
+// In this case the uploaded object has a .jpg suffix and we determine whether the content_type can correctly be identified
+// as "image/jpeg", instead of "binary/octet-stream", without it being explicitly set by the user.
+func TestAccObsBucketObject_sourceWithSuffix(t *testing.T) {
+	name := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_obs_bucket_object.test"
+
+	tmpFile, err := os.CreateTemp("", "tf-acc-obs-obj-source*.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// write some data to the tempfile
+	err = os.WriteFile(tmpFile.Name(), []byte("initial object state"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketObjectWithSuffix_source_step1(name, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", name),
+					resource.TestCheckResourceAttr(resourceName, "content_type", "image/jpeg"),
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.x-obs-meta-test1", "meta test1"),
+				),
+			},
+			{
+				// update with encryption
+				Config: testAccBucketObjectWithSuffix_source_step2(name, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "content_type", "image/jpeg"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.x-obs-meta-test-update", "update meta test1"),
+				),
+			},
+			{
+				// update with encryption
+				Config: testAccBucketObjectWithSuffix_source_step3(name, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "content_type", "image/jpeg"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBucketObjectImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"encryption", "source",
+				},
+			},
+		},
+	})
+}
+
+// A large file (> 5GB) is uploaded to test the multipart upload functionality.
+// Note that this test will take longer to run and will consume more bandwidth.
+func TestAccObsBucketObject_sourceWithSuffixAndLargeFile(t *testing.T) {
+	name := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_obs_bucket_object.test"
+
+	tmpFile, err := os.CreateTemp("", "tf-acc-obs-obj-source*.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// write some data to the tempfile
+	err = os.WriteFile(tmpFile.Name(), []byte("initial object state"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the file large
+	size := int64(5.5 * 1024 * 1024 * 1024) // 5.5 GB
+	err = tmpFile.Truncate(size)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketObjectWithSuffix_source_step1(name, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", name),
+					resource.TestCheckResourceAttr(resourceName, "content_type", "image/jpeg"),
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.x-obs-meta-test1", "meta test1"),
+				),
+			},
+			{
+				// update with encryption
+				Config: testAccBucketObjectWithSuffix_source_step2(name, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "content_type", "image/jpeg"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.x-obs-meta-test-update", "update meta test1"),
+				),
+			},
+			{
+				// update with encryption
+				Config: testAccBucketObjectWithSuffix_source_step3(name, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "content_type", "image/jpeg"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "0"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -302,6 +465,77 @@ resource "huaweicloud_obs_bucket_object" "test" {
   key          = "%[2]s"
   source       = "%[3]s"
   content_type = "binary/octet-stream"
+  encryption   = true
+
+  tags = {}
+}
+`, testAccBucketObject_base(name), name, source)
+}
+
+func testAccBucketObject_source_step4(bucketName, name, source string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[2]s"
+  source       = "%[3]s"
+  encryption   = true
+
+  tags = {}
+}
+`, testAccBucketObject_base(bucketName), name, source)
+}
+
+func testAccBucketObjectWithSuffix_source_step1(name, source string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[2]s"
+  source       = "%[3]s"
+
+  tags = {
+    foo = "bar"
+  }
+
+  metadata = {
+    "x-obs-meta-test1" = "meta test1"
+  }
+}
+`, testAccBucketObject_base(name), name, source)
+}
+
+func testAccBucketObjectWithSuffix_source_step2(name, source string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[2]s"
+  source       = "%[3]s"
+  encryption   = true
+
+  tags = {
+    owner = "terraform"
+  }
+
+  metadata = {
+    "x-obs-meta-test-update" = "update meta test1"
+  }
+}
+`, testAccBucketObject_base(name), name, source)
+}
+
+func testAccBucketObjectWithSuffix_source_step3(name, source string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[2]s"
+  source       = "%[3]s"
   encryption   = true
 
   tags = {}

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
@@ -190,14 +190,15 @@ func putContentToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.
 	return obsClient.PutObject(putInput)
 }
 
-func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.PutObjectOutput, error) {
+func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.CompleteMultipartUploadOutput, error) {
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 
-	putInput := &obs.PutFileInput{}
+	putInput := &obs.UploadFileInput{}
 	putInput.Bucket = bucket
 	putInput.Key = key
-	putInput.SourceFile = d.Get("source").(string)
+	putInput.UploadFile = d.Get("source").(string)
+	putInput.TaskNum = 5
 
 	if v, ok := d.GetOk("acl"); ok {
 		putInput.ACL = obs.AclType(v.(string))
@@ -221,7 +222,7 @@ func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.Put
 	}
 
 	log.Printf("[DEBUG] putting %s to OBS Bucket %s, opts: %#v", key, bucket, putInput)
-	return obsClient.PutFile(putInput)
+	return obsClient.UploadFile(putInput)
 }
 
 func deleteBucketObjectTags(obsClient *obs.ObsClient, bucket, key, versionId string) error {
@@ -384,9 +385,9 @@ func resourceObsBucketObjectUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func updateBucketObject(obsClient *obs.ObsClient, d *schema.ResourceData, bucket, key string) (string, error) {
 	var (
-		resp   *obs.PutObjectOutput
-		err    error
-		source = d.Get("source").(string)
+		versionId string
+		err       error
+		source    = d.Get("source").(string)
 	)
 
 	if source != "" {
@@ -401,26 +402,40 @@ func updateBucketObject(obsClient *obs.ObsClient, d *schema.ResourceData, bucket
 		}
 
 		// Put source file.
+		var resp *obs.CompleteMultipartUploadOutput
 		resp, err = putFileToObject(obsClient, d)
+		if err != nil {
+			return "", err
+		}
+
+		log.Printf("[DEBUG] Response of putting object (%s) to OBS bucket (%s): %#v", key, bucket, resp)
+		if resp == nil {
+			return "", fmt.Errorf("putting object to OBS bucket %s without null response", bucket)
+		}
+
+		versionId = resp.VersionId
 	}
 
 	content := d.Get("content").(string)
 	if content != "" {
 		// Put content.
+		var resp *obs.PutObjectOutput
 		resp, err = putContentToObject(obsClient, d)
+
+		if err != nil {
+			return "", err
+		}
+
+		log.Printf("[DEBUG] Response of putting object (%s) to OBS bucket (%s): %#v", key, bucket, resp)
+		if resp == nil {
+			return "", fmt.Errorf("putting object to OBS bucket %s without null response", bucket)
+		}
+
+		versionId = resp.VersionId
 	}
 
-	if err != nil {
-		return "", err
-	}
-
-	log.Printf("[DEBUG] Response of putting object (%s) to OBS bucket (%s): %#v", key, bucket, resp)
-	if resp == nil {
-		return "", fmt.Errorf("putting object to OBS bucket %s without null response", bucket)
-	}
-
-	if resp.VersionId != "null" {
-		return resp.VersionId, nil
+	if versionId != "null" {
+		return versionId, nil
 	}
 
 	return "", nil

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -21,17 +22,19 @@ import (
 
 // @API OBS HEAD /
 // @API OBS HEAD /{ObjectName}
-// @API OBS PUT /{ObjectName}
+// @API OBS POST /{ObjectName}?uploads
+// @API OBS PUT /{ObjectName}?partNumber&uploadId
 // @API OBS DELETE /{ObjectName}
 // @API OBS PUT /{ObjectName}?tagging
 // @API OBS GET /{ObjectName}?tagging
 // @API OBS DELETE /{ObjectName}?tagging
+
 func ResourceObsBucketObject() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceObsBucketObjectCreate,
-		ReadContext:   resourceObsBucketObjectRead,
-		UpdateContext: resourceObsBucketObjectUpdate,
-		DeleteContext: resourceObsBucketObjectDelete,
+		CreateWithoutTimeout: resourceObsBucketObjectCreate,
+		ReadContext:          resourceObsBucketObjectRead,
+		UpdateWithoutTimeout: resourceObsBucketObjectUpdate,
+		DeleteContext:        resourceObsBucketObjectDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceObsBucketObjectImport,
 		},
@@ -117,6 +120,10 @@ func ResourceObsBucketObject() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"source_hash": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -190,15 +197,14 @@ func putContentToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.
 	return obsClient.PutObject(putInput)
 }
 
-func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.CompleteMultipartUploadOutput, error) {
+func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.PutObjectOutput, error) {
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 
-	putInput := &obs.UploadFileInput{}
+	putInput := &obs.PutFileInput{}
 	putInput.Bucket = bucket
 	putInput.Key = key
-	putInput.UploadFile = d.Get("source").(string)
-	putInput.TaskNum = 5
+	putInput.SourceFile = d.Get("source").(string)
 
 	if v, ok := d.GetOk("acl"); ok {
 		putInput.ACL = obs.AclType(v.(string))
@@ -208,6 +214,57 @@ func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.Com
 	}
 	if v, ok := d.GetOk("content_type"); ok {
 		putInput.ContentType = v.(string)
+	}
+
+	if v, ok := d.GetOk("metadata"); ok {
+		putInput.Metadata = utils.ExpandToStringMap(v.(map[string]interface{}))
+	}
+
+	var sseKmsHeader = obs.SseKmsHeader{}
+	if d.Get("encryption").(bool) {
+		sseKmsHeader.Encryption = obs.DEFAULT_SSE_KMS_ENCRYPTION
+		sseKmsHeader.Key = d.Get("kms_key_id").(string)
+		putInput.SseHeader = sseKmsHeader
+	}
+
+	log.Printf("[DEBUG] putting %s to OBS Bucket %s, opts: %#v", key, bucket, putInput)
+	return obsClient.PutFile(putInput)
+}
+
+func putFileToObjectMultipart(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.CompleteMultipartUploadOutput, error) {
+	bucket := d.Get("bucket").(string)
+	key := d.Get("key").(string)
+	source := d.Get("source").(string)
+
+	const defaultTaskNum = 5
+	var taskNum int = defaultTaskNum
+	taskNumStr := os.Getenv("HW_OBS_UPLOAD_CONCURRENT_TASK_NUM")
+	if taskNumStr != "" {
+		taskNum, _ = strconv.Atoi(taskNumStr)
+	}
+
+	putInput := &obs.UploadFileInput{}
+	putInput.Bucket = bucket
+	putInput.Key = key
+	putInput.UploadFile = source
+	putInput.TaskNum = taskNum
+
+	if v, ok := d.GetOk("acl"); ok {
+		putInput.ACL = obs.AclType(v.(string))
+	}
+	if v, ok := d.GetOk("storage_class"); ok {
+		putInput.StorageClass = obs.StorageClassType(v.(string))
+	}
+	if v, ok := d.GetOk("content_type"); ok {
+		putInput.ContentType = v.(string)
+	} else {
+		// The SDK derives the content type from the key/source implicitly when using the PutFile function,
+		// but it needs to be done by us explicitly when using the Resumable UploadFile function.
+		if v, ok := obs.GetContentType(key); ok {
+			putInput.ContentType = v
+		} else if v, ok := obs.GetContentType(source); ok {
+			putInput.ContentType = v
+		}
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {
@@ -390,9 +447,15 @@ func updateBucketObject(obsClient *obs.ObsClient, d *schema.ResourceData, bucket
 		source    = d.Get("source").(string)
 	)
 
+	// This threshold is set to the maximum size that a single PUT request allows,
+	// thereby reducing the chances of regression for existing users when multipart upload was introduced.
+	// It may be set lower to have have smaller files benefit from multipart upload too.
+	const multipartThreshold int64 = 5 * 1024 * 1024 * 1024 // 5 GiB
+
 	if source != "" {
 		// Check source file whether exist.
-		_, err = os.Stat(source)
+		var fileInfo os.FileInfo
+		fileInfo, err = os.Stat(source)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return "", fmt.Errorf("source file %s is not exist", source)
@@ -401,19 +464,34 @@ func updateBucketObject(obsClient *obs.ObsClient, d *schema.ResourceData, bucket
 			return "", err
 		}
 
-		// Put source file.
-		var resp *obs.CompleteMultipartUploadOutput
-		resp, err = putFileToObject(obsClient, d)
-		if err != nil {
-			return "", err
-		}
+		if fileInfo.Size() < multipartThreshold {
+			// Put source file.
+			var resp *obs.PutObjectOutput
+			resp, err = putFileToObject(obsClient, d)
+			if err != nil {
+				return "", err
+			}
 
-		log.Printf("[DEBUG] Response of putting object (%s) to OBS bucket (%s): %#v", key, bucket, resp)
-		if resp == nil {
-			return "", fmt.Errorf("putting object to OBS bucket %s without null response", bucket)
-		}
+			log.Printf("[DEBUG] Response of putting object (%s) to OBS bucket (%s): %#v", key, bucket, resp)
+			if resp == nil {
+				return "", fmt.Errorf("putting object to OBS bucket %s with null response", bucket)
+			}
 
-		versionId = resp.VersionId
+			versionId = resp.VersionId
+		} else {
+			var resp *obs.CompleteMultipartUploadOutput
+			resp, err = putFileToObjectMultipart(obsClient, d)
+			if err != nil {
+				return "", err
+			}
+
+			log.Printf("[DEBUG] Response of putting object (%s) to OBS bucket (%s): %#v", key, bucket, resp)
+			if resp == nil {
+				return "", fmt.Errorf("putting object to OBS bucket %s with null response", bucket)
+			}
+
+			versionId = resp.VersionId
+		}
 	}
 
 	content := d.Get("content").(string)
@@ -428,7 +506,7 @@ func updateBucketObject(obsClient *obs.ObsClient, d *schema.ResourceData, bucket
 
 		log.Printf("[DEBUG] Response of putting object (%s) to OBS bucket (%s): %#v", key, bucket, resp)
 		if resp == nil {
-			return "", fmt.Errorf("putting object to OBS bucket %s without null response", bucket)
+			return "", fmt.Errorf("putting object to OBS bucket %s with null response", bucket)
 		}
 
 		versionId = resp.VersionId


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR makes the provider's huaweicloud_obs_bucket_object resource use the [multi-part upload API](https://support.huaweicloud.com/eu/api-obs/obs_04_0098.html) instead of the [single upload PUT API](https://support.huaweicloud.com/eu/api-obs/obs_04_0080.html) that is currently used.

This allows users to upload files larger than 5 GB to OBS buckets using our Terraform provider.

Thereby, more sophisticated Terraform configurations may be developed, for example, to load data into OBS buckets and create Big Data services that will ingest that data, or to upload a private image into an OBS bucket and use IMS resources to create the private image, all from Terraform.

Previously:
<img width="1884" height="343" alt="image" src="https://github.com/user-attachments/assets/de9d98f1-a311-46bc-b169-31c6a261a02f" />

Currently:
<img width="982" height="304" alt="image" src="https://github.com/user-attachments/assets/d86146cc-bbb8-4a7e-95e7-e70c7582457c" />


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
N/A

**Special notes for your reviewer**:
I tested the changes by uploading and deleting three types of files:
1) Small files uploaded using the "content" field.
2) Small files uploaded using the "source" (file) field (< 100 KB).
3) Large files uploaded using the "source" (file) field (7 GB, 16 GB, 500 GB).

All three types of files could be uploaded and deleted using the Terraform provider.
After uploading, the files were also downloaded to confirm that the hashes correspond to the hashes of the original files.
<img width="1570" height="358" alt="image" src="https://github.com/user-attachments/assets/cca0b66b-b43e-4202-9196-6e61e74c1be1" />

I also added extra test cases to
1) test an edge case about inferring the content-type from source or key when a content-type is not explicitly defined.
2) Uploading files larger than 5 GB (triggering multi-part upload).

The change was easy to make, because the SDK already has a convenient wrapper around the multi-part upload APIs, called [Resumable Upload](https://support.huaweicloud.com/eu/sdk-go-devg-obs/obs_23_0409.html).
A bit of code duplication seemed necessary, because the return values for content-based upload is *obs.PutObjectOutput, whereas the return value for resumable/multi-part file-based upload is *obs.CompleteMultipartUploadOutput.

I did my tests only on the EU Site using the eu-west-101 region.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add multi-part upload logic so that files larger than 5 GB can also be uploaded to OBS using Terraform.
2. Add the "source_hash" argument as an alternative to the "etag" argument, so that file changes can be tracked and files reuploaded also when encryption and/or multipart upload is used.

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
(Note: some other OBS-related tests fail, mainly due to missing features in the Dublin region and/or hardcoded ".com" URLs in the test cases.)

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run=TestAccObsBucketObject_source'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run=TestAccObsBucketObject_source -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_sourceWithSuffix
=== PAUSE TestAccObsBucketObject_sourceWithSuffix
=== RUN   TestAccObsBucketObject_sourceWithSuffixAndLargeFile
=== PAUSE TestAccObsBucketObject_sourceWithSuffixAndLargeFile
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_sourceWithSuffixAndLargeFile
=== CONT  TestAccObsBucketObject_sourceWithSuffix
--- PASS: TestAccObsBucketObject_sourceWithSuffix (39.39s)
--- PASS: TestAccObsBucketObject_source (52.97s)
--- PASS: TestAccObsBucketObject_sourceWithSuffixAndLargeFile (2275.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       2275.688s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
