### PR TITLE
feat(dsc): support `batch_delete_obs` resource

### DIFF
--- a/docs/resources/dsc_batch_delete_obs.md
+++ b/docs/resources/dsc_batch_delete_obs.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_batch_delete_obs"
+description: |-
+  Manages a resource to batch delete OBS assets within HuaweiCloud.
+---
+
+# huaweicloud_dsc_batch_delete_obs
+
+Manages a resource to batch delete OBS assets within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch delete DSC OBS assets. Deleting this resource will not
+  restore the deleted OBS assets or undo the delete action, but will only remove the resource information from
+  the tf state file.
+
+## Example Usage
+
+```hcl
+variable "obs_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_dsc_batch_delete_obs" "test" {
+  obs_ids = var.obs_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `obs_ids` - (Required, List, NonUpdatable) Specifies the list of OBS bucket IDs to delete.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `msg` - The returned message describing the operation result or error information.
+
+* `status` - The returned status, such as '200' or '400'.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4984,6 +4984,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_instance":                     dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_asset_obs":                    dsc.ResourceAssetObs(),
 			"huaweicloud_dsc_alarm_notification":           dsc.ResourceAlarmNotification(),
+			"huaweicloud_dsc_batch_delete_obs":             dsc.ResourceBatchDeleteObs(),
 			"huaweicloud_dsc_multi_enable_trusted_service": dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_data_map_score_update":        dsc.ResourceDscDataMapScoreUpdate(),
 			"huaweicloud_dsc_device":                       dsc.ResourceDscDevice(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -463,6 +463,7 @@ var (
 	HW_DSC_TYPE_ID          = os.Getenv("HW_DSC_TYPE_ID")
 	HW_DSC_SCAN_TEMPLATE_ID = os.Getenv("HW_DSC_SCAN_TEMPLATE_ID")
 	HW_DSC_SCAN_JOB_ID      = os.Getenv("HW_DSC_SCAN_JOB_ID")
+	HW_DSC_OBS_ID           = os.Getenv("HW_DSC_OBS_ID")
 
 	HW_EIP_ID      = os.Getenv("HW_EIP_ID")
 	HW_EIP_ADDRESS = os.Getenv("HW_EIP_ADDRESS")
@@ -5324,6 +5325,13 @@ func TestAccPreCheckDSCScanTemplateID(t *testing.T) {
 func TestAccPreCheckDscScanJobId(t *testing.T) {
 	if HW_DSC_SCAN_JOB_ID == "" {
 		t.Skip("HW_DSC_SCAN_JOB_ID must be set for DSC acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDscObsId(t *testing.T) {
+	if HW_DSC_OBS_ID == "" {
+		t.Skip("HW_DSC_OBS_ID must be set for DSC acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_batch_delete_obs_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_batch_delete_obs_test.go
@@ -1,0 +1,34 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceBatchDeleteObs_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscObsId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceBatchDeleteObs_basic(),
+			},
+		},
+	})
+}
+
+func testAccResourceBatchDeleteObs_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_batch_delete_obs" "test" {
+  obs_ids = split(",", "%s")
+}
+`, acceptance.HW_DSC_OBS_ID)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_batch_delete_obs.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_batch_delete_obs.go
@@ -1,0 +1,132 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchDeleteObsNonUpdatableParams = []string{"obs_ids"}
+
+// @API DSC POST /v1/{project_id}/asset-center/obs/buckets/batch-delete
+func ResourceBatchDeleteObs() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchDeleteObsCreate,
+		ReadContext:   resourceBatchDeleteObsRead,
+		UpdateContext: resourceBatchDeleteObsUpdate,
+		DeleteContext: resourceBatchDeleteObsDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchDeleteObsNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"obs_ids": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildBatchDeleteObsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"obs_ids": utils.ExpandToStringList(d.Get("obs_ids").([]interface{})),
+	}
+}
+
+func resourceBatchDeleteObsCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/asset-center/obs/buckets/batch-delete"
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildBatchDeleteObsBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch deleting DSC OBS assets: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("msg", utils.PathSearch("msg", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceBatchDeleteObsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDeleteObsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDeleteObsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch delete DSC OBS assets. Deleting this
+resource will not restore the deleted OBS assets or undo the delete action, but will only remove the resource
+information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `batch_delete_obs` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support `batch_delete_obs` resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dsc" TESTARGS="-run TestAccResourceBatchDeleteObs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dsc-v -run TestAccResourceBatchDeleteObs_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceBatchDeleteObs_basic
=== PAUSE TestAccResourceBatchDeleteObs_basic
=== CONT  TestAccResourceBatchDeleteObs_basic
--- PASS: TestAccResourceBatchDeleteObs_basic (22.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       21.311s
```
<img width="565" height="29" alt="image" src="https://github.com/user-attachments/assets/a630740b-99e9-4b93-b41b-ed1589b16e92" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
