### PR TITLE
feat(dsc): support dsc_data_map_score_update resource

### DIFF
--- a/docs/resources/dsc_data_map_score_update.md
+++ b/docs/resources/dsc_data_map_score_update.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_data_map_score_update"
+description: |-
+  Use this resource to update the data map score within HuaweiCloud.
+---
+
+# huaweicloud_dsc_data_map_score_update
+
+Use this resource to update the data map score within HuaweiCloud.
+
+-> This resource is a one-time action resource. Deleting this resource will not revert the score update,
+  but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_dsc_data_map_score_update" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to update the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `request_id` - The unique ID of this request.
+
+* `msg` - The operation result message.
+
+* `status` - The operation status identifier.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4982,6 +4982,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_asset_obs":                    dsc.ResourceAssetObs(),
 			"huaweicloud_dsc_alarm_notification":           dsc.ResourceAlarmNotification(),
 			"huaweicloud_dsc_multi_enable_trusted_service": dsc.ResourceMultiEnableTrustedService(),
+			"huaweicloud_dsc_data_map_score_update":        dsc.ResourceDscDataMapScoreUpdate(),
 			"huaweicloud_dsc_device":                       dsc.ResourceDscDevice(),
 			"huaweicloud_dsc_stop_scan_job":                dsc.ResourceStopScanJob(),
 

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_data_map_score_update_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_data_map_score_update_test.go
@@ -1,0 +1,31 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceDscDataMapScoreUpdate_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceDscDataMapScoreUpdate_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("huaweicloud_dsc_data_map_score_update.test", "status"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceDscDataMapScoreUpdate_basic = `
+resource "huaweicloud_dsc_data_map_score_update" "test" {}
+`

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_data_map_score_update.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_data_map_score_update.go
@@ -1,0 +1,128 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var dataMapScoreUpdateNonUpdatableParams = []string{""}
+
+// @API DSC PUT /v2/{project_id}/data-map/risk-score
+func ResourceDscDataMapScoreUpdate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDscDataMapScoreUpdateCreate,
+		ReadContext:   resourceDscDataMapScoreUpdateRead,
+		UpdateContext: resourceDscDataMapScoreUpdateUpdate,
+		DeleteContext: resourceDscDataMapScoreUpdateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(dataMapScoreUpdateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"request_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDscDataMapScoreUpdateCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v2/{project_id}/data-map/risk-score"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error updating DSC data map score: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("request_id", utils.PathSearch("id", respBody, nil)),
+		d.Set("msg", utils.PathSearch("msg", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDscDataMapScoreUpdateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDscDataMapScoreUpdateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDscDataMapScoreUpdateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to update the data map score. Deleting this resource
+will not revert the score update, but will only remove the resource information from the tfstate file.`
+
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support dsc_data_map_score_update resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support dsc_data_map_score_update resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dsc' TESTARGS='-run TestAccResourceDscDataMapScoreUpdate_basic -v'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dsc -v -run TestAccResourceDscDataMapScoreUpdate_basic -v -timeout 360m -parallel 4
=== RUN   TestAccResourceDscDataMapScoreUpdate_basic
=== PAUSE TestAccResourceDscDataMapScoreUpdate_basic
=== CONT  TestAccResourceDscDataMapScoreUpdate_basic
--- PASS: TestAccResourceDscDataMapScoreUpdate_basic (30.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       30.844s
```
<img width="468" height="18" alt="Snipaste_2026-07-10_11-41-01" src="https://github.com/user-attachments/assets/d966acdd-2331-4810-9727-ca402e39a047" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
