### PR TITLE
feat(dsc): ass new data source to query top 5 classifications

### DIFF
--- a/docs/data-sources/dsc_catalog_top_classifications.md
+++ b/docs/data-sources/dsc_catalog_top_classifications.md
@@ -1,0 +1,109 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_catalog_top_classifications"
+description: |-
+  Use this data source to query the top 5 classifications in the asset catalog within HuaweiCloud.
+---
+
+# huaweicloud_dsc_catalog_top_classifications
+
+Use this data source to query the top 5 classifications in the asset catalog within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "type_id" {}
+
+data "huaweicloud_dsc_catalog_top_classifications" "test" {
+  type_id = var.type_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the catalog top classifications are located.
+  If omitted, the provider-level region will be used.
+
+* `label_id` - (Optional, String) Specifies the ID of the group label.
+
+* `type_id` - (Optional, String) Specifies the ID of the data type.
+
+-> Exactly one of the `label_id` and `type_id` parameters must be specified.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `classifications` - The list of classifications.  
+  The [classifications](#catalog_top_classifications_attr) structure is documented below.
+
+<a name="catalog_top_classifications_attr"></a>
+The `classifications` block supports:
+
+* `classification_name` - The name of the classification.
+
+* `hit_number` - The number of matched records.
+
+* `column_details` - The column detail list of the classification.  
+  The [column_details](#catalog_top_classifications_column_details) structure is documented below.
+
+<a name="catalog_top_classifications_column_details"></a>
+The `column_details` block supports:
+
+* `asset_id` - The ID of the asset corresponding to the database.
+
+* `asset_name` - The name of the asset corresponding to the database.
+
+* `column_fqn` - The fully qualified name of the column.
+
+* `db_type` - The type of the database.
+
+* `match_infos` - The match information list.  
+  The [match_infos](#catalog_top_classifications_column_details_match_infos) structure is documented below.
+
+<a name="catalog_top_classifications_column_details_match_infos"></a>
+The `match_infos` block supports:
+
+* `classification_id` - The ID of the classification.
+
+* `classification_name` - The name of the classification.
+
+* `match_content_cnt` - The matched content count.
+
+* `match_rate` - The match rate (percentage).
+
+* `matched_detail` - The match detail.
+
+* `matched_examples` - The matched example list.  
+  The [matched_examples](#catalog_top_classifications_column_details_match_infos_matched_examples) structure is
+  documented below.
+
+* `rule_id` - The ID of the rule.
+
+* `rule_name` - The name of the rule.
+
+* `security_level_id` - The ID of the security level.
+
+* `security_level_name` - The name of the security level.
+
+* `security_level_color` - The color corresponding to the security level.
+
+* `template_id` - The ID of the template.
+
+* `template_name` - The name of the template.
+
+<a name="catalog_top_classifications_column_details_match_infos_matched_examples"></a>
+The `matched_examples` block supports:
+
+* `context` - The match context.
+
+* `line_number` - The line number of the match.
+
+* `matched_content` - The matched content.
+
+* `nlp_revised` - Whether it has been NLP revised.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1418,6 +1418,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_catalog_details_by_obs":           dsc.DataSourceCatalogDetailsByObs(),
 			"huaweicloud_dsc_catalog_instances":                dsc.DataSourceCatalogInstances(),
 			"huaweicloud_dsc_catalog_quantity_variation":       dsc.DataSourceDscCatalogQuantityVariation(),
+			"huaweicloud_dsc_catalog_top_classifications":      dsc.DataSourceCatalogTopClassifications(),
 			"huaweicloud_dsc_column_details_by_database":       dsc.DataSourceDscColumnDetailsByDatabase(),
 			"huaweicloud_dsc_column_details_by_classification": dsc.DataSourceDscColumnDetailsByClassification(),
 			"huaweicloud_dsc_dashboard_score":                  dsc.DataSourceDscDashboardScore(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_catalog_top_classifications_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_catalog_top_classifications_test.go
@@ -1,0 +1,52 @@
+package dsc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, ensure that sensitive data identification has been completed for specific assets
+// under the HW_DSC_TYPE_ID.
+func TestAccDataSourceCatalogTopClassifications_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_catalog_top_classifications.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscTypeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCatalogTopClassifications_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "classifications.#", regexp.MustCompile(`^[1-9]([0-9]+)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "classifications.0.classification_name"),
+					resource.TestMatchResourceAttr(dataSource, "classifications.0.hit_number", regexp.MustCompile(`^[1-9]([0-9]+)?$`)),
+					resource.TestMatchResourceAttr(dataSource, "classifications.0.column_details.#", regexp.MustCompile(`^[1-9]([0-9]+)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "classifications.0.column_details.0.asset_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "classifications.0.column_details.0.asset_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "classifications.0.column_details.0.column_fqn"),
+					resource.TestCheckResourceAttrSet(dataSource, "classifications.0.column_details.0.db_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCatalogTopClassifications_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_catalog_top_classifications" "test" {
+  type_id = "%[1]s"
+}
+`, acceptance.HW_DSC_TYPE_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_catalog_top_classifications.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_catalog_top_classifications.go
@@ -1,0 +1,360 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/metadata/catalog/classification-tops
+func DataSourceCatalogTopClassifications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCatalogTopClassificationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the catalog top classifications are located.`,
+			},
+
+			// Optional parameters.
+			"label_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"type_id"},
+				Description:  `The ID of the group label.`,
+			},
+			"type_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the data type.`,
+			},
+
+			// Attributes.
+			"classifications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"classification_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the classification.`,
+						},
+						"hit_number": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of matched records.`,
+						},
+						"column_details": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        catalogTopClassificationColumnDetails(),
+							Description: `The column detail list of the classification.`,
+						},
+					},
+				},
+				Description: `The list of classifications.`,
+			},
+		},
+	}
+}
+
+func catalogTopClassificationColumnDetails() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"asset_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the asset corresponding to the database.`,
+			},
+			"asset_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the asset corresponding to the database.`,
+			},
+			"column_fqn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The fully qualified name of the column.`,
+			},
+			"db_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the database.`,
+			},
+			"match_infos": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        catalogTopClassificationColumnDetailsMatchInfos(),
+				Description: `The match information list.`,
+			},
+		},
+	}
+}
+
+func catalogTopClassificationColumnDetailsMatchInfos() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"classification_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the classification.`,
+			},
+			"classification_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the classification.`,
+			},
+			"match_content_cnt": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The matched content count.`,
+			},
+			"match_rate": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The match rate (percentage).`,
+			},
+			"matched_detail": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The match detail.`,
+			},
+			"matched_examples": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        catalogTopClassificationMatchedExamples(),
+				Description: `The matched example list.`,
+			},
+			"rule_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the rule.`,
+			},
+			"rule_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the rule.`,
+			},
+			"security_level_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the security level.`,
+			},
+			"security_level_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the security level.`,
+			},
+			"security_level_color": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The color corresponding to the security level.`,
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the template.`,
+			},
+			"template_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the template.`,
+			},
+		},
+	}
+}
+
+func catalogTopClassificationMatchedExamples() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"context": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The match context.`,
+			},
+			"line_number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The line number of the match.`,
+			},
+			"matched_content": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The matched content.`,
+			},
+			"nlp_revised": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether it has been NLP revised.`,
+			},
+		},
+	}
+}
+
+func buildCatalogTopClassificationsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("label_id"); ok {
+		res = fmt.Sprintf("%s&label_id=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("type_id"); ok {
+		res = fmt.Sprintf("%s&type_id=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+
+	return res
+}
+
+func listCatalogTopClassifications(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v1/{project_id}/metadata/catalog/classification-tops"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildCatalogTopClassificationsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func dataSourceCatalogTopClassificationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	respBody, err := listCatalogTopClassifications(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving catalog top 5 classifications: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("classifications", flattenCatalogTopClassifications(utils.PathSearch("detection_classifications",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCatalogTopClassifications(classifications []interface{}) []interface{} {
+	if len(classifications) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(classifications))
+	for _, v := range classifications {
+		rst = append(rst, map[string]interface{}{
+			"classification_name": utils.PathSearch("classification_name", v, nil),
+			"hit_number":          utils.PathSearch("hit_number", v, nil),
+			"column_details": flattenCatalogTopClassificationColumnDetails(utils.PathSearch("column_details",
+				v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenCatalogTopClassificationColumnDetails(columns []interface{}) []interface{} {
+	if len(columns) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(columns))
+	for _, v := range columns {
+		rst = append(rst, map[string]interface{}{
+			"asset_id":   utils.PathSearch("asset_id", v, nil),
+			"asset_name": utils.PathSearch("asset_name", v, nil),
+			"column_fqn": utils.PathSearch("column_fqn", v, nil),
+			"db_type":    utils.PathSearch("db_type", v, nil),
+			"match_infos": flattenCatalogTopClassificationMatchInfos(utils.PathSearch("match_infos",
+				v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenCatalogTopClassificationMatchInfos(matchInfos []interface{}) []interface{} {
+	if len(matchInfos) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(matchInfos))
+	for _, v := range matchInfos {
+		rst = append(rst, map[string]interface{}{
+			"classification_id":   utils.PathSearch("classification_id", v, nil),
+			"classification_name": utils.PathSearch("classification_name", v, nil),
+			"match_content_cnt":   utils.PathSearch("match_content_cnt", v, nil),
+			"match_rate":          utils.PathSearch("match_rate", v, nil),
+			"matched_detail":      utils.PathSearch("matched_detail", v, nil),
+			"matched_examples": flattenCatalogTopClassificationMatchedExamples(utils.PathSearch("matched_examples",
+				v, make([]interface{}, 0)).([]interface{})),
+			"rule_id":              utils.PathSearch("rule_id", v, nil),
+			"rule_name":            utils.PathSearch("rule_name", v, nil),
+			"security_level_id":    utils.PathSearch("security_level_id", v, nil),
+			"security_level_name":  utils.PathSearch("security_level_name", v, nil),
+			"security_level_color": utils.PathSearch("security_level_color", v, nil),
+			"template_id":          utils.PathSearch("template_id", v, nil),
+			"template_name":        utils.PathSearch("template_name", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenCatalogTopClassificationMatchedExamples(examples []interface{}) []interface{} {
+	if len(examples) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(examples))
+	for _, v := range examples {
+		rst = append(rst, map[string]interface{}{
+			"context":         utils.PathSearch("context", v, nil),
+			"line_number":     utils.PathSearch("line_number", v, nil),
+			"matched_content": utils.PathSearch("matched_content", v, nil),
+			"nlp_revised":     utils.PathSearch("nlp_revised", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source to query the top 5 classification list in the asset catalog.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
huawei@wuzhuanhong-dev:/mnt/d/code/provider/terraform-provider-huaweicloud$ ./scripts/coverage.sh -o dsc -f TestAccDataSourceCatalogTopClassifications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceCatalogTopClassifications_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCatalogTopClassifications_basic
=== PAUSE TestAccDataSourceCatalogTopClassifications_basic
=== CONT  TestAccDataSourceCatalogTopClassifications_basic
--- PASS: TestAccDataSourceCatalogTopClassifications_basic (11.18s)
PASS
coverage: 7.7% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       11.434s coverage: 7.7% of statements in ./huaweicloud/services/dsc
```
<img width="1040" height="38" alt="image" src="https://github.com/user-attachments/assets/848249e5-6652-42e2-8aea-eb85b8db8510" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
