### PR TITLE
feat(dsc): new datasource to query catalog statical char

### DIFF
--- a/docs/data-sources/dsc_catalog_statical_chart.md
+++ b/docs/data-sources/dsc_catalog_statical_chart.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_catalog_statical_chart"
+description: |-
+  Use this data source to get the list of DSC catalog statical chart within HuaweiCloud.
+---
+
+# huaweicloud_dsc_catalog_statical_chart
+
+Use this data source to get the list of DSC catalog statical chart within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "label_id" {}
+
+data "huaweicloud_dsc_catalog_statical_chart" "test" {
+  label_id = var.label_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `label_id` - (Optional, String) Specifies the group label ID used to filter the statical chart
+  of a specific group. `label_id` and `type_id` must be specified at least one.
+
+* `type_id` - (Optional, String) Specifies the type ID used to filter the statical chart
+  of a specific type. `label_id` and `type_id` must be specified at least one.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `detection_rules` - The detection rule list.
+
+  The [detection_rules](#detection_rules_struct) structure is documented below.
+
+* `sensitive_col_infos` - The sensitive column information list.
+
+  The [sensitive_col_infos](#sensitive_col_infos_struct) structure is documented below.
+
+* `total_column_number` - The total column number.
+
+<a name="detection_rules_struct"></a>
+The `detection_rules` block supports:
+
+* `hit_number` - The hit number of the rule.
+
+* `rule_name` - The rule name.
+
+<a name="sensitive_col_infos_struct"></a>
+The `sensitive_col_infos` block supports:
+
+* `color_number` - The color number.
+
+* `level_name` - The level name.
+
+* `sensitive_number` - The sensitive number.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1423,6 +1423,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_database_instances":         dsc.DataSourceDatabaseInstances(),
 			"huaweicloud_dsc_scan_jobs":                  dsc.DataSourceScanJobs(),
 			"huaweicloud_dsc_dbss_oem_info":              dsc.DataSourceDbssOemInfo(),
+			"huaweicloud_dsc_catalog_statical_chart":     dsc.DataSourceCatalogStaticalChart(),
 			"huaweicloud_dsc_multi_accounts":             dsc.DataSourceMultiAccounts(),
 			"huaweicloud_dsc_multi_account_assets":       dsc.DataSourceMultiAccountAssets(),
 			"huaweicloud_dsc_multi_account_info":         dsc.DataSourceMultiAccountInfo(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_catalog_statical_chart_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_catalog_statical_chart_test.go
@@ -1,0 +1,44 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscCatalogStaticalChart_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_dsc_catalog_statical_chart.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscTypeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscCatalogStaticalChart_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "detection_rules.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "sensitive_col_infos.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_column_number"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDscCatalogStaticalChart_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_catalog_statical_chart" "test" {
+  type_id = "%[1]s"
+}
+`, acceptance.HW_DSC_TYPE_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_catalog_statical_chart.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_catalog_statical_chart.go
@@ -1,0 +1,187 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/metadata/catalog/statical-chart
+func DataSourceCatalogStaticalChart() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCatalogStaticalChartRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"label_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"detection_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     detectionRuleSchema(),
+			},
+			"sensitive_col_infos": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     sensitiveColInfoSchema(),
+			},
+			"total_column_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func detectionRuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"hit_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func sensitiveColInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"color_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"level_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sensitive_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCatalogStaticalChartQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("label_id"); ok {
+		res += fmt.Sprintf("&label_id=%s", v.(string))
+	}
+	if v, ok := d.GetOk("type_id"); ok {
+		res += fmt.Sprintf("&type_id=%s", v.(string))
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func dataSourceCatalogStaticalChartRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/metadata/catalog/statical-chart"
+		product = "dsc"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildCatalogStaticalChartQueryParams(d)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC catalog statical chart: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("detection_rules", flattenDetectionRules(utils.PathSearch(
+			"detection_rules", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("sensitive_col_infos", flattenSensitiveColInfos(utils.PathSearch(
+			"sensitive_col_infos", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("total_column_number", utils.PathSearch("total_column_number", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDetectionRules(rules []interface{}) []interface{} {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(rules))
+	for _, v := range rules {
+		rst = append(rst, utils.RemoveNil(map[string]interface{}{
+			"hit_number": utils.PathSearch("hit_number", v, nil),
+			"rule_name":  utils.PathSearch("rule_name", v, nil),
+		}))
+	}
+
+	return rst
+}
+
+func flattenSensitiveColInfos(infos []interface{}) []interface{} {
+	if len(infos) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(infos))
+	for _, v := range infos {
+		rst = append(rst, utils.RemoveNil(map[string]interface{}{
+			"color_number":     utils.PathSearch("color_number", v, nil),
+			"level_name":       utils.PathSearch("level_name", v, nil),
+			"sensitive_number": utils.PathSearch("sensitive_number", v, nil),
+		}))
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query catalog statical char

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscCatalogStaticalChart_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscCatalogStaticalChart_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscCatalogStaticalChart_basic
=== PAUSE TestAccDataSourceDscCatalogStaticalChart_basic
=== CONT  TestAccDataSourceDscCatalogStaticalChart_basic
--- PASS: TestAccDataSourceDscCatalogStaticalChart_basic (10.76s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       10.879s coverage: 7.6% of statements in ./huaweicloud/services/dsc
```
<img width="1413" height="71" alt="image" src="https://github.com/user-attachments/assets/0dba1a2a-8a3d-45e4-b8ad-7e1656e55742" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
