### PR TITLE
docs(fgs): fix contradictory code_type guidance for SWR images in function resource's doc

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -413,7 +413,7 @@ The following arguments are supported:
 
 * `handler` - (Required, String) Specifies the entry point of the function.
 
--> If the function is created by an SWR image, keep `code_type` empty and use hyphen character (-) to set the handler.
+-> If the function is created by an SWR image, set `code_type` to **Custom-Image-Swr** and use the hyphen character (-) to set the handler.
 
 * `description` - (Optional, String) Specifies the description of the function.
 

--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -413,7 +413,8 @@ The following arguments are supported:
 
 * `handler` - (Required, String) Specifies the entry point of the function.
 
--> If the function is created by an SWR image, set `code_type` to **Custom-Image-Swr** and use the hyphen character (-) to set the handler.
+-> If the function is created by an SWR image, set `code_type` to **Custom-Image-Swr** and use the hyphen character (-)
+   to set the handler.
 
 * `description` - (Optional, String) Specifies the description of the function.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

An incorrect document misled the user, causing an error to occur after the script ran. Therefore, the document needs to be corrected.
```
ReferenceTransformer: "huaweicloud_fgs_function.create_by_swr_image" references: []
2025-01-10T11:49:10.940+0800 [DEBUG] refresh: huaweicloud_fgs_function.create_by_swr_image: no state, so not refreshing
2025-01-10T11:49:10.942+0800 [ERROR] provider.terraform-provider-huaweicloud_v1.70.0: Response contains error diagnostic: diagnostic_detail=""custom_image": conflicts with code_type" diagnostic_severity=ERROR tf_provider_addr=provider tf_req_id=b5173a5f-7334-e9c6-ca60-9bf55c3640e3 tf_resource_type=huaweicloud_fgs_function diagnostic_attribute="AttributeName("custom_image")" diagnostic_summary="Conflicting configuration arguments" tf_rpc=ValidateResourceTypeConfig @caller=github.com/hashicorp/terraform-plugin-go@v0.14.0/tfprotov5/internal/diag/diagnostics.go:55 @module=sdk.proto tf_proto_version=5.3 timestamp="2025-01-10T11:49:10.942+0800"
2025-01-10T11:49:10.943+0800 [ERROR] vertex "huaweicloud_fgs_function.create_by_swr_image" error: Conflicting configuration arguments
2025-01-10T11:49:10.943+0800 [ERROR] vertex "huaweicloud_fgs_function.create_by_swr_image (expand)" error: Conflicting configuration arguments
2025-01-10T11:49:10.943+0800 [WARN] Planning encountered errors, so plan is not applyable
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #9801 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix contradictory code_type guidance for SWR images in function resource's doc
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
