### PR TITLE
feat(dsc): support `dsc_vpc_ep_quotas` datasource

### DIFF
--- a/docs/data-sources/dsc_vpc_ep_quotas.md
+++ b/docs/data-sources/dsc_vpc_ep_quotas.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_vpc_ep_quotas"
+description: |-
+  Use this data source to get the VPC endpoint quotas within HuaweiCloud.
+---
+
+# huaweicloud_dsc_vpc_ep_quotas
+
+Use this data source to get the VPC endpoint quotas within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_vpc_ep_quotas" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `quotas` - The VPC endpoint quota information list.
+  The [quotas](#dsc_quotas) structure is documented below.
+
+<a name="dsc_quotas"></a>
+The `quotas` block supports:
+
+* `quota` - The quota.
+* `type` - The quota type.
+* `used` - The used quota.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1431,6 +1431,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_multi_account_info":         dsc.DataSourceMultiAccountInfo(),
 			"huaweicloud_dsc_multi_organizations":        dsc.DataSourceMultiOrganizations(),
 			"huaweicloud_dsc_multi_organization_tree":    dsc.DataSourceMultiOrganizationTree(),
+			"huaweicloud_dsc_vpc_ep_quotas":              dsc.DataSourceDscVpcEpQuotas(),
 
 			// EventGrid
 			"huaweicloud_eg_connections":           eg.DataSourceConnections(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_vpc_ep_quotas_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_vpc_ep_quotas_test.go
@@ -1,0 +1,37 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscVpcEpQuotas_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dsc_vpc_ep_quotas.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscVpcEpQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.quota"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.used"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDscVpcEpQuotas_basic = `
+data "huaweicloud_dsc_vpc_ep_quotas" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_vpc_ep_quotas.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_vpc_ep_quotas.go
@@ -1,0 +1,144 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/vpcep/quotas
+func DataSourceDscVpcEpQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscVpcEpQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"quotas": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The VPC endpoint quota information list.",
+				Elem:        dscVpcEpQuotaSchema(),
+			},
+		},
+	}
+}
+
+func dscVpcEpQuotaSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"quota": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The quota.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The quota type.",
+			},
+			"used": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The used quota.",
+			},
+		},
+	}
+}
+
+func buildDscVpcEpQuotasQueryParams(limit, offset int) string {
+	return fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+}
+
+func dataSourceDscVpcEpQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v1/{project_id}/vpcep/quotas"
+		offset  = 0
+		limit   = 1000
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	for {
+		currentPath := requestPath + buildDscVpcEpQuotasQueryParams(limit, offset)
+
+		resp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DSC VPC endpoint quotas: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		quotasResp := utils.PathSearch("quotas.resources", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, quotasResp...)
+
+		if len(quotasResp) < limit {
+			break
+		}
+
+		offset += len(quotasResp)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("quotas", flattenDscVpcEpQuotas(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDscVpcEpQuotas(quotas []interface{}) []interface{} {
+	if len(quotas) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(quotas))
+	for _, v := range quotas {
+		rst = append(rst, map[string]interface{}{
+			"quota": utils.PathSearch("quota", v, nil),
+			"type":  utils.PathSearch("type", v, nil),
+			"used":  utils.PathSearch("used", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `dsc_vpc_ep_quotas` datasource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `dsc_vpc_ep_quotas` datasource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dsc" TESTARGS="-run TestAccDataSourceDscVpcEpQuotas_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dsc-v -run TestAccDataSourceDscVpcEpQuotas_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDscVpcEpQuotas_basic
=== PAUSE TestAccDataSourceDscVpcEpQuotas_basic
=== CONT  TestAccDataSourceDscVpcEpQuotas_basic
--- PASS: TestAccDataSourceDscVpcEpQuotas_basic (24.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       21.311s
```
<img width="534" height="26" alt="image" src="https://github.com/user-attachments/assets/330af303-c6ba-4011-b28d-811aaa1e556a" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
