### PR TITLE
feat(dsc): support `dsc_stop_scan_job` resource

### DIFF
--- a/docs/resources/dsc_stop_scan_job.md
+++ b/docs/resources/dsc_stop_scan_job.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_stop_scan_job"
+description: |-
+  Manages a resource to stop a DSC scan job within HuaweiCloud.
+---
+
+# huaweicloud_dsc_stop_scan_job
+
+Manages a resource to stop a DSC scan job within HuaweiCloud.
+
+-> This resource is a one-time action resource used to stop a DSC scan job. Deleting this resource will not
+  restart the scan job, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+resource "huaweicloud_dsc_stop_scan_job" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the scan job ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `msg` - The returned message, which describes the operation result or status information.
+
+* `status` - The returned status, indicating whether the operation is successful.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4980,6 +4980,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_alarm_notification":           dsc.ResourceAlarmNotification(),
 			"huaweicloud_dsc_multi_enable_trusted_service": dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_device":                       dsc.ResourceDscDevice(),
+			"huaweicloud_dsc_stop_scan_job":                dsc.ResourceStopScanJob(),
 
 			// internal only
 			"huaweicloud_apm_aksk": apm.ResourceApmAkSk(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -459,6 +459,7 @@ var (
 	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
 	HW_DSC_ENABLE_FLAG    = os.Getenv("HW_DSC_ENABLE_FLAG")
 	HW_DSC_TYPE_ID        = os.Getenv("HW_DSC_TYPE_ID")
+	HW_DSC_SCAN_JOB_ID    = os.Getenv("HW_DSC_SCAN_JOB_ID")
 
 	HW_EIP_ID      = os.Getenv("HW_EIP_ID")
 	HW_EIP_ADDRESS = os.Getenv("HW_EIP_ADDRESS")
@@ -5292,6 +5293,13 @@ func TestAccPreCheckDscEnableFlag(t *testing.T) {
 func TestAccPreCheckDscTypeId(t *testing.T) {
 	if HW_DSC_TYPE_ID == "" {
 		t.Skip("HW_DSC_TYPE_ID must be set for DSC acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDscScanJobId(t *testing.T) {
+	if HW_DSC_SCAN_JOB_ID == "" {
+		t.Skip("HW_DSC_SCAN_JOB_ID must be set for DSC acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_stop_scan_job_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_stop_scan_job_test.go
@@ -1,0 +1,34 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceStopScanJob_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscScanJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceStopScanJob_basic(),
+			},
+		},
+	})
+}
+
+func testAccResourceStopScanJob_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_stop_scan_job" "test" {
+  job_id = "%[1]s"
+}
+`, acceptance.HW_DSC_SCAN_JOB_ID)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_stop_scan_job.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_stop_scan_job.go
@@ -1,0 +1,126 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var stopScanJobNonUpdatableParams = []string{
+	"job_id",
+}
+
+// @API DSC POST /v1/{project_id}/sdg/scan/job/{job_id}/stop
+func ResourceStopScanJob() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStopScanJobCreate,
+		ReadContext:   resourceStopScanJobRead,
+		UpdateContext: resourceStopScanJobUpdate,
+		DeleteContext: resourceStopScanJobDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(stopScanJobNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceStopScanJobCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sdg/scan/job/{job_id}/stop"
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", d.Get("job_id").(string))
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error stopping DSC scan job: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("msg", utils.PathSearch("msg", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceStopScanJobRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceStopScanJobUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceStopScanJobDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to stop a DSC scan job. Deleting this resource will not
+restart the scan job, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `dsc_stop_scan_job` resource


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support `dsc_stop_scan_job` resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dsc" TESTARGS="-run TestAccResourceStopScanJob_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dsc-v -run TestAccResourceStopScanJob_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceStopScanJob_basic
=== PAUSE TestAccResourceStopScanJob_basic
=== CONT  TestAccResourceStopScanJob_basic
--- PASS: TestAccResourceStopScanJob_basic (17.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       21.311s
```
<img width="556" height="29" alt="image" src="https://github.com/user-attachments/assets/2aed413b-3f9a-474d-b07e-9f9ae078b54a" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
