### PR TITLE
feat(dataarts): add new data-source for querying architecture dimensions

### DIFF
--- a/docs/data-sources/dataarts_architecture_dimensions.md
+++ b/docs/data-sources/dataarts_architecture_dimensions.md
@@ -1,0 +1,321 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_dimensions"
+description: |-
+  Use this data source to query DataArts Architecture dimensions within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_architecture_dimensions
+
+Use this data source to query DataArts Architecture dimensions within HuaweiCloud.
+
+## Example Usage
+
+### Query all dimensions under a specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_dimensions" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query dimensions by name and type
+
+```hcl
+variable "workspace_id" {}
+variable "dimension_name" {}
+
+data "huaweicloud_dataarts_architecture_dimensions" "test" {
+  workspace_id    = var.workspace_id
+  name            = var.dimension_name
+  dimension_type  = "COMMON"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the dimensions are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the dimensions belong.
+
+* `name` - (Optional, String) Specifies the name or code of the dimension to be fuzzy queried.
+
+* `name_ch` - (Optional, String) Specifies the Chinese name of the dimension to be exactly queried.
+
+* `name_en` - (Optional, String) Specifies the English name of the dimension to be exactly queried.
+
+* `create_by` - (Optional, String) Specifies the creator of the dimension to be queried.
+
+* `approver` - (Optional, String) Specifies the approver of the dimension to be queried.
+
+* `status` - (Optional, String) Specifies the publishing status of the dimension to be queried.
+
+* `l2_id` - (Optional, String) Specifies the subject domain L2 ID to which the dimension belongs.
+
+* `dimension_type` - (Optional, String) Specifies the type of the dimension to be queried.
+
+* `biz_catalog_id` - (Optional, String) Specifies the business catalog ID to which the dimension belongs.
+
+* `fact_logic_id` - (Optional, String) Specifies the fact table ID of the dimension to be queried.
+
+* `begin_time` - (Optional, String) Specifies the start time of the dimension to be queried, in RFC3339 format.
+
+* `end_time` - (Optional, String) Specifies the end time of the dimension to be queried, in RFC3339 format.
+
+* `derivative_ids` - (Optional, List) Specifies the derivative indicator ID list for querying dimensions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `dimensions` - The list of dimensions that matched filter parameters.  
+  The [dimensions](#dataarts_architecture_dimensions_attr) structure is documented below.
+
+<a name="dataarts_architecture_dimensions_attr"></a>
+The `dimensions` block supports:
+
+* `id` - The ID of the dimension.
+
+* `name_ch` - The Chinese name of the dimension.
+
+* `name_en` - The English name of the dimension.
+
+* `dimension_type` - The type of the dimension.
+
+* `description` - The description of the dimension.
+
+* `owner` - The asset owner of the dimension.
+
+* `status` - The publishing status of the dimension.
+  + **DRAFT**
+  + **PUBLISH_DEVELOPING**
+  + **PUBLISHED**
+  + **OFFLINE_DEVELOPING**
+  + **OFFLINE**
+  + **REJECT**
+
+* `code_table_id` - The code table ID of the dimension.
+
+* `l1_id` - The L1 subject domain grouping ID of the dimension.
+
+* `l2_id` - The L2 subject domain ID of the dimension.
+
+* `l3_id` - The L3 business object ID of the dimension.
+
+* `l1_name` - The L1 subject domain grouping name of the dimension.
+
+* `l2_name` - The L2 subject domain name of the dimension.
+
+* `l3_name` - The L3 business object name of the dimension.
+
+* `created_by` - The creator of the dimension.
+
+* `updated_by` - The updater of the dimension.
+
+* `created_at` - The creation time of the dimension, in RFC3339 format.
+
+* `updated_at` - The latest update time of the dimension, in RFC3339 format.
+
+* `table_type` - The table type of the dimension.
+
+* `distribute` - The distribute type of the dimension.
+
+* `distribute_column` - The distribute column of the dimension.
+
+* `obs_location` - The OBS location of the dimension.
+
+* `alias` - The alias of the dimension.
+
+* `configs` - The configs of the dimension.
+
+* `env_type` - The environment type of the dimension.
+
+* `model_id` - The model ID of the dimension.
+
+* `dev_version` - The development environment version of the dimension.
+
+* `prod_version` - The production environment version of the dimension.
+
+* `dev_version_name` - The development environment version name of the dimension.
+
+* `prod_version_name` - The production environment version name of the dimension.
+
+* `datasource` - The data source configuration of the dimension.  
+  The [datasource](#dataarts_architecture_dimensions_datasource_attr) structure is documented below.
+
+* `attributes` - The list of attributes of the dimension.  
+  The [attributes](#dataarts_architecture_dimensions_attributes_attr) structure is documented below.
+
+* `hierarchies` - The hierarchy attributes of the dimension.  
+  The [hierarchies](#dataarts_architecture_dimensions_hierarchies_attr) structure is documented below.
+
+* `code_table` - The code table information of the dimension.  
+  The [code_table](#dataarts_architecture_dimensions_code_table_attr) structure is documented below.
+
+* `model` - The model information of the dimension.  
+  The [model](#dataarts_architecture_dimensions_model_attr) structure is documented below.
+
+<a name="dataarts_architecture_dimensions_datasource_attr"></a>
+The `datasource` block supports:
+
+* `id` - The ID of the data source.
+
+* `biz_type` - The business type of the data source.
+
+* `biz_id` - The business ID of the data source.
+
+* `dw_id` - The ID of the data connection.
+
+* `dw_type` - The type of the data connection.
+
+* `dw_name` - The name of the data connection.
+
+* `db_name` - The name of the database corresponding to the data connection.
+
+* `queue_name` - The queue name corresponding to the DLI data connection.
+
+* `schema` - The name of the database schema.
+
+<a name="dataarts_architecture_dimensions_attributes_attr"></a>
+The `attributes` block supports:
+
+* `id` - The ID of the attribute.
+
+* `name_en` - The English name of the attribute.
+
+* `name_ch` - The Chinese name of the attribute.
+
+* `description` - The description of the attribute.
+
+* `data_type` - The data type of the attribute.
+
+* `domain_type` - The domain type of the attribute.
+
+* `data_type_extend` - The data type extension of the attribute.
+
+* `is_primary_key` - Whether the attribute is the primary key.
+
+* `is_biz_primary` - Whether the attribute is the business primary key.
+
+* `is_partition_key` - Whether the attribute is the partition key.
+
+* `ordinal` - The sequence number of the attribute.
+
+* `not_null` - Whether the attribute is not null.
+
+* `code_table_field_id` - The code table field ID of the attribute.
+
+* `create_by` - The creator of the attribute.
+
+* `stand_row_id` - The associated data standard ID of the attribute.
+
+* `stand_row_name` - The associated data standard name of the attribute.
+
+* `quality_infos` - The quality information of the attribute.
+
+* `secrecy_levels` - The secrecy levels of the attribute.
+
+* `status` - The publishing status of the attribute.
+
+* `create_time` - The creation time of the attribute, in RFC3339 format.
+
+* `update_time` - The latest update time of the attribute, in RFC3339 format.
+
+* `alias` - The alias of the attribute.
+
+* `self_defined_fields` - The self-defined fields of the attribute.
+
+<a name="dataarts_architecture_dimensions_hierarchies_attr"></a>
+The `hierarchies` block supports:
+
+* `id` - The ID of the hierarchy.
+
+* `name` - The name of the hierarchy.
+
+* `created_by` - The creator of the hierarchy.
+
+* `updated_by` - The updater of the hierarchy.
+
+* `created_at` - The creation time of the hierarchy, in RFC3339 format.
+
+* `updated_at` - The latest update time of the hierarchy, in RFC3339 format.
+
+* `attrs` - The attributes of the hierarchy.  
+  The [attrs](#dataarts_architecture_dimensions_hierarchies_attrs_attr) structure is documented below.
+
+<a name="dataarts_architecture_dimensions_hierarchies_attrs_attr"></a>
+The `attrs` block supports:
+
+* `id` - The ID of the hierarchy attribute.
+
+* `hierarchies_id` - The hierarchy ID of the attribute.
+
+* `attr_id` - The attribute ID.
+
+* `level` - The level of the hierarchy attribute.
+
+* `attr_name_en` - The English name of the referenced attribute.
+
+* `attr_name_ch` - The Chinese name of the referenced attribute.
+
+<a name="dataarts_architecture_dimensions_code_table_attr"></a>
+The `code_table` block supports:
+
+* `id` - The ID of the code table.
+
+* `name_en` - The English name of the code table.
+
+* `name_ch` - The Chinese name of the code table.
+
+* `tb_version` - The version of the code table.
+
+* `directory_id` - The directory ID of the code table.
+
+* `directory_path` - The directory path of the code table.
+
+* `description` - The description of the code table.
+
+* `status` - The publishing status of the code table.
+
+<a name="dataarts_architecture_dimensions_model_attr"></a>
+The `model` block supports:
+
+* `id` - The ID of the workspace.
+
+* `name` - The name of the workspace.
+
+* `description` - The description of the workspace.
+
+* `is_physical` - Whether it is a physical table.
+
+* `frequent` - Whether it is frequently used.
+
+* `top` - Whether it is a top-level governance.
+
+* `level` - The data governance level.
+
+* `dw_type` - The data warehouse type.
+
+* `create_time` - The creation time of the workspace, in RFC3339 format.
+
+* `update_time` - The latest update time of the workspace, in RFC3339 format.
+
+* `create_by` - The creator of the workspace.
+
+* `update_by` - The updater of the workspace.
+
+* `type` - The workspace type.
+
+* `biz_catalog_ids` - The associated business catalog IDs.
+
+* `databases` - The database names.
+
+* `table_model_prefix` - The table model prefix.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1115,6 +1115,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_data_standards":                   dataarts.DataSourceArchitectureDataStandards(),
 			"huaweicloud_dataarts_architecture_data_standard_template_customs":   dataarts.DataSourceArchitectureDataStandardTemplateCustoms(),
 			"huaweicloud_dataarts_architecture_data_standard_template_optionals": dataarts.DataSourceArchitectureDataStandardTemplateOptionals(),
+			"huaweicloud_dataarts_architecture_dimensions":                       dataarts.DataSourceArchitectureDimensions(),
 			"huaweicloud_dataarts_architecture_directories":                      dataarts.DataSourceArchitectureDirectories(),
 			"huaweicloud_dataarts_architecture_models":                           dataarts.DataSourceArchitectureModels(),
 			"huaweicloud_dataarts_architecture_model_statistic":                  dataarts.DataSourceArchitectureModelStatistic(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_dimensions_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_dimensions_test.go
@@ -1,0 +1,447 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureDimensions_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_dimensions.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_architecture_dimensions.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNameCh   = "data.huaweicloud_dataarts_architecture_dimensions.filter_by_name_ch"
+		dcByNameCh = acceptance.InitDataSourceCheck(byNameCh)
+
+		byNameEn   = "data.huaweicloud_dataarts_architecture_dimensions.filter_by_name_en"
+		dcByNameEn = acceptance.InitDataSourceCheck(byNameEn)
+
+		byCreateBy   = "data.huaweicloud_dataarts_architecture_dimensions.filter_by_create_by"
+		dcByCreateBy = acceptance.InitDataSourceCheck(byCreateBy)
+
+		byStatus   = "data.huaweicloud_dataarts_architecture_dimensions.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byDimensionType   = "data.huaweicloud_dataarts_architecture_dimensions.filter_by_dimension_type"
+		dcByDimensionType = acceptance.InitDataSourceCheck(byDimensionType)
+
+		byBeginTime   = "data.huaweicloud_dataarts_architecture_dimensions.filter_by_begin_time"
+		dcByBeginTime = acceptance.InitDataSourceCheck(byBeginTime)
+
+		byEndTime   = "data.huaweicloud_dataarts_architecture_dimensions.filter_by_end_time"
+		dcByEndTime = acceptance.InitDataSourceCheck(byEndTime)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsConnectionID(t)
+			acceptance.TestAccPreCheckDataArtsArchitectureReviewer(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.14.0",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataArchitectureDimensions_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Architecture dimensions"),
+			},
+			{
+				Config: testAccDataArchitectureDimensions_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "dimensions.#", regexp.MustCompile(`^[2-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.id"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.name_ch"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.name_en"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.dimension_type"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.status"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.created_by"),
+					resource.TestMatchResourceAttr(all, "dimensions.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(all, "dimensions.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.l1_id"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.l2_id"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.l1_name"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.l2_name"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.l3_name"),
+					resource.TestCheckResourceAttrSet(all, "dimensions.0.model_id"),
+					resource.TestMatchResourceAttr(all, "dimensions.0.datasource.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestMatchResourceAttr(all, "dimensions.0.attributes.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestMatchResourceAttr(all, "dimensions.0.model.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+
+					// Filter by name (fuzzy).
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+
+					// Filter by name_ch (exact).
+					dcByNameCh.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_ch_filter_useful", "true"),
+
+					// Filter by name_en (exact).
+					dcByNameEn.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_en_filter_useful", "true"),
+
+					// Filter by create_by.
+					dcByCreateBy.CheckResourceExists(),
+					resource.TestCheckOutput("is_create_by_filter_useful", "true"),
+
+					// Filter by status.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+
+					// Filter by dimension_type.
+					dcByDimensionType.CheckResourceExists(),
+					resource.TestCheckOutput("is_dimension_type_filter_useful", "true"),
+
+					// Filter by begin_time.
+					dcByBeginTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_begin_time_filter_useful", "true"),
+
+					// Filter by end_time.
+					dcByEndTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_end_time_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureDimensions_nonExistentWorkspace() string {
+	randUUID := uuid.New().String()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_architecture_dimensions" "test" {
+  workspace_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataArchitectureDimension_base(name string) string {
+	return fmt.Sprintf(`
+# Need to create the parent subject first, and then create the child subject
+resource "huaweicloud_dataarts_architecture_subject" "level1" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  code         = "%[2]s"
+  owner        = "%[3]s"
+  level        = 1
+  description  = "level 1 created by terraform acc test"
+}
+
+resource "huaweicloud_dataarts_architecture_subject" "level2" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  code         = "%[2]s"
+  owner        = "%[3]s"
+  level        = 2
+  parent_id    = huaweicloud_dataarts_architecture_subject.level1.id
+  description  = "level 2 created by terraform acc test"
+}
+
+resource "huaweicloud_dataarts_architecture_subject" "level3" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  code         = "%[2]s"
+  department   = "%[2]s"
+  owner        = "%[3]s"
+  level        = 3
+  parent_id    = huaweicloud_dataarts_architecture_subject.level2.id
+  description  = "level 3 created by terraform acc test"
+}
+
+# The sub-subject can only be published after the parent subject is published
+resource "huaweicloud_dataarts_architecture_batch_publishment" "publish1" {
+  workspace_id       = "%[1]s"
+  approver_user_name = "%[3]s"
+  approver_user_id   = "%[4]s"
+  fast_approval      = true
+
+  biz_infos {
+    biz_id   = huaweicloud_dataarts_architecture_subject.level1.id
+    biz_type = "SUBJECT"
+  }
+}
+
+resource "huaweicloud_dataarts_architecture_batch_publishment" "publish2" {
+  workspace_id       = "%[1]s"
+  approver_user_name = "%[3]s"
+  approver_user_id   = "%[4]s"
+  fast_approval      = true
+
+  biz_infos {
+    biz_id   = huaweicloud_dataarts_architecture_subject.level2.id
+    biz_type = "SUBJECT"
+  }
+
+  depends_on = [
+    huaweicloud_dataarts_architecture_batch_publishment.publish1,
+  ]
+}
+
+resource "huaweicloud_dataarts_architecture_batch_publishment" "publish3" {
+  workspace_id       = "%[1]s"
+  approver_user_name = "%[3]s"
+  approver_user_id   = "%[4]s"
+  fast_approval      = true
+
+  biz_infos {
+    biz_id   = huaweicloud_dataarts_architecture_subject.level3.id
+    biz_type = "SUBJECT"
+  }
+
+  depends_on = [
+    huaweicloud_dataarts_architecture_batch_publishment.publish2,
+  ]
+}
+
+# Need to wait for the dimension database in the cloud service backend to obtain the subject publishment information
+resource "time_sleep" "wait_10_second" {
+  create_duration = "10s"
+
+  depends_on = [
+    huaweicloud_dataarts_architecture_batch_publishment.publish3
+  ]
+}
+
+resource "huaweicloud_dataarts_architecture_dimension" "test" {
+  count = 2
+
+  workspace_id   = "%[1]s"
+  name_ch        = "dim_%[2]s_${count.index + 1}"
+  name_en        = "dim_%[2]s_${count.index + 1}"
+  l3_id          = huaweicloud_dataarts_architecture_subject.level3.id
+  dimension_type = "COMMON"
+  owner          = "%[3]s"
+  description    = "Created by terraform script"
+
+  # delete physical table when deleting the dimension
+  is_delete_physical_table = true
+
+  attributes {
+    name_en        = "attr1_en"
+    name_ch        = "attr1_ch"
+    data_type      = "STRING"
+    is_primary_key = true
+    ordinal        = 1
+  }
+
+  attributes {
+    name_en        = "attr2_en"
+    name_ch        = "attr2_ch"
+    data_type      = "BIGINT"
+    is_primary_key = false
+    ordinal        = 2
+  }
+
+  datasource {
+    dw_id   = "%[5]s"
+    dw_type = "DLI"
+    db_name = "default"
+  }
+
+  depends_on = [
+    time_sleep.wait_10_second
+  ]
+}
+`,
+		acceptance.HW_DATAARTS_WORKSPACE_ID,
+		name,
+		acceptance.HW_DATAARTS_ARCHITECTURE_USER_NAME,
+		acceptance.HW_DATAARTS_ARCHITECTURE_USER_ID,
+		acceptance.HW_DATAARTS_CONNECTION_ID)
+}
+
+func testAccDataArchitectureDimensions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dataarts_architecture_dimensions" "all" {
+  workspace_id = "%[2]s"
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+# Filter by name (fuzzy).
+locals {
+  dimension_name = huaweicloud_dataarts_architecture_dimension.test[0].name_ch
+}
+
+data "huaweicloud_dataarts_architecture_dimensions" "filter_by_name" {
+  workspace_id = "%[2]s"
+  name         = local.dimension_name
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+locals {
+  name_filter_has_one   = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_name.dimensions[*].id,
+  huaweicloud_dataarts_architecture_dimension.test[0].id)
+  name_filter_has_other = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_name.dimensions[*].id,
+  huaweicloud_dataarts_architecture_dimension.test[1].id)
+  name_filter_is_useful = local.name_filter_has_one && !local.name_filter_has_other
+}
+
+output "is_name_filter_useful" {
+  value = local.name_filter_is_useful
+}
+
+# Filter by name_ch (exact).
+locals {
+  dimension_name_ch = huaweicloud_dataarts_architecture_dimension.test[0].name_ch
+}
+
+data "huaweicloud_dataarts_architecture_dimensions" "filter_by_name_ch" {
+  workspace_id = "%[2]s"
+  name_ch      = local.dimension_name_ch
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+locals {
+  name_ch_filter_has_one   = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_name_ch.dimensions[*].id,
+  huaweicloud_dataarts_architecture_dimension.test[0].id)
+  name_ch_filter_has_other = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_name_ch.dimensions[*].id,
+  huaweicloud_dataarts_architecture_dimension.test[1].id)
+  is_name_ch_filter_useful = local.name_ch_filter_has_one && !local.name_ch_filter_has_other
+}
+
+output "is_name_ch_filter_useful" {
+  value = local.is_name_ch_filter_useful
+}
+
+# Filter by name_en (exact).
+locals {
+  dimension_name_en = try(huaweicloud_dataarts_architecture_dimension.test[0].name_en, "NOT_FOUND")
+}
+
+data "huaweicloud_dataarts_architecture_dimensions" "filter_by_name_en" {
+  workspace_id = "%[2]s"
+  name_en      = local.dimension_name_en
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+locals {
+  name_en_filter_has_one   = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_name_en.dimensions[*].id,
+  huaweicloud_dataarts_architecture_dimension.test[0].id)
+  name_en_filter_has_other = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_name_en.dimensions[*].id,
+  huaweicloud_dataarts_architecture_dimension.test[1].id)
+  is_name_en_filter_useful = local.name_en_filter_has_one && !local.name_en_filter_has_other
+}
+
+output "is_name_en_filter_useful" {
+  value = local.is_name_en_filter_useful
+}
+
+# Filter by create_by.
+locals {
+  dimension_creator = try(huaweicloud_dataarts_architecture_dimension.test[0].created_by, "NOT_FOUND")
+}
+
+data "huaweicloud_dataarts_architecture_dimensions" "filter_by_create_by" {
+  workspace_id = "%[2]s"
+  create_by    = local.dimension_creator
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+output "is_create_by_filter_useful" {
+  value = length(data.huaweicloud_dataarts_architecture_dimensions.filter_by_create_by.dimensions) >= 1
+}
+
+# Filter by status.
+locals {
+  dimension_status = try(huaweicloud_dataarts_architecture_dimension.test[0].status, "NOT_FOUND")
+}
+
+data "huaweicloud_dataarts_architecture_dimensions" "filter_by_status" {
+  workspace_id = "%[2]s"
+  status       = local.dimension_status
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_dimensions.filter_by_status.dimensions :
+      v.status == local.dimension_status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by dimension_type.
+data "huaweicloud_dataarts_architecture_dimensions" "filter_by_dimension_type" {
+  workspace_id    = "%[2]s"
+  dimension_type  = "COMMON"
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+locals {
+  type_filter_has_one   = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_name_en.dimensions[*].id,
+  huaweicloud_dataarts_architecture_dimension.test[0].id)
+  type_filter_has_other = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_name_en.dimensions[*].id,
+  huaweicloud_dataarts_architecture_dimension.test[1].id)
+  type_filter_useful    = local.type_filter_has_one && !local.type_filter_has_other
+}
+
+output "is_dimension_type_filter_useful" {
+  value = local.type_filter_useful
+}
+
+# Filter by begin_time.
+locals {
+  dimension_begin_time = timeadd(huaweicloud_dataarts_architecture_dimension.test[0].create_time, "-10m")
+}
+
+data "huaweicloud_dataarts_architecture_dimensions" "filter_by_begin_time" {
+  workspace_id = "%[2]s"
+  begin_time   = local.dimension_begin_time
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+output "is_begin_time_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_begin_time.dimensions[*].id,
+    huaweicloud_dataarts_architecture_dimension.test[0].id)
+}
+
+# Filter by end_time.
+locals {
+  dimension_end_time = timeadd(huaweicloud_dataarts_architecture_dimension.test[0].create_time, "10m")
+}
+
+data "huaweicloud_dataarts_architecture_dimensions" "filter_by_end_time" {
+  workspace_id = "%[2]s"
+  end_time     = local.dimension_end_time
+
+  depends_on = [huaweicloud_dataarts_architecture_dimension.test]
+}
+
+output "is_end_time_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_dimensions.filter_by_end_time.dimensions[*].id,
+    huaweicloud_dataarts_architecture_dimension.test[0].id)
+}
+`, testAccDataArchitectureDimension_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_dimensions.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_dimensions.go
@@ -1,0 +1,1005 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/dimensions
+func DataSourceArchitectureDimensions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureDimensionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the dimensions are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the dimensions belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name or code of the dimension to be fuzzy queried.`,
+			},
+			"name_ch": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The Chinese name of the dimension to be exactly queried.`,
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The English name of the dimension to be exactly queried.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The creator of the dimension to be queried.`,
+			},
+			"approver": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The approver of the dimension to be queried.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The publishing status of the dimension to be queried.`,
+			},
+			"l2_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The subject domain L2 ID to which the dimension belongs.`,
+			},
+			"dimension_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the dimension to be queried.`,
+			},
+			"biz_catalog_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The business catalog ID to which the dimension belongs.`,
+			},
+			"fact_logic_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The fact table ID of the dimension to be queried.`,
+			},
+			"begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The start time of the dimension to be queried, in RFC3339 format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The end time of the dimension to be queried, in RFC3339 format.`,
+			},
+			"derivative_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The derivative indicator ID list for querying dimensions.`,
+			},
+
+			// Attributes.
+			"dimensions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDimensionsElem(),
+				Description: `The list of dimensions that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDimensionsElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the dimension.`,
+			},
+			"name_ch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Chinese name of the dimension.`,
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The English name of the dimension.`,
+			},
+			"dimension_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the dimension.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the dimension.`,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The asset owner of the dimension.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The publishing status of the dimension.`,
+			},
+			"code_table_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The code table ID of the dimension.`,
+			},
+			"l1_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The L1 subject domain grouping ID of the dimension.`,
+			},
+			"l2_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The L2 subject domain ID of the dimension.`,
+			},
+			"l3_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The L3 business object ID of the dimension.`,
+			},
+			"l1_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The L1 subject domain grouping name of the dimension.`,
+			},
+			"l2_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The L2 subject domain name of the dimension.`,
+			},
+			"l3_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The L3 business object name of the dimension.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the dimension.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The updater of the dimension.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the dimension, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the dimension, in RFC3339 format.`,
+			},
+			"table_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The table type of the dimension.`,
+			},
+			"distribute": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The distribute type of the dimension.`,
+			},
+			"distribute_column": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The distribute column of the dimension.`,
+			},
+			"obs_location": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OBS location of the dimension.`,
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The alias of the dimension.`,
+			},
+			"configs": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The configs of the dimension.`,
+			},
+			"env_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The environment type of the dimension.`,
+			},
+			"model_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The model ID of the dimension.`,
+			},
+			"dev_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The development environment version of the dimension.`,
+			},
+			"prod_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The production environment version of the dimension.`,
+			},
+			"dev_version_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The development environment version name of the dimension.`,
+			},
+			"prod_version_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The production environment version name of the dimension.`,
+			},
+			"datasource": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDimensionDatasource(),
+				Description: `The data source configuration of the dimension.`,
+			},
+			"attributes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDimensionAttributes(),
+				Description: `The list of attributes of the dimension.`,
+			},
+			"hierarchies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDimensionHierarchies(),
+				Description: `The hierarchy attributes of the dimension.`,
+			},
+			"code_table": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDimensionCodeTable(),
+				Description: `The code table information of the dimension.`,
+			},
+			"model": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDimensionModel(),
+				Description: `The model information of the dimension.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDimensionDatasource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the data source.`,
+			},
+			"biz_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The business type of the data source.`,
+			},
+			"biz_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The business ID of the data source.`,
+			},
+			"dw_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the data connection.`,
+			},
+			"dw_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the data connection.`,
+			},
+			"dw_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the data connection.`,
+			},
+			"db_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database corresponding to the data connection.`,
+			},
+			"queue_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The queue name corresponding to the DLI data connection.`,
+			},
+			"schema": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database schema.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDimensionAttributes() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the attribute.`,
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The English name of the attribute.`,
+			},
+			"name_ch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Chinese name of the attribute.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the attribute.`,
+			},
+			"data_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data type of the attribute.`,
+			},
+			"domain_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain type of the attribute.`,
+			},
+			"data_type_extend": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data type extension of the attribute.`,
+			},
+			"is_primary_key": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the attribute is the primary key.`,
+			},
+			"is_biz_primary": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the attribute is the business primary key.`,
+			},
+			"is_partition_key": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the attribute is the partition key.`,
+			},
+			"ordinal": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The sequence number of the attribute.`,
+			},
+			"not_null": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the attribute is not null.`,
+			},
+			"code_table_field_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The code table field ID of the attribute.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the attribute.`,
+			},
+			"stand_row_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The associated data standard ID of the attribute.`,
+			},
+			"stand_row_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The associated data standard name of the attribute.`,
+			},
+			"quality_infos": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The quality information of the attribute.`,
+			},
+			"secrecy_levels": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The secrecy levels of the attribute.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The publishing status of the attribute.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the attribute, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the attribute, in RFC3339 format.`,
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The alias of the attribute.`,
+			},
+			"self_defined_fields": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The self-defined fields of the attribute.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDimensionHierarchies() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the hierarchy.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the hierarchy.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the hierarchy.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The updater of the hierarchy.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the hierarchy, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the hierarchy, in RFC3339 format.`,
+			},
+			"attrs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDimensionHierarchiesAttr(),
+				Description: `The attributes of the hierarchy.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDimensionHierarchiesAttr() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the hierarchy attribute.`,
+			},
+			"hierarchies_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The hierarchy ID of the attribute.`,
+			},
+			"attr_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The attribute ID.`,
+			},
+			"level": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The level of the hierarchy attribute.`,
+			},
+			"attr_name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The English name of the referenced attribute.`,
+			},
+			"attr_name_ch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Chinese name of the referenced attribute.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDimensionCodeTable() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the code table.`,
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The English name of the code table.`,
+			},
+			"name_ch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Chinese name of the code table.`,
+			},
+			"tb_version": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The version of the code table.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory ID of the code table.`,
+			},
+			"directory_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory path of the code table.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the code table.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The publishing status of the code table.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDimensionModel() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the workspace.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the workspace.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the workspace.`,
+			},
+			"is_physical": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether it is a physical table.`,
+			},
+			"frequent": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether it is frequently used.`,
+			},
+			"top": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether it is a top-level governance.`,
+			},
+			"level": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data governance level.`,
+			},
+			"dw_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data warehouse type.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the workspace, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the workspace, in RFC3339 format.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the workspace.`,
+			},
+			"update_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The updater of the workspace.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The workspace type.`,
+			},
+			"biz_catalog_ids": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The associated business catalog IDs.`,
+			},
+			"databases": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The database names.`,
+			},
+			"table_model_prefix": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The table model prefix.`,
+			},
+		},
+	}
+}
+
+func buildArchitectureDimensionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("name_ch"); ok {
+		res = fmt.Sprintf("%s&name_ch=%v", res, v)
+	}
+	if v, ok := d.GetOk("name_en"); ok {
+		res = fmt.Sprintf("%s&name_en=%v", res, v)
+	}
+	if v, ok := d.GetOk("create_by"); ok {
+		res = fmt.Sprintf("%s&create_by=%v", res, v)
+	}
+	if v, ok := d.GetOk("approver"); ok {
+		res = fmt.Sprintf("%s&approver=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("l2_id"); ok {
+		res = fmt.Sprintf("%s&l2_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("dimension_type"); ok {
+		res = fmt.Sprintf("%s&dimension_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("biz_catalog_id"); ok {
+		res = fmt.Sprintf("%s&biz_catalog_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("fact_logic_id"); ok {
+		res = fmt.Sprintf("%s&fact_logic_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("begin_time"); ok {
+		res = fmt.Sprintf("%s&begin_time=%s", res, url.QueryEscape(v.(string)))
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		res = fmt.Sprintf("%s&end_time=%s", res, url.QueryEscape(v.(string)))
+	}
+	if v, ok := d.GetOk("derivative_ids"); ok {
+		for _, id := range v.([]interface{}) {
+			res = fmt.Sprintf("%s&derivative_ids=%v", res, id)
+		}
+	}
+
+	return res
+}
+
+func listArchitectureDimensions(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/design/dimensions?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildArchitectureDimensionsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		records := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, records...)
+
+		if len(records) < limit {
+			break
+		}
+		offset += len(records)
+	}
+
+	return result, nil
+}
+
+func flattenDimensionsHierarchies(hierarchies []interface{}) []map[string]interface{} {
+	if len(hierarchies) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(hierarchies))
+	for _, hierarchy := range hierarchies {
+		result = append(result, map[string]interface{}{
+			"id":         utils.PathSearch("id", hierarchy, nil),
+			"name":       utils.PathSearch("name", hierarchy, nil),
+			"created_by": utils.PathSearch("create_by", hierarchy, nil),
+			"updated_by": utils.PathSearch("update_by", hierarchy, nil),
+			"created_at": utils.PathSearch("create_time", hierarchy, nil),
+			"updated_at": utils.PathSearch("update_time", hierarchy, nil),
+			"attrs":      flattenDimensionsHierarchiesAttrs(utils.PathSearch("attrs", hierarchy, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenDimensionsHierarchiesAttrs(attrs []interface{}) []map[string]interface{} {
+	if len(attrs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(attrs))
+	for _, attr := range attrs {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", attr, nil),
+			"hierarchies_id": utils.PathSearch("hierarchies_id", attr, nil),
+			"attr_id":        utils.PathSearch("attr_id", attr, nil),
+			"level":          utils.PathSearch("level", attr, nil),
+			"attr_name_en":   utils.PathSearch("attr_name_en", attr, nil),
+			"attr_name_ch":   utils.PathSearch("attr_name_ch", attr, nil),
+		})
+	}
+	return result
+}
+
+func flattenDimensionsCodeTable(codeTable map[string]interface{}) []map[string]interface{} {
+	if len(codeTable) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":             utils.PathSearch("id", codeTable, nil),
+			"name_en":        utils.PathSearch("name_en", codeTable, nil),
+			"name_ch":        utils.PathSearch("name_ch", codeTable, nil),
+			"tb_version":     utils.PathSearch("tb_version", codeTable, nil),
+			"directory_id":   utils.PathSearch("directory_id", codeTable, nil),
+			"directory_path": utils.PathSearch("directory_path", codeTable, nil),
+			"description":    utils.PathSearch("description", codeTable, nil),
+			"status":         utils.PathSearch("status", codeTable, nil),
+		},
+	}
+}
+
+func flattenDimensionsDatasource(datasource map[string]interface{}) []map[string]interface{} {
+	if len(datasource) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":         utils.PathSearch("id", datasource, nil),
+			"biz_type":   utils.PathSearch("biz_type", datasource, nil),
+			"biz_id":     utils.PathSearch("biz_id", datasource, nil),
+			"dw_id":      utils.PathSearch("dw_id", datasource, nil),
+			"dw_type":    utils.PathSearch("dw_type", datasource, nil),
+			"dw_name":    utils.PathSearch("dw_name", datasource, nil),
+			"db_name":    utils.PathSearch("db_name", datasource, nil),
+			"queue_name": utils.PathSearch("queue_name", datasource, nil),
+			"schema":     utils.PathSearch("schema", datasource, nil),
+		},
+	}
+}
+
+func flattenDimensionsAttributes(attributes []interface{}) []map[string]interface{} {
+	if len(attributes) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(attributes))
+	for _, attr := range attributes {
+		result = append(result, map[string]interface{}{
+			"id":                  utils.PathSearch("id", attr, nil),
+			"name_en":             utils.PathSearch("name_en", attr, nil),
+			"name_ch":             utils.PathSearch("name_ch", attr, nil),
+			"description":         utils.PathSearch("description", attr, nil),
+			"data_type":           utils.PathSearch("data_type", attr, nil),
+			"domain_type":         utils.PathSearch("domain_type", attr, nil),
+			"data_type_extend":    utils.PathSearch("data_type_extend", attr, nil),
+			"is_primary_key":      utils.PathSearch("is_primary_key", attr, nil),
+			"is_biz_primary":      utils.PathSearch("is_biz_primary", attr, nil),
+			"is_partition_key":    utils.PathSearch("is_partition_key", attr, nil),
+			"ordinal":             utils.PathSearch("ordinal", attr, nil),
+			"not_null":            utils.PathSearch("not_null", attr, nil),
+			"code_table_field_id": utils.PathSearch("code_table_field_id", attr, nil),
+			"create_by":           utils.PathSearch("create_by", attr, nil),
+			"stand_row_id":        utils.PathSearch("stand_row_id", attr, nil),
+			"stand_row_name":      utils.PathSearch("stand_row_name", attr, nil),
+			"quality_infos":       utils.PathSearch("quality_infos", attr, nil),
+			"secrecy_levels":      utils.PathSearch("secrecy_levels", attr, nil),
+			"status":              utils.PathSearch("status", attr, nil),
+			"create_time":         utils.PathSearch("create_time", attr, nil),
+			"update_time":         utils.PathSearch("update_time", attr, nil),
+			"alias":               utils.PathSearch("alias", attr, nil),
+			"self_defined_fields": utils.PathSearch("self_defined_fields", attr, nil),
+		})
+	}
+	return result
+}
+
+func flattenDimensionsModel(model map[string]interface{}) []map[string]interface{} {
+	if len(model) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":                 utils.PathSearch("id", model, nil),
+			"name":               utils.PathSearch("name", model, nil),
+			"description":        utils.PathSearch("description", model, nil),
+			"is_physical":        utils.PathSearch("is_physical", model, nil),
+			"frequent":           utils.PathSearch("frequent", model, nil),
+			"top":                utils.PathSearch("top", model, nil),
+			"level":              utils.PathSearch("level", model, nil),
+			"dw_type":            utils.PathSearch("dw_type", model, nil),
+			"create_time":        utils.PathSearch("create_time", model, nil),
+			"update_time":        utils.PathSearch("update_time", model, nil),
+			"create_by":          utils.PathSearch("create_by", model, nil),
+			"update_by":          utils.PathSearch("update_by", model, nil),
+			"type":               utils.PathSearch("type", model, nil),
+			"biz_catalog_ids":    utils.PathSearch("biz_catalog_ids", model, nil),
+			"databases":          utils.PathSearch("databases", model, nil),
+			"table_model_prefix": utils.PathSearch("table_model_prefix", model, nil),
+		},
+	}
+}
+
+func flattenArchitectureDimensions(dimensions []interface{}) []map[string]interface{} {
+	if len(dimensions) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(dimensions))
+	for _, dimension := range dimensions {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", dimension, nil),
+			"name_ch":           utils.PathSearch("name_ch", dimension, nil),
+			"name_en":           utils.PathSearch("name_en", dimension, nil),
+			"dimension_type":    utils.PathSearch("dimension_type", dimension, nil),
+			"description":       utils.PathSearch("description", dimension, nil),
+			"owner":             utils.PathSearch("owner", dimension, nil),
+			"status":            utils.PathSearch("status", dimension, nil),
+			"code_table_id":     utils.PathSearch("code_table_id", dimension, nil),
+			"l1_id":             utils.PathSearch("l1_id", dimension, nil),
+			"l2_id":             utils.PathSearch("l2_id", dimension, nil),
+			"l3_id":             utils.PathSearch("l3_id", dimension, nil),
+			"l1_name":           utils.PathSearch("l1", dimension, nil),
+			"l2_name":           utils.PathSearch("l2", dimension, nil),
+			"l3_name":           utils.PathSearch("l3", dimension, nil),
+			"created_by":        utils.PathSearch("create_by", dimension, nil),
+			"updated_by":        utils.PathSearch("update_by", dimension, nil),
+			"created_at":        utils.PathSearch("create_time", dimension, nil),
+			"updated_at":        utils.PathSearch("update_time", dimension, nil),
+			"table_type":        utils.PathSearch("table_type", dimension, nil),
+			"distribute":        utils.PathSearch("distribute", dimension, nil),
+			"distribute_column": utils.PathSearch("distribute_column", dimension, nil),
+			"obs_location":      utils.PathSearch("obs_location", dimension, nil),
+			"alias":             utils.PathSearch("alias", dimension, nil),
+			"configs":           utils.PathSearch("configs", dimension, nil),
+			"env_type":          utils.PathSearch("env_type", dimension, nil),
+			"model_id":          utils.PathSearch("model_id", dimension, nil),
+			"dev_version":       utils.PathSearch("dev_version", dimension, nil),
+			"prod_version":      utils.PathSearch("prod_version", dimension, nil),
+			"dev_version_name":  utils.PathSearch("dev_version_name", dimension, nil),
+			"prod_version_name": utils.PathSearch("prod_version_name", dimension, nil),
+			"datasource": flattenDimensionsDatasource(
+				utils.PathSearch("datasource", dimension, make(map[string]interface{})).(map[string]interface{})),
+			"attributes":  flattenDimensionsAttributes(utils.PathSearch("attributes", dimension, make([]interface{}, 0)).([]interface{})),
+			"hierarchies": flattenDimensionsHierarchies(utils.PathSearch("hierarchies", dimension, make([]interface{}, 0)).([]interface{})),
+			"code_table": flattenDimensionsCodeTable(
+				utils.PathSearch("code_table", dimension, make(map[string]interface{})).(map[string]interface{})),
+			"model": flattenDimensionsModel(
+				utils.PathSearch("model", dimension, make(map[string]interface{})).(map[string]interface{})),
+		})
+	}
+	return result
+}
+
+func dataSourceArchitectureDimensionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	dimensions, err := listArchitectureDimensions(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Architecture dimensions: %s", err)
+	}
+
+	d.SetId(uuid.New().String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("dimensions", flattenArchitectureDimensions(dimensions)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data-source for querying architecture dimensions.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. create the implement of the resource.
2. create the document of the resource.
3. create the acceptance test case of the resource.
4. add respond resource name in `provider.go`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureDimensions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureDimensions_basic
=== PAUSE TestAccDataArchitectureDimensions_basic
=== CONT  TestAccDataArchitectureDimensions_basic
--- PASS: TestAccDataArchitectureDimensions_basic (33.98s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  34.128s coverage: 6.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.