### PR TITLE
feat(gaussdb): gaussdb authorizing users to download backups

### DIFF
--- a/docs/resources/gaussdb_download_backups_authorize.md
+++ b/docs/resources/gaussdb_download_backups_authorize.md
@@ -1,0 +1,44 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_download_backups_authorize"
+description: |-
+  Manages a GaussDB to download GaussDB backups within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_download_backups_authorize
+
+Manages a GaussDB to download GaussDB backups within HuaweiCloud.
+
+-> This resource is a one-time action resource for authorizing users to download backups. Deleting this resource will
+   not revoke the authorization, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "backup_id" {}
+
+resource "huaweicloud_gaussdb_download_backups_authorize" "test" {
+  backup_id = var.backup_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+
+* `backup_id` - (Required, String, ForceNew) Specifies the backup ID, which uniquely identifies a backup.
+  The value must be in UUID format, exactly 36 characters long, and contain only letters and digits.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `bucket` - The name of the bucket where the file is stored.
+
+* `file_paths` - The paths from which backups can be downloaded using OBS Browser+.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4055,6 +4055,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_quota":                             gaussdb.ResourceGaussDbQuota(),
 			"huaweicloud_gaussdb_sql_throttling_task":               gaussdb.ResourceGaussDbSqlThrottlingTask(),
 			"huaweicloud_gaussdb_asp_collect":                       gaussdb.ResourceGaussDbAspCollect(),
+			"huaweicloud_gaussdb_download_backups_authorize":        gaussdb.ResourceGaussDBDownloadBackupsAuthorize(),
 			"huaweicloud_gaussdb_wdr_snapshot":                      gaussdb.ResourceGaussDbWdrSnapshot(),
 			"huaweicloud_gaussdb_wdr_snapshot_collect":              gaussdb.ResourceGaussDbWdrSnapshotCollect(),
 			"huaweicloud_gaussdb_dr_configuration_reset":            gaussdb.ResourceGaussDbDrConfigurationReset(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -297,6 +297,7 @@ var (
 	HW_GAUSSDB_HBA_HISTORY_ID        = os.Getenv("HW_GAUSSDB_HBA_HISTORY_ID")
 	HW_GAUSSDB_SQL_ID                = os.Getenv("HW_GAUSSDB_SQL_ID")
 	HW_GAUSSDB_SESSION_ID            = os.Getenv("HW_GAUSSDB_SESSION_ID")
+	HW_GAUSSDB_BACKUP_ID             = os.Getenv("HW_GAUSSDB_BACKUP_ID")
 
 	HW_VOD_WATERMARK_FILE   = os.Getenv("HW_VOD_WATERMARK_FILE")
 	HW_VOD_MEDIA_ASSET_FILE = os.Getenv("HW_VOD_MEDIA_ASSET_FILE")
@@ -2448,6 +2449,13 @@ func TestAccPreCheckGaussDBSqlId(t *testing.T) {
 func TestAccPreCheckGaussDBSessionId(t *testing.T) {
 	if HW_GAUSSDB_SESSION_ID == "" {
 		t.Skip("HW_GAUSSDB_SESSION_ID must be set for GaussDB acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGaussDBBackupId(t *testing.T) {
+	if HW_GAUSSDB_BACKUP_ID == "" {
+		t.Skip("HW_GAUSSDB_BACKUP_ID must be set for GaussDB acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_download_backups_authorize_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_download_backups_authorize_test.go
@@ -1,0 +1,41 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGaussDBDownloadBackupsAuthorize_basic(t *testing.T) {
+	resourceName := "huaweicloud_gaussdb_download_backups_authorize.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBBackupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBDownloadBackupsAuthorize_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "bucket"),
+					resource.TestCheckResourceAttrSet(resourceName, "file_paths.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGaussDBDownloadBackupsAuthorize_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_download_backups_authorize" "test" {
+  backup_id = "%s"
+}
+`, acceptance.HW_GAUSSDB_BACKUP_ID)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_download_backups_authorize.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_download_backups_authorize.go
@@ -1,0 +1,128 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var geminiDBDownloadBackupsAuthorizeParams = []string{
+	"backup_id",
+}
+
+// @API GaussDB POST /v3/{project_id}/backups/{backup_id}/download/authorization
+func ResourceGaussDBDownloadBackupsAuthorize() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussDBDownloadBackupsAuthorizeCreate,
+		ReadContext:   resourceGaussDBDownloadBackupsAuthorizeRead,
+		UpdateContext: resourceGaussDBDownloadBackupsAuthorizeUpdate,
+		DeleteContext: resourceGaussDBDownloadBackupsAuthorizeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(geminiDBDownloadBackupsAuthorizeParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"backup_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bucket": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_paths": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceGaussDBDownloadBackupsAuthorizeCreate(_ context.Context, d *schema.ResourceData,
+	meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/backups/{backup_id}/download/authorization"
+		product = "opengauss"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	backupID := d.Get("backup_id").(string)
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{backup_id}", backupID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error authorizing to download GaussDB backup (%s): %s", backupID, err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(backupID)
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("bucket", utils.PathSearch("bucket", createRespBody, nil)),
+		d.Set("file_paths", utils.PathSearch("file_paths", createRespBody, make([]interface{}, 0))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceGaussDBDownloadBackupsAuthorizeUpdate(_ context.Context, _ *schema.ResourceData,
+	_ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGaussDBDownloadBackupsAuthorizeRead(_ context.Context, _ *schema.ResourceData,
+	_ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGaussDBDownloadBackupsAuthorizeDelete(_ context.Context, _ *schema.ResourceData,
+	_ interface{}) diag.Diagnostics {
+	errorMsg := "This resource is a one-time action resource for authorizing users to download backups. " +
+		"Deleting this resource will not revoke the authorization, but will only remove the resource " +
+		"information from the tfstate file."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Resource deletion is not supported",
+			Detail:   errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
gaussdb authorizing users to download backups
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
gaussdb authorizing users to download backups
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBAuthorizationDownloadBackups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBAuthorizationDownloadBackups_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBAuthorizationDownloadBackups_basic
=== PAUSE TestAccGaussDBAuthorizationDownloadBackups_basic
=== CONT  TestAccGaussDBAuthorizationDownloadBackups_basic
--- PASS: TestAccGaussDBAuthorizationDownloadBackups_basic (20.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   22.203s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
