### PR TITLE
fix(ges): correct ID field mapping in graph creation response

### DIFF
--- a/huaweicloud/services/ges/resource_huaweicloud_ges_graph.go
+++ b/huaweicloud/services/ges/resource_huaweicloud_ges_graph.go
@@ -331,7 +331,9 @@ func resourceGesGraphCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	graphId := utils.PathSearch("graph_id", createGraphRespBody, "").(string)
+	// The legacy code only used "graph_id". The original intent is unclear,
+	// so the new implementation adds "id" as a fallback for backward compatibility.
+	graphId := utils.PathSearch("graph_id||id", createGraphRespBody, "").(string)
 	if graphId == "" {
 		return diag.Errorf("unable to find the GES graph ID from the API response")
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix incorrect ID field extraction in resource_huaweicloud_ges_graph during resource creation. The GES create graph API returns the graph identifier in the id field, but the legacy code incorrectly referenced graph_id, causing the resource ID to be empty after creation and all subsequent operations (read, update, delete) to fail.
This PR corrects the create response parsing logic to extract the ID from the proper id field, ensuring the resource is properly registered in Terraform state after creation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
Only the create response ID extraction logic is modified; no API request parameters, schema definitions, or other CRUD operations are affected.
The fix is limited to the resourceGesGraphCreate function's response parsing section.
Existing resources with empty IDs in state may require terraform refresh or re-apply after upgrading to this version.
Acceptance test TestAccGesGraph_basic passes successfully (1862s).

**Release note**:
<!--  Steps to write your release note:
bug(ges): fix resource_huaweicloud_ges_graph creation failure caused by incorrect ID field mapping from create API response
-->

```release-note
bug: fix resource_huaweicloud_ges_graph creation failure caused by incorrect ID field mapping from create API response
```

Screenshot of the error before testing
<img width="1462" height="962" alt="image" src="https://github.com/user-attachments/assets/eabf47e3-be41-4d46-a6fd-a63b4e33f60e" />

Unit test (UT) passing screenshot after the fix
<img width="1466" height="741" alt="image" src="https://github.com/user-attachments/assets/b6d3f650-8a42-4b47-9f94-fd440d6eb43c" />
<img width="1164" height="925" alt="image" src="https://github.com/user-attachments/assets/ecd32a39-e08e-4827-be7d-dad0e9db541a" />


## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccGesGraph_basic'
...
=== RUN   TestAccGesGraph_basic
--- PASS: TestAccGesGraph_basic (1829.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ges       1829.392s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
