### PR TITLE
feat(cce): add new data source for node pools

### DIFF
--- a/docs/data-sources/cce_node_pools.md
+++ b/docs/data-sources/cce_node_pools.md
@@ -1,0 +1,296 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cce_node_pools"
+description: |-
+  Use this data source to query CCE node pools within HuaweiCloud.
+---
+
+# huaweicloud_cce_node_pools
+
+Use this data source to query CCE node pools within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_cce_node_pools" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the CCE node pools are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the CCE cluster.
+
+* `show_default_node_pool` - (Optional, String) Specifies whether to show the default node pool.  
+  The value can be **true** or **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `node_pools` - The list of CCE node pools that matched filter parameters.  
+  The [node_pools](#cce_node_pools) structure is documented below.
+
+<a name="cce_node_pools"></a>
+The `node_pools` block supports:
+
+* `id` - The ID of the node pool.
+
+* `name` - The name of the node pool.
+
+* `initial_node_count` - The initial number of nodes in the node pool.
+
+* `current_node_count` - The current number of nodes in the node pool.
+
+* `flavor_id` - The flavor ID of the node pool.
+
+* `type` - The type of the node pool.
+
+* `availability_zone` - The availability zone of the node pool.
+
+* `os` - The operating system of the node pool.
+
+* `key_pair` - The key pair name of the node pool.
+
+* `subnet_id` - The subnet ID of the NIC.
+
+* `subnet_list` - The subnet ID list of the NIC.
+
+* `ecs_group_id` - The ECS group ID of the node pool.
+
+* `max_pods` - The maximum number of pods allowed on a node.
+
+* `extend_param` - The extended parameters of the node pool, in key/value format.
+
+* `extend_params` - The extended parameters of the node pool.  
+  The [extend_params](#cce_node_pools_extend_params) structure is documented below.
+
+* `extension_scale_groups` - The extended scaling groups.  
+  The [extension_scale_groups](#cce_node_pools_extension_scale_groups) structure is documented below.
+
+* `scall_enable` - Whether auto scaling is enabled.
+
+* `min_node_count` - The minimum number of nodes if auto scaling is enabled.
+
+* `max_node_count` - The maximum number of nodes if auto scaling is enabled.
+
+* `scale_down_cooldown_time` - The interval between two scaling operations, in minutes.
+
+* `priority` - The weight of the node pool during scaling.
+
+* `labels` - The labels of a Kubernetes node.
+
+* `tags` - The tags of a VM node.
+
+* `root_volume` - The system disk configuration of the node pool.  
+  The [root_volume](#cce_node_pools_volume) structure is documented below.
+
+* `data_volumes` - The data disk configurations of the node pool.  
+  The [data_volumes](#cce_node_pools_volume) structure is documented below.
+
+* `storage` - The disk initialization configuration of the node pool.  
+  The [storage](#cce_node_pools_storage) structure is documented below.
+
+* `taints` - The taints configuration of the node pool.  
+  The [taints](#cce_node_pools_taints) structure is documented below.
+
+* `security_groups` - The custom security group IDs of the node pool.
+
+* `pod_security_groups` - The pod security group IDs of the node pool.
+
+* `initialized_conditions` - The custom initialization flags of the node pool.
+
+* `label_policy_on_existing_nodes` - The label policy on existing nodes.
+
+* `tag_policy_on_existing_nodes` - The tag policy on existing nodes.
+
+* `taint_policy_on_existing_nodes` - The taint policy on existing nodes.
+
+* `hostname_config` - The hostname configuration of the kubernetes node.  
+  The [hostname_config](#cce_node_pools_hostname_config) structure is documented below.
+
+* `partition` - The partition to which the node belongs.
+
+* `enterprise_project_id` - The enterprise project ID of the node pool.
+
+* `runtime` - The runtime of the node pool.
+
+* `billing_mode` - The billing mode of a node.
+
+* `period_unit` - The charging period unit of the node pool.
+
+* `period` - The charging period of the node pool.
+
+* `auto_renew` - Whether auto-renew is enabled.
+
+* `status` - The status of the node pool.
+
+<a name="cce_node_pools_extend_params"></a>
+The `extend_params` block supports:
+
+* `max_pods` - The maximum number of pods allowed on a node.
+
+* `docker_base_size` - The available disk space of a single container on a node, in GB.
+
+* `preinstall` - The script to be executed before installation.
+
+* `postinstall` - The script to be executed after installation.
+
+* `node_image_id` - The image ID used to create the node.
+
+* `node_multi_queue` - The number of ENI queues.
+
+* `nic_threshold` - The ENI pre-binding thresholds.
+
+* `agency_name` - The agency name of the node pool.
+
+* `kube_reserved_mem` - The reserved memory for Kubernetes components.
+
+* `system_reserved_mem` - The reserved memory for system components.
+
+* `security_reinforcement_type` - The security reinforcement type.
+
+* `market_type` - The market type of the spot node pool.
+
+* `spot_price` - The highest price per hour for a spot node.
+
+<a name="cce_node_pools_extension_scale_groups"></a>
+The `extension_scale_groups` block supports:
+
+* `metadata` - The basic information about the extended scaling group.  
+  The [metadata](#cce_node_pools_extension_scale_groups_metadata) structure is documented below.
+
+* `spec` - The configurations of the extended scaling group.  
+  The [spec](#cce_node_pools_extension_scale_groups_spec) structure is documented below.
+
+<a name="cce_node_pools_extension_scale_groups_metadata"></a>
+The `metadata` block supports:
+
+* `name` - The name of the extended scaling group.
+
+* `uid` - The UUID of the extended scaling group.
+
+<a name="cce_node_pools_extension_scale_groups_spec"></a>
+The `spec` block supports:
+
+* `flavor` - The node flavor.
+
+* `az` - The availability zone.
+
+* `capacity_reservation_specification` - The capacity reservation configurations.  
+  The [capacity_reservation_specification](#cce_node_pools_capacity_reservation_specification) structure is documented below.
+
+* `autoscaling` - The auto scaling configurations.  
+  The [autoscaling](#cce_node_pools_autoscaling) structure is documented below.
+
+<a name="cce_node_pools_capacity_reservation_specification"></a>
+The `capacity_reservation_specification` block supports:
+
+* `id` - The private pool ID.
+
+* `preference` - The private pool capacity preference.
+
+<a name="cce_node_pools_autoscaling"></a>
+The `autoscaling` block supports:
+
+* `enable` - Whether auto scaling is enabled.
+
+* `extension_priority` - The priority of the scaling group.
+
+* `min_node_count` - The minimum number of nodes.
+
+* `max_node_count` - The maximum number of nodes.
+
+<a name="cce_node_pools_volume"></a>
+The `root_volume` and `data_volumes` blocks support:
+
+* `size` - The disk size in GB.
+
+* `volumetype` - The disk type.
+
+* `extend_params` - The disk expansion parameters.
+
+* `kms_key_id` - The KMS key ID of the disk.
+
+* `dss_pool_id` - The DSS pool ID of the disk.
+
+* `iops` - The IOPS of the disk.
+
+* `throughput` - The throughput of the disk.
+
+* `hw_passthrough` - Whether passthrough is enabled.
+
+<a name="cce_node_pools_storage"></a>
+The `storage` block supports:
+
+* `selectors` - The disk selection configuration.  
+  The [selectors](#cce_node_pools_storage_selectors) structure is documented below.
+
+* `groups` - The storage group configuration.  
+  The [groups](#cce_node_pools_storage_groups) structure is documented below.
+
+<a name="cce_node_pools_storage_selectors"></a>
+The `selectors` block supports:
+
+* `name` - The selector name.
+
+* `type` - The storage type.
+
+* `match_label_size` - The matched disk size.
+
+* `match_label_volume_type` - The EVS disk type.
+
+* `match_label_metadata_encrypted` - The disk encryption identifier.
+
+* `match_label_metadata_cmkid` - The customer master key ID of an encrypted disk.
+
+* `match_label_count` - The number of disks to be selected.
+
+<a name="cce_node_pools_storage_groups"></a>
+The `groups` block supports:
+
+* `name` - The name of a virtual storage group.
+
+* `cce_managed` - Whether the storage space is for kubernetes and runtime components.
+
+* `selector_names` - The list of selector names to match.
+
+* `virtual_spaces` - The detailed space configuration in a group.  
+  The [virtual_spaces](#cce_node_pools_storage_virtual_spaces) structure is documented below.
+
+<a name="cce_node_pools_storage_virtual_spaces"></a>
+The `virtual_spaces` block supports:
+
+* `name` - The virtual space name.
+
+* `size` - The size of a virtual space.
+
+* `lvm_lv_type` - The LVM write mode.
+
+* `lvm_path` - The absolute path to which the disk is attached.
+
+* `runtime_lv_type` - The LVM write mode of runtime.
+
+<a name="cce_node_pools_taints"></a>
+The `taints` block supports:
+
+* `key` - The key of the taint.
+
+* `value` - The value of the taint.
+
+* `effect` - The effect of the taint.
+
+<a name="cce_node_pools_hostname_config"></a>
+The `hostname_config` block supports:
+
+* `type` - The hostname type of the kubernetes node.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -738,6 +738,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_node":                               cce.DataSourceNode(),
 			"huaweicloud_cce_nodes":                              cce.DataSourceNodes(),
 			"huaweicloud_cce_node_pool":                          cce.DataSourceCCENodePoolV3(),
+			"huaweicloud_cce_node_pools":                         cce.DataSourceNodePools(),
 			"huaweicloud_cce_charts":                             cce.DataSourceCCECharts(),
 			"huaweicloud_cce_cluster_configurations":             cce.DataSourceClusterConfigurations(),
 			"huaweicloud_cce_addons":                             cce.DataSourceCceAddons(),

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pools_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pools_test.go
@@ -1,0 +1,257 @@
+package cce
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataNodePools_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		all = "data.huaweicloud_cce_node_pools.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byShowDefault   = "data.huaweicloud_cce_node_pools.with_default"
+		dcByShowDefault = acceptance.InitDataSourceCheck(byShowDefault)
+
+		byWithoutDefault   = "data.huaweicloud_cce_node_pools.without_default"
+		dcByWithoutDefault = acceptance.InitDataSourceCheck(byWithoutDefault)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataNodePools_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "node_pools.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "node_pools.0.id"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.id",
+						"huaweicloud_cce_node_pool.test", "id"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.name",
+						"huaweicloud_cce_node_pool.test", "name"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.initial_node_count",
+						"huaweicloud_cce_node_pool.test", "initial_node_count"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.flavor_id",
+						"huaweicloud_cce_node_pool.test", "flavor_id"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.type",
+						"huaweicloud_cce_node_pool.test", "type"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.availability_zone",
+						"huaweicloud_cce_node_pool.test", "availability_zone"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.os",
+						"huaweicloud_cce_node_pool.test", "os"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.key_pair",
+						"huaweicloud_cce_node_pool.test", "key_pair"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.subnet_id",
+						"huaweicloud_cce_node_pool.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.runtime",
+						"huaweicloud_cce_node_pool.test", "runtime"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.labels.test_key",
+						"huaweicloud_cce_node_pool.test", "labels.test_key"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.tags.foo",
+						"huaweicloud_cce_node_pool.test", "tags.foo"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.taints.0.key",
+						"huaweicloud_cce_node_pool.test", "taints.0.key"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.taints.0.value",
+						"huaweicloud_cce_node_pool.test", "taints.0.value"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.taints.0.effect",
+						"huaweicloud_cce_node_pool.test", "taints.0.effect"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.extend_params.0.max_pods",
+						"huaweicloud_cce_node_pool.test", "extend_params.0.max_pods"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.extend_params.0.docker_base_size",
+						"huaweicloud_cce_node_pool.test", "extend_params.0.docker_base_size"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.hostname_config.0.type",
+						"huaweicloud_cce_node_pool.test", "hostname_config.0.type"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.root_volume.0.size",
+						"huaweicloud_cce_node_pool.test", "root_volume.0.size"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.root_volume.0.volumetype",
+						"huaweicloud_cce_node_pool.test", "root_volume.0.volumetype"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.data_volumes.0.size",
+						"huaweicloud_cce_node_pool.test", "data_volumes.0.size"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.data_volumes.0.volumetype",
+						"huaweicloud_cce_node_pool.test", "data_volumes.0.volumetype"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.extension_scale_groups.0.metadata.0.name",
+						"huaweicloud_cce_node_pool.test", "extension_scale_groups.0.metadata.0.name"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.extension_scale_groups.0.spec.0.flavor",
+						"huaweicloud_cce_node_pool.test", "extension_scale_groups.0.spec.0.flavor"),
+					resource.TestCheckResourceAttrPair(all, "node_pools.0.extension_scale_groups.0.spec.0.az",
+						"huaweicloud_cce_node_pool.test", "extension_scale_groups.0.spec.0.az"),
+					resource.TestCheckResourceAttrSet(all, "node_pools.0.storage.#"),
+					resource.TestCheckResourceAttrSet(all, "node_pools.0.storage.0.selectors.#"),
+					resource.TestCheckResourceAttrSet(all, "node_pools.0.storage.0.groups.#"),
+					resource.TestCheckOutput("is_storage_set", "true"),
+
+					// filter by show_default_node_pool
+					dcByShowDefault.CheckResourceExists(),
+					dcByWithoutDefault.CheckResourceExists(),
+					resource.TestCheckOutput("is_show_default_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataNodePools_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_cce_node_pool" "test" {
+  cluster_id               = huaweicloud_cce_cluster.test.id
+  name                     = "%[2]s"
+  os                       = "Huawei Cloud EulerOS 2.0"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
+  initial_node_count       = 0
+  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  key_pair                 = huaweicloud_kps_keypair.test.name
+  scall_enable             = false
+  min_node_count           = 0
+  max_node_count           = 0
+  scale_down_cooldown_time = 0
+  priority                 = 0
+  type                     = "vm"
+  runtime                  = "containerd"
+  subnet_id                = huaweicloud_vpc_subnet.test.id
+  security_groups          = [huaweicloud_networking_secgroup.test.id]
+  initialized_conditions   = ["CCEInitial"]
+
+  tag_policy_on_existing_nodes   = "ignore"
+  label_policy_on_existing_nodes = "ignore"
+  taint_policy_on_existing_nodes = "ignore"
+
+  labels = {
+    test_key = "test_value"
+  }
+
+  tags = {
+    foo = "bar"
+  }
+
+  taints {
+    key    = "test_key"
+    value  = "test_value"
+    effect = "NoSchedule"
+  }
+
+  extend_params {
+    max_pods         = 50
+    docker_base_size = 20
+  }
+
+  hostname_config {
+    type = "cceNodeName"
+  }
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  storage {
+    selectors {
+      name              = "cceUse"
+      type              = "evs"
+      match_label_size  = "100"
+      match_label_count = "1"
+    }
+
+    groups {
+      name           = "vgpaas"
+      selector_names = ["cceUse"]
+      cce_managed    = true
+
+      virtual_spaces {
+        name        = "kubernetes"
+        size        = "10%%"
+        lvm_lv_type = "linear"
+      }
+
+      virtual_spaces {
+        name            = "runtime"
+        size            = "90%%"
+        runtime_lv_type = "linear"
+      }
+    }
+  }
+
+  extension_scale_groups {
+    metadata {
+      name = "%[2]s-group1"
+    }
+
+    spec {
+      flavor = data.huaweicloud_compute_flavors.test.ids[0]
+      az     = data.huaweicloud_availability_zones.test.names[1]
+
+      autoscaling {
+        extension_priority = 1
+        enable             = true
+      }
+    }
+  }
+}
+
+data "huaweicloud_cce_node_pools" "test" {
+  depends_on = [
+    huaweicloud_cce_node_pool.test,
+  ]
+
+  cluster_id = huaweicloud_cce_cluster.test.id
+}
+
+# Filter by show_default_node_pool=true
+data "huaweicloud_cce_node_pools" "with_default" {
+  depends_on = [
+    huaweicloud_cce_node_pool.test,
+  ]
+
+  cluster_id             = huaweicloud_cce_cluster.test.id
+  show_default_node_pool = "true"
+}
+
+# Filter by show_default_node_pool=false
+data "huaweicloud_cce_node_pools" "without_default" {
+  depends_on = [
+    huaweicloud_cce_node_pool.test,
+  ]
+
+  cluster_id             = huaweicloud_cce_cluster.test.id
+  show_default_node_pool = "false"
+}
+
+output "is_show_default_filter_useful" {
+  value = (
+    length(data.huaweicloud_cce_node_pools.with_default.node_pools) >= length(data.huaweicloud_cce_node_pools.without_default.node_pools) &&
+    length(data.huaweicloud_cce_node_pools.with_default.node_pools) > 0
+  )
+}
+
+locals {
+  target_pools = [
+    for p in data.huaweicloud_cce_node_pools.test.node_pools : p
+    if p.id == huaweicloud_cce_node_pool.test.id
+  ]
+  target_pool = length(local.target_pools) > 0 ? local.target_pools[0] : null
+}
+
+output "is_storage_set" {
+  value = local.target_pool != null && length(local.target_pool.storage) > 0
+}
+`, testAccNodePool_base(name), name)
+}

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_node_pools.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_node_pools.go
@@ -1,0 +1,925 @@
+package cce
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCE GET /api/v3/projects/{project_id}/clusters/{cluster_id}/nodepools
+func DataSourceNodePools() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNodePoolsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the CCE node pools are located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the CCE cluster.`,
+			},
+
+			// Optional parameters.
+			"show_default_node_pool": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
+				Description: `Whether to show the default node pool.`,
+			},
+
+			// Attributes.
+			"node_pools": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataNodePoolsElem(),
+				Description: `The list of CCE node pools that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataNodePoolsElem() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the node pool.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the node pool.`,
+			},
+			"initial_node_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The initial number of nodes in the node pool.`,
+			},
+			"current_node_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The current number of nodes in the node pool.`,
+			},
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor ID of the node pool.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the node pool.`,
+			},
+			"availability_zone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The availability zone of the node pool.`,
+			},
+			"os": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The operating system of the node pool.`,
+			},
+			"key_pair": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The key pair name of the node pool.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subnet ID of the NIC.`,
+			},
+			"subnet_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The subnet ID list of the NIC.`,
+			},
+			"ecs_group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ECS group ID of the node pool.`,
+			},
+			"max_pods": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum number of pods allowed on a node.`,
+			},
+			"extend_param": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The extended parameters of the node pool, in key/value format.`,
+			},
+			"extend_params":          dataNodePoolsExtendParamsElem(),
+			"extension_scale_groups": nodePoolExtensionScaleGroupsSchema(),
+			"scall_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether auto scaling is enabled.`,
+			},
+			"min_node_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The minimum number of nodes if auto scaling is enabled.`,
+			},
+			"max_node_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum number of nodes if auto scaling is enabled.`,
+			},
+			"scale_down_cooldown_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The interval between two scaling operations, in minutes.`,
+			},
+			"priority": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The weight of the node pool during scaling.`,
+			},
+			"labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The labels of a Kubernetes node.`,
+			},
+			"tags": common.TagsComputedSchema(),
+			"root_volume": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataNodePoolsVolumeElem(),
+				Description: `The system disk configuration of the node pool.`,
+			},
+			"data_volumes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataNodePoolsVolumeElem(),
+				Description: `The data disk configurations of the node pool.`,
+			},
+			"storage": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataNodePoolsStorageElem(),
+				Description: `The disk initialization configuration of the node pool.`,
+			},
+			"taints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the taint.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The value of the taint.`,
+						},
+						"effect": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The effect of the taint.`,
+						},
+					},
+				},
+				Description: `The taints configuration of the node pool.`,
+			},
+			"security_groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The custom security group IDs of the node pool.`,
+			},
+			"pod_security_groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The pod security group IDs of the node pool.`,
+			},
+			"initialized_conditions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The custom initialization flags of the node pool.`,
+			},
+			"label_policy_on_existing_nodes": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The label policy on existing nodes.`,
+			},
+			"tag_policy_on_existing_nodes": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The tag policy on existing nodes.`,
+			},
+			"taint_policy_on_existing_nodes": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The taint policy on existing nodes.`,
+			},
+			"hostname_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The hostname type of the kubernetes node.`,
+						},
+					},
+				},
+				Description: `The hostname configuration of the kubernetes node.`,
+			},
+			"partition": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The partition to which the node belongs.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The enterprise project ID of the node pool.`,
+			},
+			"runtime": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The runtime of the node pool.`,
+			},
+			"billing_mode": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The billing mode of a node.`,
+			},
+			"period_unit": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The charging period unit of the node pool.`,
+			},
+			"period": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The charging period of the node pool.`,
+			},
+			"auto_renew": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Whether auto-renew is enabled.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the node pool.`,
+			},
+		},
+	}
+
+	return &sc
+}
+
+func dataNodePoolsExtendParamsElem() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: `The extended parameters of the node pool.`,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"max_pods": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: `The maximum number of pods allowed on a node.`,
+				},
+				"docker_base_size": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: `The available disk space of a single container on a node, in GB.`,
+				},
+				"preinstall": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The script to be executed before installation.`,
+				},
+				"postinstall": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The script to be executed after installation.`,
+				},
+				"node_image_id": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The image ID used to create the node.`,
+				},
+				"node_multi_queue": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The number of ENI queues.`,
+				},
+				"nic_threshold": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The ENI pre-binding thresholds.`,
+				},
+				"agency_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The agency name of the node pool.`,
+				},
+				"kube_reserved_mem": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: `The reserved memory for Kubernetes components.`,
+				},
+				"system_reserved_mem": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: `The reserved memory for system components.`,
+				},
+				"security_reinforcement_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The security reinforcement type.`,
+				},
+				"market_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The market type of the spot node pool.`,
+				},
+				"spot_price": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `The highest price per hour for a spot node.`,
+				},
+			},
+		},
+	}
+}
+
+func dataNodePoolsStorageElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"selectors": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The disk selection configuration.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The selector name.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The storage type.`,
+						},
+						"match_label_size": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The matched disk size.`,
+						},
+						"match_label_volume_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The EVS disk type.`,
+						},
+						"match_label_metadata_encrypted": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The disk encryption identifier.`,
+						},
+						"match_label_metadata_cmkid": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The customer master key ID of an encrypted disk.`,
+						},
+						"match_label_count": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The number of disks to be selected.`,
+						},
+					},
+				},
+			},
+			"groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The storage group configuration.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of a virtual storage group.`,
+						},
+						"cce_managed": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the storage space is for kubernetes and runtime components.`,
+						},
+						"selector_names": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of selector names to match.`,
+						},
+						"virtual_spaces": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The detailed space configuration in a group.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The virtual space name.`,
+									},
+									"size": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The size of a virtual space.`,
+									},
+									"lvm_lv_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The LVM write mode.`,
+									},
+									"lvm_path": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The absolute path to which the disk is attached.`,
+									},
+									"runtime_lv_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The LVM write mode of runtime.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataNodePoolsVolumeElem() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The disk size in GB.`,
+			},
+			"volumetype": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The disk type.`,
+			},
+			"extend_params": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The disk expansion parameters.`,
+			},
+			"kms_key_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The KMS key ID of the disk.`,
+			},
+			"dss_pool_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The DSS pool ID of the disk.`,
+			},
+			"iops": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The IOPS of the disk.`,
+			},
+			"throughput": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The throughput of the disk.`,
+			},
+			"hw_passthrough": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether passthrough is enabled.`,
+			},
+		},
+	}
+
+	return &sc
+}
+
+func buildGetNodePoolsQueryParams(d *schema.ResourceData) string {
+	if showDefault, ok := d.GetOk("show_default_node_pool"); ok {
+		return fmt.Sprintf("?showDefaultNodePool=%v", showDefault)
+	}
+	return ""
+}
+
+func listNodePools(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl  = "api/v3/projects/{project_id}/clusters/{cluster_id}/nodepools"
+		listPath = client.Endpoint + httpUrl
+	)
+
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{cluster_id}", d.Get("cluster_id").(string))
+	listPath += buildGetNodePoolsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenNodePoolStorageVirtualSpaces(group interface{}) []map[string]interface{} {
+	virtualSpacesRaw := utils.PathSearch("virtualSpaces", group, make([]interface{}, 0)).([]interface{})
+	if len(virtualSpacesRaw) < 1 {
+		return nil
+	}
+
+	virtualSpaces := make([]map[string]interface{}, 0, len(virtualSpacesRaw))
+	for _, space := range virtualSpacesRaw {
+		virtualSpaces = append(virtualSpaces, map[string]interface{}{
+			"name":            utils.PathSearch("name", space, nil),
+			"size":            utils.PathSearch("size", space, nil),
+			"lvm_lv_type":     utils.PathSearch("lvmConfig.lvType", space, nil),
+			"lvm_path":        utils.PathSearch("lvmConfig.path", space, nil),
+			"runtime_lv_type": utils.PathSearch("runtimeConfig.lvType", space, nil),
+		})
+	}
+	return virtualSpaces
+}
+
+func flattenNodePoolStorage(storage interface{}) []map[string]interface{} {
+	if storage == nil {
+		return nil
+	}
+
+	selectorsRaw := utils.PathSearch("storageSelectors", storage, make([]interface{}, 0)).([]interface{})
+	groupsRaw := utils.PathSearch("storageGroups", storage, make([]interface{}, 0)).([]interface{})
+	if len(selectorsRaw) < 1 && len(groupsRaw) < 1 {
+		return nil
+	}
+
+	selectors := make([]map[string]interface{}, 0, len(selectorsRaw))
+	for _, selector := range selectorsRaw {
+		selectors = append(selectors, map[string]interface{}{
+			"name":                           utils.PathSearch("name", selector, nil),
+			"type":                           utils.PathSearch("storageType", selector, nil),
+			"match_label_size":               utils.PathSearch("matchLabels.size", selector, nil),
+			"match_label_volume_type":        utils.PathSearch("matchLabels.volumeType", selector, nil),
+			"match_label_metadata_encrypted": utils.PathSearch("matchLabels.metadataEncrypted", selector, nil),
+			"match_label_metadata_cmkid":     utils.PathSearch("matchLabels.metadataCmkid", selector, nil),
+			"match_label_count":              utils.PathSearch("matchLabels.count", selector, nil),
+		})
+	}
+
+	groups := make([]map[string]interface{}, 0, len(groupsRaw))
+	for _, group := range groupsRaw {
+		groups = append(groups, map[string]interface{}{
+			"name":           utils.PathSearch("name", group, nil),
+			"cce_managed":    utils.PathSearch("cceManaged", group, nil),
+			"selector_names": utils.PathSearch("selectorNames", group, make([]interface{}, 0)),
+			"virtual_spaces": flattenNodePoolStorageVirtualSpaces(group),
+		})
+	}
+
+	return []map[string]interface{}{
+		{
+			"selectors": selectors,
+			"groups":    groups,
+		},
+	}
+}
+
+func flattenNodePoolTags(userTags []interface{}) map[string]string {
+	if len(userTags) < 1 {
+		return nil
+	}
+
+	result := make(map[string]string, len(userTags))
+	for _, tag := range userTags {
+		key := utils.PathSearch("key", tag, "").(string)
+		if key == "" {
+			continue
+		}
+		result[key] = utils.PathSearch("value", tag, "").(string)
+	}
+	return result
+}
+
+func flattenNodePoolRootVolume(rootVolume interface{}) []map[string]interface{} {
+	if rootVolume == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"size":           int(utils.PathSearch("size", rootVolume, float64(0)).(float64)),
+			"volumetype":     utils.PathSearch("volumetype", rootVolume, nil),
+			"extend_params":  utils.PathSearch("extendParam", rootVolume, nil),
+			"hw_passthrough": utils.PathSearch(`"hw:passthrough"`, rootVolume, nil),
+			"dss_pool_id":    utils.PathSearch("cluster_id", rootVolume, nil),
+			"iops":           int(utils.PathSearch("iops", rootVolume, float64(0)).(float64)),
+			"throughput":     int(utils.PathSearch("throughput", rootVolume, float64(0)).(float64)),
+			"kms_key_id":     utils.PathSearch(`metadata."__system__cmkid"`, rootVolume, nil),
+		},
+	}
+}
+
+func flattenNodePoolDataVolumes(dataVolumes []interface{}) []map[string]interface{} {
+	if len(dataVolumes) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(dataVolumes))
+	for _, volume := range dataVolumes {
+		result = append(result, map[string]interface{}{
+			"size":           int(utils.PathSearch("size", volume, float64(0)).(float64)),
+			"volumetype":     utils.PathSearch("volumetype", volume, nil),
+			"extend_params":  utils.PathSearch("extendParam", volume, nil),
+			"hw_passthrough": utils.PathSearch(`"hw:passthrough"`, volume, nil),
+			"dss_pool_id":    utils.PathSearch("cluster_id", volume, nil),
+			"iops":           int(utils.PathSearch("iops", volume, float64(0)).(float64)),
+			"throughput":     int(utils.PathSearch("throughput", volume, float64(0)).(float64)),
+			"kms_key_id":     utils.PathSearch(`metadata."__system__cmkid"`, volume, nil),
+		})
+	}
+	return result
+}
+
+func flattenNodePoolHostnameConfig(hostnameConfig interface{}) []map[string]interface{} {
+	if hostnameConfig == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"type": utils.PathSearch("type", hostnameConfig, nil),
+		},
+	}
+}
+
+func flattenNodePoolExtendParams(extendParams map[string]interface{}) []map[string]interface{} {
+	if len(extendParams) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"max_pods":                    int(utils.PathSearch("maxPods", extendParams, float64(0)).(float64)),
+			"docker_base_size":            int(utils.PathSearch("dockerBaseSize", extendParams, float64(0)).(float64)),
+			"preinstall":                  utils.PathSearch(`"alpha.cce/preInstall"`, extendParams, nil),
+			"postinstall":                 utils.PathSearch(`"alpha.cce/postInstall"`, extendParams, nil),
+			"node_image_id":               utils.PathSearch(`"alpha.cce/NodeImageID"`, extendParams, nil),
+			"node_multi_queue":            utils.PathSearch("nicMultiqueue", extendParams, nil),
+			"nic_threshold":               utils.PathSearch("nicThreshold", extendParams, nil),
+			"agency_name":                 utils.PathSearch("agency_name", extendParams, nil),
+			"kube_reserved_mem":           int(utils.PathSearch("kubeReservedMem", extendParams, float64(0)).(float64)),
+			"system_reserved_mem":         int(utils.PathSearch("systemReservedMem", extendParams, float64(0)).(float64)),
+			"security_reinforcement_type": utils.PathSearch("securityReinforcementType", extendParams, nil),
+			"market_type":                 utils.PathSearch("marketType", extendParams, nil),
+			"spot_price":                  utils.PathSearch("spotPrice", extendParams, nil),
+		},
+	}
+}
+
+func flattenNodePoolTaints(taints []interface{}) []map[string]interface{} {
+	if len(taints) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(taints))
+	for _, taint := range taints {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", taint, nil),
+			"value":  utils.PathSearch("value", taint, nil),
+			"effect": utils.PathSearch("effect", taint, nil),
+		})
+	}
+	return result
+}
+
+func flattenNodePoolExtensionScaleGroupsSpecAutoscaling(spec interface{}) []map[string]interface{} {
+	autoscaling := utils.PathSearch("autoscaling", spec, nil)
+	if autoscaling == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"extension_priority": int(utils.PathSearch("extensionPriority", autoscaling, float64(0)).(float64)),
+			"max_node_count":     int(utils.PathSearch("maxNodeCount", autoscaling, float64(0)).(float64)),
+			"min_node_count":     int(utils.PathSearch("minNodeCount", autoscaling, float64(0)).(float64)),
+			"enable":             utils.PathSearch("enable", autoscaling, nil),
+		},
+	}
+}
+
+func flattenNodePoolExtensionScaleGroupsSpec(extensionScaleGroup interface{}) []map[string]interface{} {
+	spec := utils.PathSearch("spec", extensionScaleGroup, nil)
+	if spec == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"flavor":                             utils.PathSearch("flavor", spec, nil),
+			"az":                                 utils.PathSearch("az", spec, nil),
+			"capacity_reservation_specification": flattenExtensionScaleGroupsSpecCapacity(spec),
+			"autoscaling":                        flattenNodePoolExtensionScaleGroupsSpecAutoscaling(spec),
+		},
+	}
+}
+
+func flattenNodePoolExtensionScaleGroups(groups []interface{}) []map[string]interface{} {
+	if len(groups) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(groups))
+	for _, group := range groups {
+		result = append(result, map[string]interface{}{
+			"metadata": flattenExtensionScaleGroupsMetadata(group),
+			"spec":     flattenNodePoolExtensionScaleGroupsSpec(group),
+		})
+	}
+	return result
+}
+
+func flattenNodePoolLabels(k8sTags interface{}) map[string]interface{} {
+	tagsMap, ok := k8sTags.(map[string]interface{})
+	if !ok || len(tagsMap) < 1 {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	for key, val := range tagsMap {
+		if strings.Contains(key, "cce.cloud.com") {
+			continue
+		}
+		result[key] = val
+	}
+
+	if len(result) < 1 {
+		return nil
+	}
+	return result
+}
+
+func flattenNodePoolExtendParam(extendParam map[string]interface{}) map[string]string {
+	if len(extendParam) < 1 {
+		return nil
+	}
+
+	result := make(map[string]string, len(extendParam))
+	for key, val := range extendParam {
+		if strVal, ok := val.(string); ok {
+			result[key] = strVal
+			continue
+		}
+		result[key] = utils.JsonToString(val)
+	}
+	return result
+}
+
+func flattenNodePoolItem(nodePool interface{}) map[string]interface{} {
+	extendParam := utils.PathSearch("spec.nodeTemplate.extendParam", nodePool, make(map[string]interface{})).(map[string]interface{})
+
+	item := map[string]interface{}{
+		"id":                       utils.PathSearch("metadata.uid", nodePool, nil),
+		"name":                     utils.PathSearch("metadata.name", nodePool, nil),
+		"type":                     utils.PathSearch("spec.type", nodePool, nil),
+		"flavor_id":                utils.PathSearch("spec.nodeTemplate.flavor", nodePool, nil),
+		"availability_zone":        utils.PathSearch("spec.nodeTemplate.az", nodePool, nil),
+		"os":                       utils.PathSearch("spec.nodeTemplate.os", nodePool, nil),
+		"billing_mode":             int(utils.PathSearch("spec.nodeTemplate.billingMode", nodePool, float64(0)).(float64)),
+		"key_pair":                 utils.PathSearch("spec.nodeTemplate.login.sshKey", nodePool, nil),
+		"scall_enable":             utils.PathSearch("spec.autoscaling.enable", nodePool, nil),
+		"initial_node_count":       int(utils.PathSearch("spec.initialNodeCount", nodePool, float64(0)).(float64)),
+		"current_node_count":       int(utils.PathSearch("status.currentNode", nodePool, float64(0)).(float64)),
+		"min_node_count":           int(utils.PathSearch("spec.autoscaling.minNodeCount", nodePool, float64(0)).(float64)),
+		"max_node_count":           int(utils.PathSearch("spec.autoscaling.maxNodeCount", nodePool, float64(0)).(float64)),
+		"scale_down_cooldown_time": int(utils.PathSearch("spec.autoscaling.scaleDownCooldownTime", nodePool, float64(0)).(float64)),
+		"priority":                 int(utils.PathSearch("spec.autoscaling.priority", nodePool, float64(0)).(float64)),
+		"ecs_group_id":             utils.PathSearch("spec.nodeManagement.serverGroupReference", nodePool, nil),
+		"storage":                  flattenNodePoolStorage(utils.PathSearch("spec.nodeTemplate.storage", nodePool, nil)),
+		"security_groups":          utils.PathSearch("spec.customSecurityGroups", nodePool, make([]interface{}, 0)),
+		"tags": flattenNodePoolTags(utils.PathSearch("spec.nodeTemplate.userTags",
+			nodePool, make([]interface{}, 0)).([]interface{})),
+		"status":      utils.PathSearch("status.phase", nodePool, nil),
+		"root_volume": flattenNodePoolRootVolume(utils.PathSearch("spec.nodeTemplate.rootVolume", nodePool, nil)),
+		"data_volumes": flattenNodePoolDataVolumes(utils.PathSearch("spec.nodeTemplate.dataVolumes",
+			nodePool, make([]interface{}, 0)).([]interface{})),
+		"initialized_conditions":         utils.PathSearch("spec.nodeTemplate.initializedConditions", nodePool, make([]interface{}, 0)),
+		"label_policy_on_existing_nodes": utils.PathSearch("spec.labelPolicyOnExistingNodes", nodePool, nil),
+		"tag_policy_on_existing_nodes":   utils.PathSearch("spec.userTagsPolicyOnExistingNodes", nodePool, nil),
+		"taint_policy_on_existing_nodes": utils.PathSearch("spec.taintPolicyOnExistingNodes", nodePool, nil),
+		"hostname_config":                flattenNodePoolHostnameConfig(utils.PathSearch("spec.nodeTemplate.hostnameConfig", nodePool, nil)),
+		"enterprise_project_id":          utils.PathSearch("spec.nodeTemplate.serverEnterpriseProjectID", nodePool, nil),
+		"subnet_id":                      utils.PathSearch("spec.nodeTemplate.nodeNicSpec.primaryNic.subnetId", nodePool, nil),
+		"subnet_list":                    utils.PathSearch("spec.nodeTemplate.nodeNicSpec.primaryNic.subnetList", nodePool, make([]interface{}, 0)),
+		"extend_params":                  flattenNodePoolExtendParams(extendParam),
+		"taints": flattenNodePoolTaints(utils.PathSearch("spec.nodeTemplate.taints",
+			nodePool, make([]interface{}, 0)).([]interface{})),
+		"extension_scale_groups": flattenNodePoolExtensionScaleGroups(utils.PathSearch("spec.extensionScaleGroups",
+			nodePool, make([]interface{}, 0)).([]interface{})),
+		"period_unit":         utils.PathSearch("periodType", extendParam, nil),
+		"period":              int(utils.PathSearch("periodNum", extendParam, float64(0)).(float64)),
+		"auto_renew":          utils.PathSearch("isAutoRenew", extendParam, nil),
+		"runtime":             utils.PathSearch("spec.nodeTemplate.runtime.name", nodePool, nil),
+		"partition":           utils.PathSearch("spec.nodeTemplate.partition", nodePool, nil),
+		"pod_security_groups": utils.PathSearch("spec.podSecurityGroups[*].id", nodePool, make([]interface{}, 0)),
+		"labels":              flattenNodePoolLabels(utils.PathSearch("spec.nodeTemplate.k8sTags", nodePool, nil)),
+		"extend_param":        flattenNodePoolExtendParam(extendParam),
+		"max_pods":            int(utils.PathSearch("maxPods", extendParam, float64(0)).(float64)),
+	}
+
+	return item
+}
+
+func flattenNodePools(nodePools []interface{}) []map[string]interface{} {
+	if len(nodePools) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(nodePools))
+	for _, nodePool := range nodePools {
+		result = append(result, flattenNodePoolItem(nodePool))
+	}
+	return result
+}
+
+func dataSourceNodePoolsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("cce", region)
+	if err != nil {
+		return diag.Errorf("error creating CCE client: %s", err)
+	}
+
+	nodePools, err := listNodePools(client, d)
+	if err != nil {
+		return diag.Errorf("error querying CCE node pools: %s", err)
+	}
+
+	randUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("node_pools", flattenNodePools(nodePools)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source huaweicloud_cce_node_pools for CCE (Cloud Container Engine) to support querying node pools information. This allows users to retrieve details of multiple node pools under a specified CCE cluster via Terraform data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #5855

**Special notes for your reviewer**:
Acceptance test TestAccCCENodePoolsDataSource_basic has been added and passed.
Documentation and schema have been updated accordingly.

Unit Test Result:
<img width="1489" height="190" alt="image" src="https://github.com/user-attachments/assets/8bb93d91-1110-40fb-abae-b5abe9c0589d" />
<img width="1393" height="822" alt="image" src="https://github.com/user-attachments/assets/209839d2-7ca9-4ee4-8782-763cd9f0a767" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
feat(cce): add new data source for node pools
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccDataNodePools_basic'
...
=== RUN   TestAccDataNodePools_basic
--- PASS: TestAccDataNodePools_basic (593.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       593.346s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
