### PR TITLE
fix(dli): queue driver property skip setting if some issue happen

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
@@ -132,6 +132,7 @@ resource "huaweicloud_dli_queue" "general" {
 }`, elasticResourceName, rName, cuCount)
 }
 
+// Before running this test, please ensure that the minimum CU of the second elastic resource pool is not less than 48.
 func TestAccDliQueue_another(t *testing.T) {
 	var (
 		obj                    queues.CreateOpts

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_queue.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_queue.go
@@ -400,7 +400,7 @@ func resourceDliQueueRead(_ context.Context, d *schema.ResourceData, meta interf
 
 	sparkDriver, err := getSparkDriverByQueueName(v3Client, queueName)
 	if err != nil {
-		return diag.Errorf("error getting properties of the queue (%s): %s", queueName, err)
+		log.Printf("[ERROR] error getting properties of the queue (%s): %s", queueName, err)
 	}
 	mErr = multierror.Append(mErr, d.Set("spark_driver", sparkDriver))
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During `ReadContext`, the `huaweicloud_dli_queue` resource fetches core queue attributes via the V1 list API, then enriches state with supplementary data from separate V3 APIs (scaling policies, Spark driver properties). Previously, any failure in `getSparkDriverByQueueName()` caused the entire read to fail, even when the queue itself was successfully retrieved.

**Changes**

**Read path — graceful degradation:** When fetching `spark_driver` properties fails, the error is logged (`[ERROR]`) but no longer returned as a diagnostic. The read continues and sets `spark_driver` to whatever was returned (typically `nil`/empty), while all other queue attributes are still refreshed.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

fixes #5357 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. queue driver property skip setting if some issue happen when attribute querying
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dli -f TestAccDliQueue_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccDliQueue_ -timeout 360m -parallel 10
=== RUN   TestAccDliQueue_basic
--- PASS: TestAccDliQueue_basic (258.49s)
=== RUN   TestAccDliQueue_another
--- PASS: TestAccDliQueue_another (271.08s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       529.703s        coverage: 6.5% of statements in ./huaweicloud/services/dli
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
