### PR TITLE
feat(dsc): add data source to query database instances in the asset catalog

### DIFF
--- a/docs/data-sources/dsc_catalog_instances.md
+++ b/docs/data-sources/dsc_catalog_instances.md
@@ -1,0 +1,118 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_catalog_instances"
+description: |-
+  Use this data source to query the instance list in the asset catalog within HuaweiCloud.
+---
+
+# huaweicloud_dsc_catalog_instances
+
+Use this data source to query the instance list in the asset catalog within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "label_id" {}
+
+data "huaweicloud_dsc_catalog_instances" "test" {
+  label_id = var.label_id
+}
+```
+
+### Filter by instance name
+
+```hcl
+variable "label_id" {}
+variable "instance_name" {}
+
+data "huaweicloud_dsc_catalog_instances" "test" {
+  label_id      = var.label_id
+  instance_name = var.instance_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the catalog instances are located.
+  If omitted, the provider-level region will be used.
+
+* `label_id` - (Optional, String) Specifies the ID of the group label to which the instance belongs.
+
+* `type_id` - (Optional, String) Specifies the ID of the data type of the database instance.
+
+-> Exactly one of the `label_id` and `type_id` parameters must be specified.
+
+* `instance_name` - (Optional, String) Specifies the name of the database instance.  
+  Fuzzy matching is supported.
+
+* `address` - (Optional, String) Specifies the address of the database instance.  
+  Fuzzy matching is supported.
+
+* `user` - (Optional, String) Specifies the access user of the database instance.  
+  Fuzzy matching is supported.
+
+* `col_id` - (Optional, String) Specifies the key used to sort the instances.
+
+* `sort` - (Optional, String) Specifies the sorting method for query results.  
+  The valid values are as follows:
+  + **asc**: Ascending order.
+  + **desc**: Descending order.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - The list of database instances.  
+  The [instances](#catalog_instances_attr) structure is documented below.
+
+<a name="catalog_instances_attr"></a>
+The `instances` block supports:
+
+* `instance_id` - The ID of the database instance.
+
+* `instance_name` - The name of the database instance.
+
+* `address` - The address of the database instance.
+
+* `db_infos` - The list of databases that belong to the instance.  
+  The [db_infos](#catalog_instances_db_infos) structure is documented below.
+
+* `sensitive_col_num` - The number of sensitive columns in the instance.
+
+* `sensitive_db_num` - The number of sensitive databases in the instance.
+
+* `sensitive_table_num` - The number of sensitive tables in the instance.
+
+* `user` - The access user of the database instance.
+
+<a name="catalog_instances_db_infos"></a>
+The `db_infos` block supports:
+
+* `db_id` - The ID of the database.
+
+* `db_name` - The name of the database.
+
+* `db_type` - The type of the database.
+
+* `asset_id` - The ID of the asset to which the database belongs.
+
+* `classifications` - The classification list of the database.
+
+* `latest_scan_time` - The latest scan time of the database, in RFC3339 format.
+
+* `sensitive_level_name` - The name of the sensitive level.
+
+* `color_number` - The color number corresponding to the database sensitive level.
+
+* `sensitive_table_count` - The number of sensitive tables in the database.
+
+* `tags` - The tag list of the database.
+
+* `total_table_count` - The total number of tables in the database.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1416,6 +1416,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_asset_quota":                      dsc.DataSourceDscAssetQuota(),
 			"huaweicloud_dsc_catalog_statistics":               dsc.DataSourceCatalogStatistics(),
 			"huaweicloud_dsc_catalog_details_by_obs":           dsc.DataSourceCatalogDetailsByObs(),
+			"huaweicloud_dsc_catalog_instances":                dsc.DataSourceCatalogInstances(),
 			"huaweicloud_dsc_catalog_quantity_variation":       dsc.DataSourceDscCatalogQuantityVariation(),
 			"huaweicloud_dsc_column_details_by_database":       dsc.DataSourceDscColumnDetailsByDatabase(),
 			"huaweicloud_dsc_column_details_by_classification": dsc.DataSourceDscColumnDetailsByClassification(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_catalog_instances_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_catalog_instances_test.go
@@ -1,0 +1,160 @@
+package dsc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, ensure that there is at least two database asset under the HW_DSC_TYPE_ID,
+// and that the metadata scan has been completed.
+func TestAccDataSourceCatalogInstances_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dsc_catalog_instances.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byInstanceName   = "data.huaweicloud_dsc_catalog_instances.filter_by_instance_name"
+		dcByInstanceName = acceptance.InitDataSourceCheck(byInstanceName)
+
+		byAddress   = "data.huaweicloud_dsc_catalog_instances.filter_by_address"
+		dcByAddress = acceptance.InitDataSourceCheck(byAddress)
+
+		byUser   = "data.huaweicloud_dsc_catalog_instances.filter_by_user"
+		dcByUser = acceptance.InitDataSourceCheck(byUser)
+
+		byColIdAndSortDesc   = "data.huaweicloud_dsc_catalog_instances.filter_by_col_id_and_sort_desc"
+		dcByColIdAndSortDesc = acceptance.InitDataSourceCheck(byColIdAndSortDesc)
+
+		byColIdAndSortAsc   = "data.huaweicloud_dsc_catalog_instances.filter_by_col_id_and_sort_asc"
+		dcByColIdAndSortAsc = acceptance.InitDataSourceCheck(byColIdAndSortAsc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscTypeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCatalogInstances_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "instances.#", regexp.MustCompile(`^[1-9]([0-9]+)?$`)),
+					resource.TestMatchResourceAttr(all, "instances.0.db_infos.#", regexp.MustCompile(`^[1-9]([0-9]+)?$`)),
+					resource.TestCheckResourceAttrSet(all, "instances.0.db_infos.0.db_id"),
+					resource.TestCheckResourceAttrSet(all, "instances.0.db_infos.0.db_name"),
+					resource.TestCheckResourceAttrSet(all, "instances.0.db_infos.0.asset_id"),
+					resource.TestMatchResourceAttr(all, "instances.0.db_infos.0.latest_scan_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Filter by 'instance_name' parameter.
+					dcByInstanceName.CheckResourceExists(),
+					resource.TestCheckOutput("is_instance_name_filter_useful", "true"),
+					// Filter by 'address' parameter.
+					dcByAddress.CheckResourceExists(),
+					resource.TestCheckOutput("is_address_filter_useful", "true"),
+					// Filter by 'user' parameter.
+					dcByUser.CheckResourceExists(),
+					resource.TestCheckOutput("is_user_filter_useful", "true"),
+					// Filter by 'col_id' and 'sort' parameters.
+					dcByColIdAndSortDesc.CheckResourceExists(),
+					dcByColIdAndSortAsc.CheckResourceExists(),
+					resource.TestCheckOutput("is_col_id_and_sort_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCatalogInstances_basic() string {
+	return fmt.Sprintf(`
+locals {
+  type_id = "%[1]s"
+}
+
+data "huaweicloud_dsc_catalog_instances" "test" {
+  type_id = local.type_id
+}
+
+# Filter by 'instance_name' parameter.
+locals {
+  instance_name = try(data.huaweicloud_dsc_catalog_instances.test.instances[0].instance_name, "NOT FOUND")
+}
+
+data "huaweicloud_dsc_catalog_instances" "filter_by_instance_name" {
+  type_id       = local.type_id
+  instance_name = local.instance_name
+}
+
+locals {
+  instance_name_filter_result = [for v in data.huaweicloud_dsc_catalog_instances.filter_by_instance_name.instances[*].instance_name :
+  strcontains(v, local.instance_name)]
+}
+
+output "is_instance_name_filter_useful" {
+  value = length(local.instance_name_filter_result) > 0 && alltrue(local.instance_name_filter_result)
+}
+
+# Filter by 'address' parameter.
+locals {
+  address = try(data.huaweicloud_dsc_catalog_instances.test.instances[0].address, "NOT FOUND")
+}
+
+data "huaweicloud_dsc_catalog_instances" "filter_by_address" {
+  type_id = local.type_id
+  address = local.address
+}
+
+locals {
+  address_filter_result = [for v in data.huaweicloud_dsc_catalog_instances.filter_by_address.instances[*].address : strcontains(v, local.address)]
+}
+
+output "is_address_filter_useful" {
+  value = length(local.address_filter_result) > 0 && alltrue(local.address_filter_result)
+}
+
+# Filter by 'user' parameter.
+locals {
+  user = try(data.huaweicloud_dsc_catalog_instances.test.instances[0].user, "NOT FOUND")
+}
+
+data "huaweicloud_dsc_catalog_instances" "filter_by_user" {
+  type_id = local.type_id
+  user    = local.user
+}
+
+locals {
+  user_filter_result = [for v in data.huaweicloud_dsc_catalog_instances.filter_by_user.instances[*].user : strcontains(v, local.user)]
+}
+
+output "is_user_filter_useful" {
+  value = length(local.user_filter_result) > 0 && alltrue(local.user_filter_result)
+}
+
+# Filter by 'col_id' and 'sort' parameters.
+data "huaweicloud_dsc_catalog_instances" "filter_by_col_id_and_sort_desc" {
+  type_id = local.type_id
+  col_id  = "address"
+  sort    = "desc"
+}
+
+data "huaweicloud_dsc_catalog_instances" "filter_by_col_id_and_sort_asc" {
+  type_id = local.type_id
+  col_id  = "address"
+  sort    = "asc"
+}
+
+locals {
+  col_id_and_sort_desc_result = data.huaweicloud_dsc_catalog_instances.filter_by_col_id_and_sort_desc.instances[*].address
+  col_id_and_sort_asc_result  = data.huaweicloud_dsc_catalog_instances.filter_by_col_id_and_sort_asc.instances[*].address
+}
+
+output "is_col_id_and_sort_useful" {
+  value = length(local.col_id_and_sort_desc_result) > 1 && local.col_id_and_sort_desc_result == reverse(local.col_id_and_sort_asc_result)
+}
+`, acceptance.HW_DSC_TYPE_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_catalog_instances.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_catalog_instances.go
@@ -1,0 +1,345 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/metadata/catalog/databases
+func DataSourceCatalogInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCatalogInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the catalog instances are located.`,
+			},
+
+			// Optional parameters.
+			"label_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"type_id"},
+				Description:  `The ID of the group label to which the instance belongs.`,
+			},
+			"type_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the data type of the database instance.`,
+			},
+			"instance_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the database instance.`,
+			},
+			"address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The address of the database instance.`,
+			},
+			"user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The access user of the database instance.`,
+			},
+			"col_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The key used to sort the instances.`,
+			},
+			"sort": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting method for query results.`,
+			},
+
+			// Attributes.
+			"instances": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of database instances.`,
+				Elem:        catalogInstanceInfoSchema(),
+			},
+		},
+	}
+}
+
+func catalogInstanceInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the database instance.`,
+			},
+			"instance_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database instance.`,
+			},
+			"address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The address of the database instance.`,
+			},
+			"db_infos": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of databases that belong to the instance.`,
+				Elem:        catalogInstanceDbInfoSchema(),
+			},
+			"sensitive_col_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of sensitive columns in the instance.`,
+			},
+			"sensitive_db_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of sensitive databases in the instance.`,
+			},
+			"sensitive_table_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of sensitive tables in the instance.`,
+			},
+			"user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The access user of the database instance.`,
+			},
+		},
+	}
+}
+
+func catalogInstanceDbInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"db_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the database.`,
+			},
+			"db_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database.`,
+			},
+			"db_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the database.`,
+			},
+			"asset_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the asset to which the database belongs.`,
+			},
+			"classifications": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The classification list of the database.`,
+			},
+			"latest_scan_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest scan time of the database, in RFC3339 format.`,
+			},
+			"sensitive_level_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the sensitive level.`,
+			},
+			"color_number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The color number corresponding to the database sensitive level.`,
+			},
+			"sensitive_table_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of sensitive tables in the database.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The tag list of the database.`,
+			},
+			"total_table_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of tables in the database.`,
+			},
+		},
+	}
+}
+
+func buildCatalogInstancesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("label_id"); ok {
+		res = fmt.Sprintf("%s&label_id=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("type_id"); ok {
+		res = fmt.Sprintf("%s&type_id=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("instance_name"); ok {
+		res = fmt.Sprintf("%s&instance_name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("address"); ok {
+		res = fmt.Sprintf("%s&address=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("user"); ok {
+		res = fmt.Sprintf("%s&user=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("col_id"); ok {
+		res = fmt.Sprintf("%s&col_id=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("sort"); ok {
+		res = fmt.Sprintf("%s&sort=%v", res, v)
+	}
+
+	return res
+}
+
+func listCatalogInstances(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/metadata/catalog/databases"
+		offset  = 0
+		limit   = 100
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += fmt.Sprintf("?limit=%v", limit) + buildCatalogInstancesQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%v", offset)
+		resp, err := client.Request("GET", listPathWithOffset, &requestOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		instances := utils.PathSearch("instance_infos", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, instances...)
+		if len(instances) < limit {
+			break
+		}
+
+		offset += len(instances)
+	}
+
+	return result, nil
+}
+
+func dataSourceCatalogInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	instances, err := listCatalogInstances(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC catalog instances: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instances", flattenCatalogInstances(instances)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCatalogInstances(instances []interface{}) []interface{} {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(instances))
+	for _, v := range instances {
+		rst = append(rst, map[string]interface{}{
+			"instance_id":         utils.PathSearch("instance_id", v, nil),
+			"instance_name":       utils.PathSearch("instance_name", v, nil),
+			"address":             utils.PathSearch("address", v, nil),
+			"db_infos":            flattenCatalogInstanceDatabases(utils.PathSearch("db_infos", v, make([]interface{}, 0)).([]interface{})),
+			"sensitive_col_num":   utils.PathSearch("sensitive_col_num", v, nil),
+			"sensitive_db_num":    utils.PathSearch("sensitive_db_num", v, nil),
+			"sensitive_table_num": utils.PathSearch("sensitive_table_num", v, nil),
+			"user":                utils.PathSearch("user", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenCatalogInstanceDatabases(dbs []interface{}) []interface{} {
+	if len(dbs) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(dbs))
+	for _, v := range dbs {
+		rst = append(rst, map[string]interface{}{
+			"db_id":           utils.PathSearch("dbId", v, nil),
+			"db_name":         utils.PathSearch("db_name", v, nil),
+			"db_type":         utils.PathSearch("db_type", v, nil),
+			"asset_id":        utils.PathSearch("asset_id", v, nil),
+			"classifications": utils.PathSearch("classifications", v, nil),
+			"latest_scan_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("latest_scan_time",
+				v, float64(0)).(float64))/1000, false),
+			"sensitive_level_name":  utils.PathSearch("sensitive_level_name", v, nil),
+			"color_number":          utils.PathSearch("color_number", v, nil),
+			"sensitive_table_count": utils.PathSearch("sensitive_table_count", v, nil),
+			"tags":                  utils.PathSearch("tags", v, nil),
+			"total_table_count":     utils.PathSearch("total_table_count", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source to query the database instance list in the asset catalog.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceCatalogInstances_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceCatalogInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCatalogInstances_basic
=== PAUSE TestAccDataSourceCatalogInstances_basic
=== CONT  TestAccDataSourceCatalogInstances_basic
--- PASS: TestAccDataSourceCatalogInstances_basic (12.71s)
PASS
coverage: 8.1% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       12.877s coverage: 8.1% of statements in ./huaweicloud/services/dsc
```
<img width="1050" height="55" alt="image" src="https://github.com/user-attachments/assets/81987d1f-ad7a-44a7-8994-b8c8f6468685" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
