### PR TITLE
feat(dsc): support `dsc_catalog_quantity_variation` datasource

### DIFF
--- a/docs/data-sources/dsc_catalog_quantity_variation.md
+++ b/docs/data-sources/dsc_catalog_quantity_variation.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_catalog_quantity_variation"
+description: |-
+  Use this data source to get the catalog quantity variation within HuaweiCloud.
+---
+
+# huaweicloud_dsc_catalog_quantity_variation
+
+Use this data source to get the catalog quantity variation within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "type_id" {}
+
+data "huaweicloud_dsc_catalog_quantity_variation" "test" {
+  type_id = var.type_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `label_id` - (Optional, String) Specifies the label ID used to filter the data quantity variation.
+  Either `label_id` or `type_id` must be specified.
+
+* `type_id` - (Optional, String) Specifies the type ID used to filter the data quantity variation.
+  Either `label_id` or `type_id` must be specified.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `sensitive_number_variation` - The sensitive number variation trend.
+
+* `time_axis` - The time axis.
+
+* `total_number_variation` - The total number variation trend.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1414,6 +1414,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_assets_count":                dsc.DataSourceDscAssetsCount(),
 			"huaweicloud_dsc_asset_quota":                 dsc.DataSourceDscAssetQuota(),
 			"huaweicloud_dsc_catalog_statistics":          dsc.DataSourceCatalogStatistics(),
+			"huaweicloud_dsc_catalog_quantity_variation":  dsc.DataSourceDscCatalogQuantityVariation(),
 			"huaweicloud_dsc_column_details_by_database":  dsc.DataSourceDscColumnDetailsByDatabase(),
 			"huaweicloud_dsc_dashboard_score":             dsc.DataSourceDscDashboardScore(),
 			"huaweicloud_dsc_data_map_dynamic_data_infos": dsc.DataSourceDataMapDynamicDataInfos(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_catalog_quantity_variation_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_catalog_quantity_variation_test.go
@@ -1,0 +1,42 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscCatalogQuantityVariation_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dsc_catalog_quantity_variation.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscTypeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscCatalogQuantityVariation_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "time_axis.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "sensitive_number_variation.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "total_number_variation.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDscCatalogQuantityVariation_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_catalog_quantity_variation" "test" {
+  type_id = "%[1]s"
+}
+`, acceptance.HW_DSC_TYPE_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_catalog_quantity_variation.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_catalog_quantity_variation.go
@@ -1,0 +1,131 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/metadata/catalog/quantity-variation
+func DataSourceDscCatalogQuantityVariation() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscCatalogQuantityVariationRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"label_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The label ID used to filter the data quantity variation.",
+			},
+			"type_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type ID used to filter the data quantity variation.",
+			},
+			"sensitive_number_variation": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The sensitive number variation trend.",
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
+			"time_axis": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The time axis.",
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
+			"total_number_variation": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The total number variation trend.",
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
+		},
+	}
+}
+
+func buildDscCatalogQuantityVariationQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+	if v, ok := d.GetOk("label_id"); ok {
+		queryParams = fmt.Sprintf("%s&label_id=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("type_id"); ok {
+		queryParams = fmt.Sprintf("%s&type_id=%v", queryParams, v)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func dataSourceDscCatalogQuantityVariationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v1/{project_id}/metadata/catalog/quantity-variation"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	currentPath := requestPath + buildDscCatalogQuantityVariationQueryParams(d)
+
+	resp, err := client.Request("GET", currentPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC catalog quantity variation: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("sensitive_number_variation",
+			utils.PathSearch("sensitive_number_variation", respBody, make([]interface{}, 0))),
+		d.Set("time_axis",
+			utils.PathSearch("time_axis", respBody, make([]interface{}, 0))),
+		d.Set("total_number_variation",
+			utils.PathSearch("total_number_variation", respBody, make([]interface{}, 0))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `dsc_catalog_quantity_variation` datasource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `dsc_catalog_quantity_variation` datasource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dsc" TESTARGS="-run TestAccDataSourceDscCatalogQuantityVariation_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dsc-v -run TestAccDataSourceDscCatalogQuantityVariation_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDscCatalogQuantityVariation_basic
=== PAUSE TestAccDataSourceDscCatalogQuantityVariation_basic
=== CONT  TestAccDataSourceDscCatalogQuantityVariation_basic
--- PASS: TestAccDataSourceDscCatalogQuantityVariation_basic (17.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       21.311s
```
<img width="529" height="35" alt="image" src="https://github.com/user-attachments/assets/97484061-081a-46e1-a5f4-24e4c7d87be2" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
