### PR TITLE
feat(TaurusDB): HTAP instance support setting query queue rule

### DIFF
--- a/docs/resources/taurusdb_htap_starrocks_instance.md
+++ b/docs/resources/taurusdb_htap_starrocks_instance.md
@@ -232,6 +232,9 @@ The following arguments are supported:
 * `open_slow_log_switch` - (Optional, String) Specifies whether to enable the slow query log original text switch.
   Valid values are **true** and **false**.
 
+* `query_queue_rule` - (Optional, List) Specifies the query queue rule configuration.
+  The [query_queue_rule](#query_queue_rule_block) structure is documented below.
+
 * `be_parameter_values` - (Optional, Map) Specifies a map contains mappings of parameter name and value to modify.
   The parameter name must be based on the default parameter template of the backend nodes.
 
@@ -287,6 +290,27 @@ The `sys_tags` block supports:
   The key **_sys_enterprise_project_id** must be set to specify the enterprise project ID.
 
 * `value` - (Required, String, NoneUpdatable) Specifies the tag value.
+
+<a name="query_queue_rule_block"></a>
+The `query_queue_rule` block supports:
+
+* `query_queue_max_queued_queries` - (Required, Int) Specifies the maximum number of queued queries.
+  The value ranges from **1** to **10,000**.
+
+* `query_queue_pending_timeout_second` - (Required, Int) Specifies the pending timeout in seconds for queued queries.
+  The value ranges from **1** to **259,200**.
+
+* `query_queue_concurrency_limit` - (Required, Int) Specifies the concurrency limit for the query queue.
+  The value ranges from **0** to **100**. The value **0** indicates no limit.
+
+* `query_queue_mem_used_pct_limit` - (Required, Int) Specifies the memory usage percentage limit for the query queue.
+  The value ranges from **0** to **100**. The value **0** indicates no limit.
+
+* `query_queue_cpu_used_pct_limit` - (Required, Int) Specifies the CPU usage percentage limit for the query queue.
+  The value ranges from **0** to **100**. The value **0** indicates no limit.
+
+* `enable_query_queue_select` - (Required, String) Specifies whether to enable the query queue for SELECT statements.
+  Valid values are **true** and **false**.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_test.go
@@ -168,6 +168,13 @@ func TestAccTaurusDBHtapStarrocksInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.type"),
 					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.description"),
 					resource.TestCheckResourceAttr(resourceName, "open_slow_log_switch", "true"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_max_queued_queries", "10240"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_pending_timeout_second", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_concurrency_limit", "100"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_mem_used_pct_limit", "100"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_cpu_used_pct_limit", "100"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.enable_query_queue_select", "true"),
 				),
 			},
 			{
@@ -180,6 +187,13 @@ func TestAccTaurusDBHtapStarrocksInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "groups.0.nodes.0.need_restart", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enable_users_sync", "false"),
 					resource.TestCheckResourceAttr(resourceName, "open_slow_log_switch", "false"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_max_queued_queries", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_pending_timeout_second", "300"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_concurrency_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_mem_used_pct_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.query_queue_cpu_used_pct_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query_queue_rule.0.enable_query_queue_select", "false"),
 				),
 			},
 			{
@@ -555,6 +569,15 @@ resource "huaweicloud_taurusdb_htap_starrocks_instance" "test" {
   }
   
   open_slow_log_switch = "true"
+
+  query_queue_rule {
+    query_queue_max_queued_queries     = 10240
+    query_queue_pending_timeout_second = 3000
+    query_queue_concurrency_limit      = 100
+    query_queue_mem_used_pct_limit     = 100
+    query_queue_cpu_used_pct_limit     = 100
+    enable_query_queue_select          = "true"
+  }
 }
 `, testAccHtapInstanceConfig_base(rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
@@ -613,6 +636,15 @@ resource "huaweicloud_taurusdb_htap_starrocks_instance" "test" {
   }
   
   open_slow_log_switch = "false"
+
+  query_queue_rule {
+    query_queue_max_queued_queries     = 1024
+    query_queue_pending_timeout_second = 300
+    query_queue_concurrency_limit      = 0
+    query_queue_mem_used_pct_limit     = 0
+    query_queue_cpu_used_pct_limit     = 0
+    enable_query_queue_select          = "false"
+  }
 }
 `, testAccHtapInstanceConfig_base(rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance.go
@@ -133,6 +133,41 @@ var htapStarrocksInstanceSchema = map[string]*schema.Schema{
 		Computed:     true,
 		ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
 	},
+	"query_queue_rule": {
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"query_queue_max_queued_queries": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"query_queue_pending_timeout_second": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"query_queue_concurrency_limit": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"query_queue_mem_used_pct_limit": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"query_queue_cpu_used_pct_limit": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"enable_query_queue_select": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				},
+			},
+		},
+	},
 	"be_parameter_values": {
 		Type:     schema.TypeMap,
 		Optional: true,
@@ -378,6 +413,9 @@ var htapStarrocksInstanceSchema = map[string]*schema.Schema{
 // @API TaurusDB POST /v3/{project_id}/instances/{instance_id}/starrocks/users/sync
 // @API TaurusDB PUT /v3/{project_id}/instances/{instance_id}/starrocks/slowlog-sensitive
 // @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/starrocks/slowlog-sensitive
+// @API TaurusDB PUT /v3/{project_id}/instances/{instance_id}/query-queue/rules
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/query-queue/rules
+// @API TaurusDB POST /v3/{project_id}/instances/{instance_id}/htap/query-queue/switch
 // @API TaurusDB GET /v3/{project_id}/jobs
 func ResourceTaurusDBHtapStarrocksInstance() *schema.Resource {
 	return &schema.Resource{
@@ -923,6 +961,17 @@ func resourceTaurusDBHtapStarrocksInstanceCreate(ctx context.Context, d *schema.
 		}
 	}
 
+	// Update query queue rule and switch
+	enableQueryQueueRule := d.Get("query_queue_rule.0.enable_query_queue_select").(string)
+	if enableQueryQueueRule == "true" {
+		if err := updateHtapQueryQueueRuleSwitch(client, d, enableQueryQueueRule); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := updateHtapQueryQueueRule(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceTaurusDBHtapStarrocksInstanceRead(ctx, d, meta)
 }
 
@@ -1126,6 +1175,108 @@ func getStarRocksSlowLogSwitch(client *golangsdk.ServiceClient, htapInstanceId s
 
 	enabled := utils.PathSearch("open_slow_log_switch", respBody, "").(string)
 	return enabled, nil
+}
+
+func updateHtapQueryQueueRule(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var httpUrl = "v3/{project_id}/instances/{instance_id}/query-queue/rules"
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Id())
+
+	ruleRaw := d.Get("query_queue_rule").([]interface{})
+	ruleMap := ruleRaw[0].(map[string]interface{})
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"query_queue_rule": map[string]interface{}{
+				"query_queue_max_queued_queries":     ruleMap["query_queue_max_queued_queries"],
+				"query_queue_pending_timeout_second": ruleMap["query_queue_pending_timeout_second"],
+				"query_queue_concurrency_limit":      ruleMap["query_queue_concurrency_limit"],
+				"query_queue_mem_used_pct_limit":     ruleMap["query_queue_mem_used_pct_limit"],
+				"query_queue_cpu_used_pct_limit":     ruleMap["query_queue_cpu_used_pct_limit"],
+			},
+		},
+	}
+
+	resp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating query queue rule of HTAP StarRocks instance(%s): %s", d.Id(), err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	status := utils.PathSearch("status", respBody, "").(string)
+	if status != "success" {
+		msg := utils.PathSearch("msg", respBody, "").(string)
+		return fmt.Errorf("error updating query queue rule of HTAP StarRocks instance(%s): status=%s, msg=%s", d.Id(), status, msg)
+	}
+
+	return nil
+}
+
+func updateHtapQueryQueueRuleSwitch(client *golangsdk.ServiceClient, d *schema.ResourceData, enableSwitch string) error {
+	var httpUrl = "v3/{project_id}/instances/{instance_id}/htap/query-queue/switch"
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"enable_query_queue_select": enableSwitch,
+		},
+	}
+
+	resp, err := client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating query queue switch of HTAP StarRocks instance(%s): %s", d.Id(), err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	status := utils.PathSearch("status", respBody, "").(string)
+	if status != "success" {
+		msg := utils.PathSearch("msg", respBody, "").(string)
+		return fmt.Errorf("error updating query queue switch of HTAP StarRocks instance(%s): status=%s, msg=%s", d.Id(), status, msg)
+	}
+
+	return nil
+}
+
+func getHtapQueryQueueRule(client *golangsdk.ServiceClient, htapInstanceId string) (interface{}, error) {
+	var httpUrl = "v3/{project_id}/instances/{instance_id}/query-queue/rules"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", htapInstanceId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error querying query queue rule of HTAP StarRocks instance(%s): %s", htapInstanceId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("query_queue_rule", respBody, nil), nil
 }
 
 func modifyStarrocksParameters(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
@@ -1347,7 +1498,6 @@ func resourceTaurusDBHtapStarrocksInstanceRead(_ context.Context, d *schema.Reso
 			}
 		}
 	}
-
 	// Set configurations and parameters of be nodes
 	beConfiguration, beParameterValues, err := getStarrocksParameters(client, htapInstanceId, "be")
 	if err != nil {
@@ -1371,6 +1521,9 @@ func resourceTaurusDBHtapStarrocksInstanceRead(_ context.Context, d *schema.Reso
 	// set slow log switch
 	mErr = multierror.Append(mErr, setOpenSlowLogSwitch(d, client, htapInstanceId))
 
+	// Set query queue rule
+	mErr = multierror.Append(mErr, setQueryQueueRule(d, client, htapInstanceId))
+
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
@@ -1381,6 +1534,32 @@ func setOpenSlowLogSwitch(d *schema.ResourceData, client *golangsdk.ServiceClien
 		return nil
 	}
 	return d.Set("open_slow_log_switch", slowLogSwitch)
+}
+
+func setQueryQueueRule(d *schema.ResourceData, client *golangsdk.ServiceClient, htapInstanceId string) error {
+	// Get query queue rule
+	queryQueueRule, err := getHtapQueryQueueRule(client, htapInstanceId)
+
+	if err != nil {
+		log.Printf("[WARN] query HTAP instance %s open slow log switch failed: %s", htapInstanceId, err)
+		return nil
+	}
+	return d.Set("query_queue_rule", flattenQueryQueueRule(queryQueueRule))
+}
+
+func flattenQueryQueueRule(rule interface{}) []interface{} {
+	if rule == nil {
+		return []interface{}{}
+	}
+	result := map[string]interface{}{
+		"query_queue_max_queued_queries":     int(utils.PathSearch("query_queue_max_queued_queries", rule, float64(0)).(float64)),
+		"query_queue_pending_timeout_second": int(utils.PathSearch("query_queue_pending_timeout_second", rule, float64(0)).(float64)),
+		"query_queue_concurrency_limit":      int(utils.PathSearch("query_queue_concurrency_limit", rule, float64(0)).(float64)),
+		"query_queue_mem_used_pct_limit":     int(utils.PathSearch("query_queue_mem_used_pct_limit", rule, float64(0)).(float64)),
+		"query_queue_cpu_used_pct_limit":     int(utils.PathSearch("query_queue_cpu_used_pct_limit", rule, float64(0)).(float64)),
+		"enable_query_queue_select":          utils.PathSearch("enable_query_queue_select", rule, "false").(string),
+	}
+	return []interface{}{result}
 }
 
 func flattenStarrocksInstanceActions(instance interface{}) []interface{} {
@@ -1799,6 +1978,20 @@ func resourceTaurusDBHtapStarrocksInstanceUpdate(ctx context.Context, d *schema.
 	// Update slow log switch
 	if d.HasChange("open_slow_log_switch") {
 		if err := updateStarRocksSlowLogSwitch(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Update query queue rule
+	if d.HasChange("query_queue_rule") {
+		// Update query queue switch if enable_query_queue_select changed
+		if d.HasChange("query_queue_rule.0.enable_query_queue_select") {
+			enableSwitch := d.Get("query_queue_rule.0.enable_query_queue_select").(string)
+			if err := updateHtapQueryQueueRuleSwitch(client, d, enableSwitch); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+		if err := updateHtapQueryQueueRule(client, d); err != nil {
 			return diag.FromErr(err)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
HTAP instance support setting query queue rule
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
HTAP instance support setting query queue rule
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBHtapStarrocksInstance_basic'
=== RUN   TestAccTaurusDBHtapStarrocksInstance_basic
=== PAUSE TestAccTaurusDBHtapStarrocksInstance_basic
=== CONT  TestAccTaurusDBHtapStarrocksInstance_basic
--- PASS: TestAccTaurusDBHtapStarrocksInstance_basic (2276.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 2276.088s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
