### PR TITLE
feat(dsc): add dsc_show_metadata datasource

### DIFF
--- a/docs/data-sources/dsc_show_metadata.md
+++ b/docs/data-sources/dsc_show_metadata.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_show_metadata"
+description: |-
+  Use this data source to get the asset metadata information required by the situation dashboard within HuaweiCloud.
+---
+
+# huaweicloud_dsc_show_metadata
+
+Use this data source to get the asset metadata information required by the situation dashboard within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_show_metadata" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `column_num` - The total number of data columns.
+
+* `file_num` - The total number of files.
+
+* `sensitive_column_num` - The number of sensitive columns.
+
+* `sensitive_file_num` - The number of sensitive files.
+
+* `table_num` - The total number of data tables.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1432,6 +1432,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_scan_tasks":                  dsc.DataSourceDscScanTasks(),
 			"huaweicloud_dsc_scan_rules":                  dsc.DataSourceScanRules(),
 			"huaweicloud_dsc_security_class":              dsc.DataSourceSecurityClass(),
+			"huaweicloud_dsc_show_metadata":               dsc.DataSourceDscShowMetadata(),
 			"huaweicloud_dsc_template_rules":              dsc.DataSourceDscTemplateRules(),
 			"huaweicloud_dsc_dbss_oem_info":               dsc.DataSourceDbssOemInfo(),
 			"huaweicloud_dsc_catalog_statical_chart":      dsc.DataSourceCatalogStaticalChart(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_show_metadata_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_show_metadata_test.go
@@ -1,0 +1,38 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscShowMetadata_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_dsc_show_metadata.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscShowMetadata_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "column_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "file_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "sensitive_column_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "sensitive_file_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "table_num"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDscShowMetadata_basic = `
+data "huaweicloud_dsc_show_metadata" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_show_metadata.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_show_metadata.go
@@ -1,0 +1,98 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v2/{project_id}/sec-ops/situation-dashboard/metadata
+func DataSourceDscShowMetadata() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscShowMetadataRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"column_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"file_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"sensitive_column_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"sensitive_file_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"table_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDscShowMetadataRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v2/{project_id}/sec-ops/situation-dashboard/metadata"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC show metadata: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("column_num", utils.PathSearch("column_num", respBody, nil)),
+		d.Set("file_num", utils.PathSearch("file_num", respBody, nil)),
+		d.Set("sensitive_column_num", utils.PathSearch("sensitive_column_num", respBody, nil)),
+		d.Set("sensitive_file_num", utils.PathSearch("sensitive_file_num", respBody, nil)),
+		d.Set("table_num", utils.PathSearch("table_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add dsc_show_metadata datasource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add dsc_show_metadata datasource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dsc' TESTARGS='-run TestAccDataSourceDscShowMetadata_basic -v'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dsc -v -run TestAccDataSourceDscShowMetadata_basic -v -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDscShowMetadata_basic
=== PAUSE TestAccDataSourceDscShowMetadata_basic
=== CONT  TestAccDataSourceDscShowMetadata_basic
--- PASS: TestAccDataSourceDscShowMetadata_basic (24.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       25.040s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.
<img width="440" height="20" alt="Snipaste_2026-07-13_14-40-30" src="https://github.com/user-attachments/assets/14c08aa8-38cc-42a9-a0e1-7df8590b286a" />

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
