### PR TITLE
chore(GaussDB): use the new API to replace the original API

### DIFF
--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance.go
@@ -64,7 +64,7 @@ var openGaussInstanceNonUpdatableParams = []string{"availability_zone", "vpc_id"
 // @API GaussDB POST /v3/{project_id}/instances/{instance_id}/action
 // @API GaussDB DELETE /v3/{project_id}/instances/{instance_id}/sharding
 // @API GaussDB DELETE /v3/{project_id}/instances/{instance_id}/coordinators
-// @API GaussDB PUT /v3/{project_id}/instances/{instance_id}/backups/policy
+// @API GaussDB PUT /v3.1/{project_id}/instances/{instance_id}/backups/policy
 // @API GaussDB PUT /v3/{project_id}/instance/{instance_id}/flavor
 // @API GaussDB PUT /v3/{project_id}/configurations/{config_id}/apply
 // @API GaussDB POST /v3/{project_id}/instances/{instance_id}/mysql-compatibility
@@ -1820,7 +1820,7 @@ func updateInstanceVolumeAndRelatedHaNumbers(ctx context.Context, client, bssCli
 
 func updateInstanceBackupStrategy(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
 	_, err := updateGaussDbInstanceField(ctx, d, client, updateInstanceFieldParams{
-		httpUrl:          "v3/{project_id}/instances/{instance_id}/backups/policy",
+		httpUrl:          "v3.1/{project_id}/instances/{instance_id}/backups/policy",
 		httpMethod:       "PUT",
 		pathParams:       map[string]string{"instance_id": d.Id()},
 		updateBodyParams: utils.RemoveNil(buildUpdateInstanceBackupStrategyBodyParams(d)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Use the new API to replace the original API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Replace the setting auto backup policy API(V3→V3.1)
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDbInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDbInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDbInstance_basic
=== PAUSE TestAccGaussDbInstance_basic
=== CONT  TestAccGaussDbInstance_basic
--- PASS: TestAccGaussDbInstance_basic (3470.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   3470.450s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
