### PR TITLE
feat(TaurusDB): action resource to compare node parameters of HTAP instance

### DIFF
--- a/docs/resources/taurusdb_htap_starrocks_parameters_compare.md
+++ b/docs/resources/taurusdb_htap_starrocks_parameters_compare.md
@@ -1,0 +1,53 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_starrocks_parameters_compare"
+description: |-
+  Manages a TaurusDB HTAP StarRocks parameters compare resource within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_starrocks_parameters_compare
+
+Manages a TaurusDB HTAP StarRocks parameters compare resource within HuaweiCloud.
+
+This is a one-time action resource that compares parameters between the source parameter template and the target
+parameter template of a HTAP StarRocks instance, and returns the differences.  Deleting this resource will not change
+the current configuration, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "source_configuration_id" {}
+
+resource "huaweicloud_taurusdb_htap_starrocks_parameters_compare" "test" {
+  source_configuration_id = var.source_configuration_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to compare the HTAP StarRocks parameters.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `source_configuration_id` - (Required, String, NoneUpdatable) Specifies the ID of the source parameter template
+  for comparison.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `differences` - The list of parameter differences between the source and target parameter templates.
+  The [differences](#htap_starrocks_parameters_compare_differences_attr) structure is documented below.
+
+<a name="htap_starrocks_parameters_compare_differences_attr"></a>
+The `differences` block supports:
+
+* `parameter_name` - The parameter name.
+
+* `source_value` - The parameter value in the source parameter template.
+
+* `target_value` - The parameter value in the target parameter template.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4758,6 +4758,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_htap_starrocks_instance":           taurusdb.ResourceTaurusDBHtapStarrocksInstance(),
 			"huaweicloud_taurusdb_htap_starrocks_instance_restart":   taurusdb.ResourceTaurusDBHtapStarrocksInstanceRestart(),
 			"huaweicloud_taurusdb_htap_starrocks_instance_upgrade":   taurusdb.ResourceTaurusDBHtapStarrocksInstanceUpgrade(),
+			"huaweicloud_taurusdb_htap_starrocks_parameters_compare": taurusdb.ResourceTaurusDBHtapStarrocksParametersCompare(),
 			"huaweicloud_taurusdb_htap_starrocks_lts_config":         taurusdb.ResourceTaurusDBHtapStarrocksLtsConfig(),
 			"huaweicloud_taurusdb_htap_starrocks_node_restart":       taurusdb.ResourceTaurusDBHtapStarrocksNodeRestart(),
 			"huaweicloud_taurusdb_htap_starrocks_replication":        taurusdb.ResourceTaurusDBHtapStarrocksReplication(),

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_parameters_compare_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_parameters_compare_test.go
@@ -1,0 +1,57 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTaurusDBHtapStarrocksParametersCompare_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		rName        = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_taurusdb_htap_starrocks_parameters_compare.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getHtapStarrocksInstanceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBHtapStarrocksParametersCompare_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "differences.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "differences.0.parameter_name", "alter_tablet_worker_count"),
+					resource.TestCheckResourceAttr(resourceName, "differences.0.source_value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "differences.0.target_value", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaurusDBHtapStarrocksParametersCompare_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  intance_config_id = huaweicloud_taurusdb_htap_starrocks_instance.test.be_configurations[0].configuration_id
+}
+
+resource "huaweicloud_taurusdb_htap_starrocks_parameters_compare" "test" {
+  source_configuration_id = local.intance_config_id
+}
+`, testAccTaurusDBHtapStarrocksInstance_basic(rName))
+}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_parameters_compare.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_parameters_compare.go
@@ -1,0 +1,158 @@
+package taurusdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var starrocksParametersCompareNoneUpdatableParams = []string{
+	"source_configuration_id",
+}
+
+// @API TaurusDB POST /v3/{project_id}/configurations/starrocks/comparison
+func ResourceTaurusDBHtapStarrocksParametersCompare() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDBHtapStarrocksParametersCompareCreate,
+		ReadContext:   resourceTaurusDBHtapStarrocksParametersCompareRead,
+		UpdateContext: resourceTaurusDBHtapStarrocksParametersCompareUpdate,
+		DeleteContext: resourceTaurusDBHtapStarrocksParametersCompareDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(starrocksParametersCompareNoneUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"source_configuration_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"differences": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     starrocksParametersCompareDifferencesSchema(),
+			},
+		},
+	}
+}
+
+func starrocksParametersCompareDifferencesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"parameter_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceTaurusDBHtapStarrocksParametersCompareCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/configurations/starrocks/comparison"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	createOpt.JSONBody = buildCompareStarrocksParametersBodyParams(d)
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error comparing HTAP StarRocks parameters: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id.String())
+
+	differences := utils.PathSearch("differences", respBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("differences", flattenStarrocksParametersCompareDifferences(differences)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildCompareStarrocksParametersBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"source_configuration_id": d.Get("source_configuration_id"),
+	}
+	return bodyParams
+}
+
+func flattenStarrocksParametersCompareDifferences(resp []interface{}) []interface{} {
+	res := make([]interface{}, 0)
+	for _, v := range resp {
+		res = append(res, map[string]interface{}{
+			"parameter_name": utils.PathSearch("parameter_name", v, nil),
+			"source_value":   utils.PathSearch("source_value", v, nil),
+			"target_value":   utils.PathSearch("target_value", v, nil),
+		})
+	}
+	return res
+}
+
+func resourceTaurusDBHtapStarrocksParametersCompareRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBHtapStarrocksParametersCompareUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBHtapStarrocksParametersCompareDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting parameters compare resource is not supported. The resource is only removed from the state," +
+		" the comparison result remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
action resource to compare node parameters of HTAP instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
action resource to compare node parameters of HTAP instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBHtapStarrocksParametersCompare'
=== RUN   TestAccTaurusDBHtapStarrocksParametersCompare_basic
=== PAUSE TestAccTaurusDBHtapStarrocksParametersCompare_basic
=== CONT  TestAccTaurusDBHtapStarrocksParametersCompare_basic
--- PASS: TestAccTaurusDBHtapStarrocksParametersCompare_basic (1726.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 1726.023s
```

<img width="737" height="225" alt="image" src="https://github.com/user-attachments/assets/24d3d8e6-3b7b-4055-86a7-68b7297476b4" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
