### PR TITLE
feat(dsc): add data source to dsc dbss ins info

### DIFF
--- a/docs/data-sources/dsc_dbss_ins_info.md
+++ b/docs/data-sources/dsc_dbss_ins_info.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_dbss_ins_info"
+description: |-
+  Use this data source to get the DBSS instance information within HuaweiCloud.
+---
+
+# huaweicloud_dsc_dbss_ins_info
+
+Use this data source to get the DBSS instance information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_dbss_ins_info" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `dbss_instance_info_list` - The list of DBSS audit instance information.
+
+  The [dbss_instance_info_list](#dbss_instance_info_list_struct) structure is documented below.
+
+* `dbss_rds_database_list` - The list of RDS database information.
+
+  The [dbss_rds_database_list](#dbss_rds_database_list_struct) structure is documented below.
+
+<a name="dbss_instance_info_list_struct"></a>
+The `dbss_instance_info_list` block supports:
+
+* `instance_id` - The DBSS instance ID.
+
+* `instance_name` - The DBSS instance name.
+
+<a name="dbss_rds_database_list_struct"></a>
+The `dbss_rds_database_list` block supports:
+
+* `configured` - Whether the RDS database is configured.
+
+* `db_name` - The database name.
+
+* `id` - The database ID.
+
+* `type` - The database type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1425,6 +1425,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_data_map_dynamic_data_infos":      dsc.DataSourceDataMapDynamicDataInfos(),
 			"huaweicloud_dsc_data_map_score":                   dsc.DataSourceDscDataMapScore(),
 			"huaweicloud_dsc_data_map_security_level":          dsc.DataSourceDscDataMapSecurityLevel(),
+			"huaweicloud_dsc_dbss_ins_info":                    dsc.DataSourceDscDbssInsInfo(),
 			"huaweicloud_dsc_devices":                          dsc.DataSourceDscDevices(),
 			"huaweicloud_dsc_device_monitor_infos":             dsc.DataSourceDscDeviceMonitorInfos(),
 			"huaweicloud_dsc_event_overview":                   dsc.DataSourceDscEventOverview(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_dbss_ins_info_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_dbss_ins_info_test.go
@@ -1,0 +1,37 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscDbssInsInfo_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_dbss_ins_info.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDscDbssInsInfo_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "dbss_instance_info_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "dbss_rds_database_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceDscDbssInsInfo_basic = `
+data "huaweicloud_dsc_dbss_ins_info" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_dbss_ins_info.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_dbss_ins_info.go
@@ -1,0 +1,159 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/security-policies/dbss-info
+func DataSourceDscDbssInsInfo() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscDbssInsInfoRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"dbss_instance_info_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dbssInstanceInfoSchema(),
+			},
+			"dbss_rds_database_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     rdsDatabaseSchema(),
+			},
+		},
+	}
+}
+
+func dbssInstanceInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func rdsDatabaseSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"configured": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDscDbssInsInfoRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/security-policies/dbss-info"
+		product = "dsc"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC DBSS instance info: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("dbss_instance_info_list", flattenDbssInstanceInfoList(
+			utils.PathSearch("dbss_instance_info_list", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("dbss_rds_database_list", flattenRdsDatabaseList(
+			utils.PathSearch("dbss_rds_database_list", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDbssInstanceInfoList(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"instance_id":   utils.PathSearch("instance_id", v, nil),
+			"instance_name": utils.PathSearch("instance_name", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenRdsDatabaseList(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"configured": utils.PathSearch("configured", v, nil),
+			"db_name":    utils.PathSearch("db_name", v, nil),
+			"id":         utils.PathSearch("id", v, nil),
+			"type":       utils.PathSearch("type", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to dsc dbss ins info
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to dsc dbss ins info
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscDbssInsInfo_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscDbssInsInfo_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscDbssInsInfo_basic
=== PAUSE TestAccDataSourceDscDbssInsInfo_basic
=== CONT  TestAccDataSourceDscDbssInsInfo_basic
--- PASS: TestAccDataSourceDscDbssInsInfo_basic (40.24s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       40.375s coverage: 6.6% of statements in ./huaweicloud/services/dsc
```
<img width="976" height="45" alt="image" src="https://github.com/user-attachments/assets/5e37f789-70f4-423f-a1a7-4eadf7252056" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
