### PR TITLE
feat(dsc): new datasource to query template rules

### DIFF
--- a/docs/data-sources/dsc_template_rules.md
+++ b/docs/data-sources/dsc_template_rules.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_template_rules"
+description: |-
+  Use this data source to get the list of DSC template rules within HuaweiCloud.
+---
+
+# huaweicloud_dsc_template_rules
+
+Use this data source to get the list of DSC template rules within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "template_id" {}
+
+data "huaweicloud_dsc_template_rules" "test" {
+  template_id = var.template_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `template_id` - (Required, String) Specifies the template ID.
+
+* `keyword` - (Optional, String) Specifies the keyword for fuzzy search of sensitive information object name.
+
+* `classification_ids` - (Optional, List of String) Specifies the list of classification IDs to filter results.
+
+* `security_level_ids` - (Optional, List of String) Specifies the list of risk level IDs to filter results.
+
+* `is_used` - (Optional, String) Specifies whether the rule is enabled.
+
+* `rule_name` - (Optional, String) Specifies the keyword for fuzzy search of rule name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `template_rules_list` - The template rules information list.
+
+  The [template_rules_list](#template_rules_list_struct) structure is documented below.
+
+<a name="template_rules_list_struct"></a>
+The `template_rules_list` block supports:
+
+* `rule_id` - The rule ID.
+
+* `project_id` - The project ID.
+
+* `rule_name` - The rule name.
+
+* `template_id` - The template ID.
+
+* `classification_id` - The classification ID.
+
+* `security_level_id` - The risk level ID.
+
+* `security_level_name` - The risk level name.
+
+* `security_level_color` - The risk level color.
+
+* `is_used` - Whether the rule is enabled.
+
+* `rule_description` - The rule description.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1428,6 +1428,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_database_instances":          dsc.DataSourceDatabaseInstances(),
 			"huaweicloud_dsc_scan_jobs":                   dsc.DataSourceScanJobs(),
 			"huaweicloud_dsc_scan_rules":                  dsc.DataSourceScanRules(),
+			"huaweicloud_dsc_template_rules":              dsc.DataSourceDscTemplateRules(),
 			"huaweicloud_dsc_dbss_oem_info":               dsc.DataSourceDbssOemInfo(),
 			"huaweicloud_dsc_catalog_statical_chart":      dsc.DataSourceCatalogStaticalChart(),
 			"huaweicloud_dsc_multi_accounts":              dsc.DataSourceMultiAccounts(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -457,11 +457,12 @@ var (
 	HW_GLOBAL_EIP_BANDWIDTH_ID            = os.Getenv("HW_GLOBAL_EIP_BANDWIDTH_ID")
 	HW_GLOBAL_EIP_SEGMENT_INSTANCE_ID     = os.Getenv("HW_GLOBAL_EIP_SEGMENT_INSTANCE_ID")
 
-	HW_DSC_INSTANCE_ID    = os.Getenv("HW_DSC_INSTANCE_ID")
-	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
-	HW_DSC_ENABLE_FLAG    = os.Getenv("HW_DSC_ENABLE_FLAG")
-	HW_DSC_TYPE_ID        = os.Getenv("HW_DSC_TYPE_ID")
-	HW_DSC_SCAN_JOB_ID    = os.Getenv("HW_DSC_SCAN_JOB_ID")
+	HW_DSC_INSTANCE_ID      = os.Getenv("HW_DSC_INSTANCE_ID")
+	HW_DSC_ALARM_TOPIC_ID   = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
+	HW_DSC_ENABLE_FLAG      = os.Getenv("HW_DSC_ENABLE_FLAG")
+	HW_DSC_TYPE_ID          = os.Getenv("HW_DSC_TYPE_ID")
+	HW_DSC_SCAN_TEMPLATE_ID = os.Getenv("HW_DSC_SCAN_TEMPLATE_ID")
+	HW_DSC_SCAN_JOB_ID      = os.Getenv("HW_DSC_SCAN_JOB_ID")
 
 	HW_EIP_ID      = os.Getenv("HW_EIP_ID")
 	HW_EIP_ADDRESS = os.Getenv("HW_EIP_ADDRESS")
@@ -5309,6 +5310,13 @@ func TestAccPreCheckDscEnableFlag(t *testing.T) {
 func TestAccPreCheckDscTypeId(t *testing.T) {
 	if HW_DSC_TYPE_ID == "" {
 		t.Skip("HW_DSC_TYPE_ID must be set for DSC acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDSCScanTemplateID(t *testing.T) {
+	if HW_DSC_SCAN_TEMPLATE_ID == "" {
+		t.Skip("HW_DSC_SCAN_TEMPLATE_ID must be set for DSC acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_template_rules_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_template_rules_test.go
@@ -1,0 +1,168 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscTemplateRules_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_dsc_template_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byRuleName   = "data.huaweicloud_dsc_template_rules.filter_by_rule_name"
+		dcByRuleName = acceptance.InitDataSourceCheck(byRuleName)
+
+		byClassificationId   = "data.huaweicloud_dsc_template_rules.filter_by_classification_id"
+		dcByClassificationId = acceptance.InitDataSourceCheck(byClassificationId)
+
+		bySecurityLevelId   = "data.huaweicloud_dsc_template_rules.filter_by_security_level_id"
+		dcBySecurityLevelId = acceptance.InitDataSourceCheck(bySecurityLevelId)
+
+		byIsUsed   = "data.huaweicloud_dsc_template_rules.filter_by_is_used"
+		dcByIsUsed = acceptance.InitDataSourceCheck(byIsUsed)
+
+		byRuleNameNotFound   = "data.huaweicloud_dsc_template_rules.not_found"
+		dcByRuleNameNotFound = acceptance.InitDataSourceCheck(byRuleNameNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare the scan template in advance and configure the template ID into
+			// the environment variable.
+			acceptance.TestAccPreCheckDSCScanTemplateID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscTemplateRules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "template_rules_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "template_rules_list.0.rule_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "template_rules_list.0.rule_name"),
+
+					dcByRuleName.CheckResourceExists(),
+					resource.TestCheckOutput("rule_name_filter_is_useful", "true"),
+
+					dcByClassificationId.CheckResourceExists(),
+					resource.TestCheckOutput("classification_id_filter_is_useful", "true"),
+
+					dcBySecurityLevelId.CheckResourceExists(),
+					resource.TestCheckOutput("security_level_id_filter_is_useful", "true"),
+
+					dcByIsUsed.CheckResourceExists(),
+					resource.TestCheckOutput("is_used_filter_is_useful", "true"),
+
+					dcByRuleNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDscTemplateRules_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_template_rules" "test" {
+  template_id = "%[1]s"
+}
+
+# Filter by rule_name
+locals {
+  rule_name = data.huaweicloud_dsc_template_rules.test.template_rules_list[0].rule_name
+}
+
+data "huaweicloud_dsc_template_rules" "filter_by_rule_name" {
+  template_id = "%[1]s"
+  rule_name   = local.rule_name
+}
+
+locals {
+  rule_name_filter_result = [
+    for v in data.huaweicloud_dsc_template_rules.filter_by_rule_name.template_rules_list[*].rule_name : v == local.rule_name
+  ]
+}
+
+output "rule_name_filter_is_useful" {
+  value = alltrue(local.rule_name_filter_result) && length(local.rule_name_filter_result) > 0
+}
+
+# Filter by classification_id
+locals {
+  classification_id = data.huaweicloud_dsc_template_rules.test.template_rules_list[0].classification_id
+}
+
+data "huaweicloud_dsc_template_rules" "filter_by_classification_id" {
+  template_id        = "%[1]s"
+  classification_ids = [local.classification_id]
+}
+
+locals {
+  classification_id_filter_result = [
+    for v in data.huaweicloud_dsc_template_rules.filter_by_classification_id.template_rules_list[*].classification_id :
+    v == local.classification_id
+  ]
+}
+
+output "classification_id_filter_is_useful" {
+  value = alltrue(local.classification_id_filter_result) && length(local.classification_id_filter_result) > 0
+}
+
+# Filter by security_level_id
+locals {
+  security_level_id = data.huaweicloud_dsc_template_rules.test.template_rules_list[0].security_level_id
+}
+
+data "huaweicloud_dsc_template_rules" "filter_by_security_level_id" {
+  template_id        = "%[1]s"
+  security_level_ids = [local.security_level_id]
+}
+
+locals {
+  security_level_id_filter_result = [
+    for v in data.huaweicloud_dsc_template_rules.filter_by_security_level_id.template_rules_list[*].security_level_id :
+    v == local.security_level_id
+  ]
+}
+
+output "security_level_id_filter_is_useful" {
+  value = alltrue(local.security_level_id_filter_result) && length(local.security_level_id_filter_result) > 0
+}
+
+# Filter by is_used
+locals {
+  is_used = tostring(data.huaweicloud_dsc_template_rules.test.template_rules_list[0].is_used)
+}
+
+data "huaweicloud_dsc_template_rules" "filter_by_is_used" {
+  template_id = "%[1]s"
+  is_used     = local.is_used
+}
+
+locals {
+  is_used_filter_result = [
+    for v in data.huaweicloud_dsc_template_rules.filter_by_is_used.template_rules_list[*].is_used :
+    tostring(v) == local.is_used
+  ]
+}
+
+output "is_used_filter_is_useful" {
+  value = alltrue(local.is_used_filter_result) && length(local.is_used_filter_result) > 0
+}
+
+data "huaweicloud_dsc_template_rules" "not_found" {
+  template_id = "%[1]s"
+  rule_name   = "not_found"
+}
+
+output "is_not_found" {
+  value = length(data.huaweicloud_dsc_template_rules.not_found.template_rules_list) == 0
+}
+`, acceptance.HW_DSC_SCAN_TEMPLATE_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_template_rules.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_template_rules.go
@@ -1,0 +1,229 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/scan-templates/{template_id}/scan-rules
+func DataSourceDscTemplateRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscTemplateRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"keyword": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"classification_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"security_level_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"is_used": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"template_rules_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dscTemplateRulesSchema(),
+			},
+		},
+	}
+}
+
+func dscTemplateRulesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"rule_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"classification_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_level_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_level_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_level_color": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"is_used": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"rule_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDscTemplateRulesQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("keyword"); ok {
+		queryParams = fmt.Sprintf("%s&keyword=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("classification_ids"); ok {
+		classificationIds := v.([]interface{})
+		for _, id := range classificationIds {
+			queryParams = fmt.Sprintf("%s&classification_ids=%v", queryParams, id)
+		}
+	}
+	if v, ok := d.GetOk("security_level_ids"); ok {
+		securityLevelIds := v.([]interface{})
+		for _, id := range securityLevelIds {
+			queryParams = fmt.Sprintf("%s&security_level_ids=%v", queryParams, id)
+		}
+	}
+	if v, ok := d.GetOk("is_used"); ok {
+		queryParams = fmt.Sprintf("%s&is_used=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("rule_name"); ok {
+		queryParams = fmt.Sprintf("%s&rule_name=%v", queryParams, v)
+	}
+
+	// In the API, this field is designated as the page number.
+	if offset > 0 {
+		queryParams = fmt.Sprintf("%s&offset=%v", queryParams, offset)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func dataSourceDscTemplateRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v1/{project_id}/scan-templates/{template_id}/scan-rules"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{template_id}", d.Get("template_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := requestPath + buildDscTemplateRulesQueryParams(d, offset)
+		requestResp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DSC template rules: %s", err)
+		}
+
+		requestRespBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		templateRulesList := utils.PathSearch("template_rules_list", requestRespBody, make([]interface{}, 0)).([]interface{})
+		if len(templateRulesList) == 0 {
+			break
+		}
+
+		result = append(result, templateRulesList...)
+		offset++
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("template_rules_list", flattenDscTemplateRulesRecords(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDscTemplateRulesRecords(templateRulesList []interface{}) []interface{} {
+	if len(templateRulesList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(templateRulesList))
+	for _, v := range templateRulesList {
+		rst = append(rst, map[string]interface{}{
+			"rule_id":              utils.PathSearch("rule_id", v, nil),
+			"project_id":           utils.PathSearch("project_id", v, nil),
+			"rule_name":            utils.PathSearch("rule_name", v, nil),
+			"template_id":          utils.PathSearch("template_id", v, nil),
+			"classification_id":    utils.PathSearch("classification_id", v, nil),
+			"security_level_id":    utils.PathSearch("security_level_id", v, nil),
+			"security_level_name":  utils.PathSearch("security_level_name", v, nil),
+			"security_level_color": utils.PathSearch("security_level_color", v, nil),
+			"is_used":              utils.PathSearch("is_used", v, nil),
+			"rule_description":     utils.PathSearch("rule_description", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query template rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscTemplateRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDaRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscTemplateRules_basic
=== PAUSE TestAccDataSourceDscTemplateRules_basic
=== CONT  TestAccDataSourceDscTemplateRules_basic
--- PASS: TestAccDataSourceDscTemplateRules_basic (18.48s)
PASS
coverage: 8.8% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       18.608s coverage: 8.8% of statements in ./huaweicloud/services/dsc
```
<img width="1341" height="81" alt="image" src="https://github.com/user-attachments/assets/e2af869a-8a83-4bbe-b7b1-95ec1419a38b" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
