### PR TITLE
fix(dli): returns empty map not nil if runtime config is empty

### DIFF
--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flinkjar_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flinkjar_job.go
@@ -484,7 +484,7 @@ func resourceFlinkJarJobRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("resume_checkpoint", detail.JobConfig.ResumeCheckpoint),
 		d.Set("resume_max_num", detail.JobConfig.ResumeMaxNum),
 		d.Set("checkpoint_path", detail.JobConfig.CheckpointPath),
-		setRuntimeConfigToState(d, detail.JobConfig.RuntimeConfig),
+		d.Set("runtime_config", parseFlinkJobRuntimeConfig(detail.JobConfig.RuntimeConfig)),
 		d.Set("status", detail.Status),
 		d.Set("tags", d.Get("tags")),
 		d.Set("checkpoint_enabled", detail.JobConfig.CheckpointEnabled),

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
@@ -432,7 +432,7 @@ func resourceFlinkSqlJobRead(ctx context.Context, d *schema.ResourceData, meta i
 		d.Set("tm_slot_num", detail.JobConfig.TmSlotNum),
 		d.Set("resume_checkpoint", detail.JobConfig.ResumeCheckpoint),
 		d.Set("resume_max_num", detail.JobConfig.ResumeMaxNum),
-		setRuntimeConfigToState(d, detail.JobConfig.RuntimeConfig),
+		d.Set("runtime_config", parseFlinkJobRuntimeConfig(detail.JobConfig.RuntimeConfig)),
 		d.Set("operator_config", detail.JobConfig.OperatorConfig),
 		d.Set("static_estimator_config", detail.JobConfig.StaticEstimatorConfig),
 		d.Set("execution_agency_urn", detail.JobConfig.ExecutionAgencyUrn),
@@ -769,17 +769,21 @@ func updateFlinkSqlJobWithStop(ctx context.Context, client *golangsdk.ServiceCli
 	return nil
 }
 
-func setRuntimeConfigToState(d *schema.ResourceData, configStr string) error {
+func parseFlinkJobRuntimeConfig(configStr string) interface{} {
 	if len(configStr) == 0 {
-		return nil
+		// Returning nil will cause `d.Set` to result in `runtime_config` being null in `tfstate` (equivalent to not
+		// setting the parameter), and will consistently result in a "Known After Apply" error because `runtime_config`
+		// is not being recognized.
+		return make(map[string]interface{})
 	}
+
 	var rst []tags.ResourceTag
 	err := json.Unmarshal([]byte(configStr), &rst)
 	if err != nil {
-		return fmt.Errorf("error parse runtime_config from API response: %s", err)
+		return make(map[string]interface{})
 	}
 
-	return d.Set("runtime_config", utils.TagsToMap(rst))
+	return utils.TagsToMap(rst)
 }
 
 func parseDliFlinkErrToError404(respErr error) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixes a perpetual plan drift issue on `huaweicloud_dli_flinksql_job` and `huaweicloud_dli_flinkjar_job` where `runtime_config` was repeatedly shown as `(known after apply)` even when the user did not configure it.
When the DLI API returns an empty `runtime_config` string, the Read logic now sets `runtime_config` to an empty map (`{}`) in state instead of leaving it unset/`null`.

The previous helper `setRuntimeConfigToState` returned early without calling `d.Set` when the API response contained an empty `runtime_config`. As a result:
- `runtime_config` remained `null` in `tfstate`
- Terraform treated it as an unset computed attribute
- Every plan/apply cycle reported `runtime_config = (known after apply)`, causing unnecessary drift noise

**`parseFlinkJobRuntimeConfig` behavior:**
- Empty API string → returns `make(map[string]interface{})` (empty map, not `nil`)
- Valid JSON tag array → returns `utils.TagsToMap(rst)` as before
- JSON unmarshal failure → returns empty map (previously returned an error)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. returns empty map not nil if runtime config is empty
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dli -f TestAccResourceDliFlinkJob_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccResourceDliFlinkJob_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceDliFlinkJob_basic
=== PAUSE TestAccResourceDliFlinkJob_basic
=== CONT  TestAccResourceDliFlinkJob_basic
--- PASS: TestAccResourceDliFlinkJob_basic (157.49s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       157.614s        coverage: 6.6% of statements in ./huaweicloud/services/dli
```
```
./scripts/coverage.sh -o dli -f TestAccDataSourceDliFlinkSQLJobs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccDataSourceDliFlinkSQLJobs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDliFlinkSQLJobs_basic
=== PAUSE TestAccDataSourceDliFlinkSQLJobs_basic
=== CONT  TestAccDataSourceDliFlinkSQLJobs_basic
--- PASS: TestAccDataSourceDliFlinkSQLJobs_basic (65.33s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       65.446s coverage: 4.9% of statements in ./huaweicloud/services/dli
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
