### PR TITLE
feat(gaussdb): gaussdb instance enable transparent data encryption

### DIFF
--- a/docs/resources/gaussdb_instance.md
+++ b/docs/resources/gaussdb_instance.md
@@ -178,6 +178,9 @@ The following arguments are supported:
 * `auto_scaling` - (Optional, List) Specifies the instance storage autoscaling policy.
   The [auto_scaling](#auto_scaling_struct) structure is documented below.
 
+* `kms_tde_switch` - (Optional, List) Specifies the enabled transparent data encryption.
+  The [kms_tde_switch](#kms_tde_switch_struct) structure is documented below.
+
 * `mysql_compatibility_port` - (Optional, String) Specifies the port for MySQL compatibility. Value range: **0** or
   **1024** to **39989**.
   + The following ports are used by the system and cannot be used: **2378**, **2379**, **2380**, **2400**, **4999**,
@@ -291,6 +294,15 @@ The `auto_scaling` block supports:
 * `step_size` - (Optional, Int) Specifies the scaling step when the storage is scaled by fixed size.
 
 * `step_percent` - (Optional, Int) Specifies the scaling step when the storage is scaled by percentage.
+
+<a name="kms_tde_switch_struct"></a>
+The `kms_tde_switch` block supports:
+
+* `kms_tde_key_id` - (Required, String) Specifies the id of the KMS master key.
+
+* `kms_project_name` - (Required, String) Specifies the name of a resource space.
+
+* `kms_tde_status` - (Required, String) Specifies the status of TDE.
 
 <a name="advance_features_struct"></a>
 The `advance_features` block supports:

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_instance_test.go
@@ -102,6 +102,10 @@ func TestAccGaussDbInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "6"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "dn:check_disconnect_query"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "off"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_tde_switch.0.kms_tde_key_id",
+						"huaweicloud_kms_key.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "kms_tde_switch.0.kms_project_name", "cn-north-4"),
+					resource.TestCheckResourceAttr(resourceName, "kms_tde_switch.0.kms_tde_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "advance_features.0.name", "ilm"),
 					resource.TestCheckResourceAttr(resourceName, "advance_features.0.value", "on"),
 					resource.TestCheckResourceAttr(resourceName, "wdr_snapshot_status", "OFF"),
@@ -134,6 +138,10 @@ func TestAccGaussDbInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "8"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "cn:auto_increment_increment"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "1000"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_tde_switch.0.kms_tde_key_id",
+						"huaweicloud_kms_key.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "kms_tde_switch.0.kms_project_name", "cn-north-4"),
+					resource.TestCheckResourceAttr(resourceName, "kms_tde_switch.0.kms_tde_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "advance_features.0.name", "ilm"),
 					resource.TestCheckResourceAttr(resourceName, "advance_features.0.value", "off"),
 					resource.TestCheckResourceAttr(resourceName, "wdr_snapshot_status", "ON"),
@@ -158,6 +166,8 @@ func TestAccGaussDbInstance_basic(t *testing.T) {
 					"availability_zone",
 					"configuration_id",
 					"parameters",
+					"kms_tde_switch",
+					"alias",
 				},
 			},
 		},
@@ -477,6 +487,21 @@ func testAccGaussDbInstance_basic(rName, password string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+resource "huaweicloud_kms_key" "test" {
+  key_alias             = "%[2]s"
+  key_algorithm         = "AES_256"
+  key_usage             = "ENCRYPT_DECRYPT"
+  origin                = "kms"
+  key_description       = "test acc"
+  enterprise_project_id = "%[4]s"
+  pending_days          = "7"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
 resource "huaweicloud_gaussdb_instance" "test" {
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
@@ -529,6 +554,12 @@ resource "huaweicloud_gaussdb_instance" "test" {
     foo = "bar"
     key = "value"
   }
+
+ kms_tde_switch {
+    kms_tde_key_id   = huaweicloud_kms_key.test.id
+    kms_project_name = "cn-north-4"
+    kms_tde_status   = "on"
+  }
 }
 `, testAccGaussDbInstance_base(rName), rName, password, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
@@ -536,6 +567,21 @@ resource "huaweicloud_gaussdb_instance" "test" {
 func testAccGaussDbInstance_update(rName, password string) string {
 	return fmt.Sprintf(`
 %[1]s
+
+resource "huaweicloud_kms_key" "test" {
+  key_alias             = "%[2]s"
+  key_algorithm         = "AES_256"
+  key_usage             = "ENCRYPT_DECRYPT"
+  origin                = "kms"
+  key_description       = "test acc"
+  enterprise_project_id = "%[4]s"
+  pending_days          = "7"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
 
 resource "huaweicloud_gaussdb_parameter_template" "test" {
   name           = "%[2]s"
@@ -605,6 +651,12 @@ resource "huaweicloud_gaussdb_instance" "test" {
   tags = {
     foo_update = "bar"
     key        = "value_update"
+  }
+
+  kms_tde_switch {
+    kms_tde_key_id   = huaweicloud_kms_key.test.id
+    kms_project_name = "cn-north-4"
+    kms_tde_status   = "on"
   }
 
   charging_mode = "prePaid"

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance.go
@@ -71,6 +71,7 @@ var openGaussInstanceNonUpdatableParams = []string{"availability_zone", "vpc_id"
 // @API GaussDB PUT /v3/{project_id}/instances/change-charge-mode
 // @API GaussDB DELETE /v3/{project_id}/instances/{instance_id}/tag
 // @API GaussDB DELETE /v3/{project_id}/instances/{instance_id}
+// @API GaussDB PUT /v3/{project_id}/instances/{instance_id}/kms-tde/switch
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/suscriptions/resources/query
 // @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
@@ -356,6 +357,28 @@ func ResourceGaussDbInstance() *schema.Resource {
 				},
 				Optional: true,
 				Computed: true,
+			},
+			"kms_tde_switch": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_tde_key_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"kms_project_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"kms_tde_status": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
 			},
 			"wdr_snapshot_status": {
 				Type:     schema.TypeString,
@@ -653,6 +676,12 @@ func resourceOpenGaussInstanceCreate(ctx context.Context, d *schema.ResourceData
 
 	if _, ok := d.GetOk("auto_scaling"); ok {
 		if err = updateAutoScaling(ctx, client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if _, ok := d.GetOk("kms_tde_switch"); ok {
+		if err = createEnablingTransparentDataEncryption(ctx, client, d); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -1456,6 +1485,13 @@ func resourceOpenGaussInstanceUpdate(ctx context.Context, d *schema.ResourceData
 
 	if d.HasChange("dn_node_deploy_mode") {
 		if err = updateDnNodeDeployMode(ctx, client, bssClient, d, schema.TimeoutUpdate); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("kms_tde_switch") {
+		err = updateEnablingTransparentDataEncryption(ctx, client, d)
+		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -2272,6 +2308,69 @@ func buildUpdateBillingModeToPeriodBodyParams(d *schema.ResourceData) map[string
 		bodyParams["is_auto_renew"] = true
 	}
 	return bodyParams
+}
+
+func createEnablingTransparentDataEncryption(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	err := enablingTransparentDataEncryption(ctx, client, d)
+	if err != nil {
+		return fmt.Errorf("error enabling GaussDB instance transparent data encryption: %s", err)
+	}
+
+	err = restartGaussDBOpenGaussInstance(ctx, client, d)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func enablingTransparentDataEncryption(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	_, err := updateGaussDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:            "v3/{project_id}/instances/{instance_id}/kms-tde/switch",
+		httpMethod:         "PUT",
+		pathParams:         map[string]string{"instance_id": d.Id()},
+		updateBodyParams:   utils.RemoveNil(buildTransparentDataEncryptionBodyParams(d)),
+		isRetry:            true,
+		timeout:            schema.TimeoutUpdate,
+		delay:              10,
+		checkJobExpression: "job_id",
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildTransparentDataEncryptionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	kmsTdeSwitchRaw := d.Get("kms_tde_switch").([]interface{})
+	if len(kmsTdeSwitchRaw) == 0 {
+		return nil
+	}
+	kmsTdeSwitch, ok := kmsTdeSwitchRaw[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	bodyParams := map[string]interface{}{
+		"kms_tde_key_id":   kmsTdeSwitch["kms_tde_key_id"],
+		"kms_project_name": kmsTdeSwitch["kms_project_name"],
+		"kms_tde_status":   kmsTdeSwitch["kms_tde_status"],
+	}
+
+	return bodyParams
+}
+
+func updateEnablingTransparentDataEncryption(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	if !d.HasChange("kms_tde_switch") {
+		return nil
+	}
+	err := enablingTransparentDataEncryption(ctx, client, d)
+	if err != nil {
+		return fmt.Errorf("error enabling GaussDB instance transparent data encryption: %s", err)
+	}
+
+	return nil
 }
 
 func addInstanceTags(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, addTags map[string]interface{}) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
gaussdb instance enable transparent data encryption
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
gaussdb instance enable transparent data encryption
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDbInstance_basic"
==> Checking that code complies with gofmt requirements...
D:/Code/terraform-provider-huaweicloud/scripts/gofmtcheck.sh: line 5: /d/DevOpts/Go/1.24.13/bin/gofmt: Argument list too long
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDbInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDbInstance_basic
=== PAUSE TestAccGaussDbInstance_basic
=== CONT  TestAccGaussDbInstance_basic
--- PASS: TestAccGaussDbInstance_basic (3445.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   3447.266s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
