### PR TITLE
feat(dsc): add a new resource to manage asset group

### DIFF
--- a/docs/resources/dsc_asset_domain_label.md
+++ b/docs/resources/dsc_asset_domain_label.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_asset_domain_label"
+description: |-
+  Manages a DSC asset domain label resource within HuaweiCloud.
+---
+
+# huaweicloud_dsc_asset_domain_label
+
+Manages a DSC asset domain label resource within HuaweiCloud.
+
+-> If the label has associated assets, deleting the label will move the assets under the label to the ungrouped label.
+
+## Example Usage
+
+### Create a top-level label
+
+```hcl
+variable "name" {}
+
+resource "huaweicloud_dsc_asset_domain_label" "test" {
+  name      = var.name
+  parent_id = "top label"
+}
+```
+
+### Create a child label
+
+```hcl
+variable "name" {}
+variable "parent_id" {}
+
+resource "huaweicloud_dsc_asset_domain_label" "test" {
+  name      = var.name
+  parent_id = var.parent_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the asset domain label is located.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the asset domain label.
+
+* `parent_id` - (Required, String, NonUpdatable) Specifies the ID of the parent to which the label belongs.  
+  When creating a top-level asset domain label, this parameter value must be set to `top label`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `depth` - The depth of the label.
+
+* `is_leaf` - Whether the label is a leaf node.
+  + **1**: The label is a leaf node.
+  + **0**: The label is not a leaf node.
+
+## Import
+
+The resource can be imported using the `name` and `parent_id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_dsc_asset_domain_label.test <name>/<parent_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4993,15 +4993,16 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_build_task_action":  codeartsbuild.ResourceCodeArtsBuildTaskAction(),
 			"huaweicloud_codearts_build_log_download": codeartsbuild.ResourceCodeArtsBuildLogDownload(),
 
-			"huaweicloud_dsc_instance":                     dsc.ResourceDscInstance(),
-			"huaweicloud_dsc_asset_obs":                    dsc.ResourceAssetObs(),
 			"huaweicloud_dsc_alarm_notification":           dsc.ResourceAlarmNotification(),
+			"huaweicloud_dsc_asset_domain_label":           dsc.ResourceAssetDomainLabel(),
+			"huaweicloud_dsc_asset_obs":                    dsc.ResourceAssetObs(),
 			"huaweicloud_dsc_batch_delete_obs":             dsc.ResourceBatchDeleteObs(),
-			"huaweicloud_dsc_multi_enable_trusted_service": dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_data_map_score_update":        dsc.ResourceDscDataMapScoreUpdate(),
 			"huaweicloud_dsc_device":                       dsc.ResourceDscDevice(),
-			"huaweicloud_dsc_switch_job":                   dsc.ResourceDscSwitchJob(),
+			"huaweicloud_dsc_instance":                     dsc.ResourceDscInstance(),
+			"huaweicloud_dsc_multi_enable_trusted_service": dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_stop_scan_job":                dsc.ResourceStopScanJob(),
+			"huaweicloud_dsc_switch_job":                   dsc.ResourceDscSwitchJob(),
 
 			// internal only
 			"huaweicloud_apm_aksk": apm.ResourceApmAkSk(),

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_asset_domain_label_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_asset_domain_label_test.go
@@ -1,0 +1,106 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dsc"
+)
+
+func getAssetDomainLabelResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dsc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DSC client: %s", err)
+	}
+
+	return dsc.GetAssetDomainLabelByName(client, state.Primary.Attributes["name"], state.Primary.Attributes["parent_id"])
+}
+
+// Before running the test, please ensure that you have created a DSC instance.
+func TestAccAssetDomainLabel_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dsc_asset_domain_label.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getAssetDomainLabelResourceFunc)
+
+		rNameWithChild = "huaweicloud_dsc_asset_domain_label.test2"
+		rcWithChild    = acceptance.InitResourceCheck(rNameWithChild, &obj, getAssetDomainLabelResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDscInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rcWithChild.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAssetDomainLabel_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "parent_id", "top label"),
+					resource.TestCheckResourceAttr(rName, "depth", "1"),
+					resource.TestCheckResourceAttr(rName, "is_leaf", "0"),
+					rcWithChild.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rNameWithChild, "parent_id", rName, "id"),
+					resource.TestCheckResourceAttr(rNameWithChild, "depth", "2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAssetDomainLabelImportStateIdFunc(rName),
+			},
+			{
+				ResourceName:      rNameWithChild,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAssetDomainLabelImportStateIdFunc(rNameWithChild),
+			},
+		},
+	})
+}
+
+func testAccAssetDomainLabelImportStateIdFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", rName)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		parentId := rs.Primary.Attributes["parent_id"]
+		if name == "" || parentId == "" {
+			return "", fmt.Errorf("missing some attributes, want '<name>/<parent_id>', but got '%s/%s'", name, parentId)
+		}
+
+		return fmt.Sprintf("%s/%s", name, parentId), nil
+	}
+}
+
+func testAssetDomainLabel_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_asset_domain_label" "test" {
+  name      = "%[1]s"
+  parent_id = "top label"
+}
+
+resource "huaweicloud_dsc_asset_domain_label" "test2" {
+  name      = "%[1]s_child"
+  parent_id = huaweicloud_dsc_asset_domain_label.test.id
+}
+`, name)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_asset_domain_label.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_asset_domain_label.go
@@ -1,0 +1,309 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	assetDomainLabelNonUpdatableParams = []string{
+		"name",
+		"parent_id",
+	}
+
+	assetDomainLabelNotFoundErrCodes = []string{
+		// dsc.10000009: Current instance does not exist.
+		"dsc.10000009",
+		// dsc.40000007: The label does not exist.
+		"dsc.40000007",
+	}
+)
+
+// @API DSC POST /v1/{project_id}/metadata/asset-domain-labels
+// @API DSC GET /v1/{project_id}/metadata/asset-domain-labels
+// @API DSC DELETE /v1/{project_id}/metadata/asset-domain-labels/{id}
+func ResourceAssetDomainLabel() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAssetDomainLabelCreate,
+		ReadContext:   resourceAssetDomainLabelRead,
+		UpdateContext: resourceAssetDomainLabelUpdate,
+		DeleteContext: resourceAssetDomainLabelDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAssetDomainLabelImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(assetDomainLabelNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the asset domain label is located.`,
+			},
+
+			// Required parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the label.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the parent to which the label belongs.`,
+			},
+
+			// Attributes.
+			"depth": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The depth of the label.`,
+			},
+			"is_leaf": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Whether the label is a leaf node.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildCreateAssetDomainLabelBodyParams(name, parentId string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":      name,
+		"parent_id": parentId,
+	}
+}
+
+func createAssetDomainLabel(client *golangsdk.ServiceClient, params map[string]interface{}) error {
+	httpUrl := "v1/{project_id}/metadata/asset-domain-labels"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         params,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func resourceAssetDomainLabelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		name     = d.Get("name").(string)
+		parentId = d.Get("parent_id").(string)
+	)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = createAssetDomainLabel(client, buildCreateAssetDomainLabelBodyParams(name, parentId))
+	if err != nil {
+		return diag.Errorf("error creating asset domain label: %s", err)
+	}
+
+	label, err := GetAssetDomainLabelByName(client, name, parentId)
+	if err != nil {
+		return diag.Errorf("error getting asset domain label (%s) under parent ID (%s): %s", name, parentId, err)
+	}
+
+	labelId, _ := utils.PathSearch("id", label, "").(string)
+	if labelId == "" {
+		return diag.Errorf("unable to find the ID of the asset domain label from the API response")
+	}
+
+	d.SetId(labelId)
+
+	return resourceAssetDomainLabelRead(ctx, d, meta)
+}
+
+func listAssetDomainLabels(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v1/{project_id}/metadata/asset-domain-labels"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func findLabelByNameAndParentId(labels []interface{}, name, parentId string) interface{} {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	for _, item := range labels {
+		if utils.PathSearch("name", item, "").(string) == name && utils.PathSearch("parent_id", item, "").(string) == parentId {
+			return item
+		}
+
+		label := findLabelByNameAndParentId(utils.PathSearch("sons", item, make([]interface{}, 0)).([]interface{}), name, parentId)
+		if label != nil {
+			return label
+		}
+	}
+
+	return nil
+}
+
+func GetAssetDomainLabelByName(client *golangsdk.ServiceClient, name, parentId string) (interface{}, error) {
+	respBody, err := listAssetDomainLabels(client)
+	if err != nil {
+		return nil, common.ConvertExpected401ErrInto404Err(err, "error_code", assetDomainLabelNotFoundErrCodes[0])
+	}
+
+	label := findLabelByNameAndParentId(utils.PathSearch("sons", respBody, make([]interface{}, 0)).([]interface{}), name, parentId)
+	if label == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/metadata/asset-domain-labels",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the asset domain label with name (%s) and parent ID (%s) does not exist", name, parentId)),
+			},
+		}
+	}
+
+	return label, nil
+}
+
+func resourceAssetDomainLabelRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		name     = d.Get("name").(string)
+		parentId = d.Get("parent_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	label, err := GetAssetDomainLabelByName(client, name, parentId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving asset domain label (%s) under parent ID (%s)", name, parentId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", label, nil)),
+		d.Set("parent_id", utils.PathSearch("parent_id", label, nil)),
+		// Attributes.
+		d.Set("depth", utils.PathSearch("depth", label, nil)),
+		d.Set("is_leaf", utils.PathSearch("is_leaf", label, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAssetDomainLabelUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func deleteAssetDomainLabel(client *golangsdk.ServiceClient, labelId string) error {
+	httpUrl := "v1/{project_id}/metadata/asset-domain-labels/{id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", labelId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceAssetDomainLabelDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = deleteAssetDomainLabel(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(common.ConvertExpected401ErrInto404Err(err, "error_code",
+			assetDomainLabelNotFoundErrCodes...), "error_code", assetDomainLabelNotFoundErrCodes...),
+			fmt.Sprintf("error deleting asset domain label (%s)", d.Get("name").(string)))
+	}
+
+	return nil
+}
+
+func resourceAssetDomainLabelImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<name>/<parent_id>', but got '%s'", importedId)
+	}
+
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return nil, fmt.Errorf("error creating DSC client: %s", err)
+	}
+
+	name := parts[0]
+	parentId := parts[1]
+	label, err := GetAssetDomainLabelByName(client, name, parentId)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(utils.PathSearch("id", label, "").(string))
+
+	mErr := multierror.Append(nil,
+		d.Set("name", name),
+		d.Set("parent_id", parentId),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage a asset group label resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource for DSC resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccAssetDomainLabel_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccAssetDomainLabel_basic -timeout 360m -parallel 10
=== RUN   TestAccAssetDomainLabel_basic
=== PAUSE TestAccAssetDomainLabel_basic
=== CONT  TestAccAssetDomainLabel_basic
--- PASS: TestAccAssetDomainLabel_basic (20.43s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       20.621s coverage: 9.8% of statements in ./huaweicloud/services/dsc
```
<img width="1108" height="47" alt="image" src="https://github.com/user-attachments/assets/393bc5e8-7d54-4dee-838d-d99f62af5223" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1148" height="866" alt="image" src="https://github.com/user-attachments/assets/9b725e09-d267-47bf-bba2-22275721eb84" />

    ab. Related resources (parent resources) not found
    <img width="1262" height="847" alt="image" src="https://github.com/user-attachments/assets/e46a8617-1a86-4608-b3d2-7fabbd1e8991" />
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1031" height="644" alt="image" src="https://github.com/user-attachments/assets/d2f31765-2ba2-4e31-a733-91a277e01920" />

    bb. Related resources (parent resources) not found
    <img width="939" height="882" alt="image" src="https://github.com/user-attachments/assets/99d5d7de-617c-43ab-a7f1-6b2833b71afd" />
