### PR TITLE
feat(dsc): support `dsc_device_monitor_infos` datasource

### DIFF
--- a/docs/data-sources/dsc_device_monitor_infos.md
+++ b/docs/data-sources/dsc_device_monitor_infos.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_device_monitor_infos"
+description: |-
+  Use this data source to get the device monitor information list within HuaweiCloud.
+---
+
+# huaweicloud_dsc_device_monitor_infos
+
+Use this data source to get the device monitor information list within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_device_monitor_infos" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `monitor_infos` - The device monitor information list.
+  The [monitor_infos](#monitor_infos_struct) structure is documented below.
+
+<a name="monitor_infos_struct"></a>
+The `monitor_infos` block supports:
+
+* `id` - The device ID.
+
+* `name` - The device name.
+
+* `ip` - The device IP address.
+
+* `type` - The device type.
+
+* `status` - The device status.
+
+* `description` - The device description.
+
+* `license_info` - The license information.
+  The [license_info](#license_info_struct) structure is documented below.
+
+* `os_info` - The VM resource usage information.
+  The [os_info](#os_info_struct) structure is documented below.
+
+<a name="license_info_struct"></a>
+The `license_info` block supports:
+
+* `license` - The license information.
+
+* `license_start` - The license effective time.
+
+* `license_end` - The license expiration time.
+
+<a name="os_info_struct"></a>
+The `os_info` block supports:
+
+* `cpu` - The number of CPU cores.
+
+* `disk` - The disk size.
+
+* `mem` - The memory size.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1418,6 +1418,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_data_map_score":             dsc.DataSourceDscDataMapScore(),
 			"huaweicloud_dsc_data_map_security_level":    dsc.DataSourceDscDataMapSecurityLevel(),
 			"huaweicloud_dsc_devices":                    dsc.DataSourceDscDevices(),
+			"huaweicloud_dsc_device_monitor_infos":       dsc.DataSourceDscDeviceMonitorInfos(),
 			"huaweicloud_dsc_event_overview":             dsc.DataSourceDscEventOverview(),
 			"huaweicloud_dsc_events":                     dsc.DataSourceDscEvents(),
 			"huaweicloud_dsc_features":                   dsc.DataSourceDscFeatures(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_device_monitor_infos_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_device_monitor_infos_test.go
@@ -1,0 +1,34 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscDeviceMonitorInfos_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dsc_device_monitor_infos.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscDeviceMonitorInfos_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "monitor_infos.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDscDeviceMonitorInfos_basic = `
+data "huaweicloud_dsc_device_monitor_infos" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_device_monitor_infos.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_device_monitor_infos.go
@@ -1,0 +1,231 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/devices/monitor-info
+func DataSourceDscDeviceMonitorInfos() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscDeviceMonitorInfosRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"monitor_infos": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The device monitor information list.",
+				Elem:        dscMonitorInfoSchema(),
+			},
+		},
+	}
+}
+
+func dscMonitorInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The device ID.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The device name.",
+			},
+			"ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The device IP address.",
+			},
+			"type": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The device type.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The device status.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The device description.",
+			},
+			"license_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The license information.",
+				Elem:        dscLicenseInfoSchema(),
+			},
+			"os_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The VM resource usage information.",
+				Elem:        dscOsInfoSchema(),
+			},
+		},
+	}
+}
+
+func dscLicenseInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"license": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The license information.",
+			},
+			"license_start": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The license effective time.",
+			},
+			"license_end": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The license expiration time.",
+			},
+		},
+	}
+}
+
+func dscOsInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cpu": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The number of CPU cores.",
+			},
+			"disk": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The disk size.",
+			},
+			"mem": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The memory size.",
+			},
+		},
+	}
+}
+
+func dataSourceDscDeviceMonitorInfosRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v1/{project_id}/devices/monitor-info"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC device monitor infos: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	monitorInfos := utils.PathSearch("monitor_infos", respBody, make([]interface{}, 0)).([]interface{})
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("monitor_infos", flattenDscMonitorInfos(monitorInfos)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDscMonitorInfos(monitorInfos []interface{}) []interface{} {
+	if len(monitorInfos) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(monitorInfos))
+	for _, v := range monitorInfos {
+		rst = append(rst, map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"name":        utils.PathSearch("name", v, nil),
+			"ip":          utils.PathSearch("ip", v, nil),
+			"type":        utils.PathSearch("type", v, nil),
+			"status":      utils.PathSearch("status", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+			"license_info": flattenDscLicenseInfo(
+				utils.PathSearch("license_info", v, nil)),
+			"os_info": flattenDscOsInfo(
+				utils.PathSearch("os_info", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenDscLicenseInfo(licenseInfo interface{}) []interface{} {
+	if licenseInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"license":       utils.PathSearch("license", licenseInfo, nil),
+			"license_start": utils.PathSearch("license_start", licenseInfo, nil),
+			"license_end":   utils.PathSearch("license_end", licenseInfo, nil),
+		},
+	}
+}
+
+func flattenDscOsInfo(osInfo interface{}) []interface{} {
+	if osInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"cpu":  utils.PathSearch("cpu", osInfo, nil),
+			"disk": utils.PathSearch("disk", osInfo, nil),
+			"mem":  utils.PathSearch("mem", osInfo, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `dsc_device_monitor_infos` datasource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support `dsc_device_monitor_infos` datasource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dsc" TESTARGS="-run TestAccDataSourceDscDeviceMonitorInfos_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dsc-v -run TestAccDataSourceDscDeviceMonitorInfos_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDscDeviceMonitorInfos_basic
=== PAUSE TestAccDataSourceDscDeviceMonitorInfos_basic
=== CONT  TestAccDataSourceDscDeviceMonitorInfos_basic
--- PASS: TestAccDataSourceDscDeviceMonitorInfos_basic (15.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       21.311s
```
<img width="535" height="38" alt="image" src="https://github.com/user-attachments/assets/06d3693c-fe07-4668-be12-ae311cdfb686" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
