### PR TITLE
feat(dsc): add data source to dsc bigdata assets

### DIFF
--- a/docs/data-sources/dsc_bigdata_assets.md
+++ b/docs/data-sources/dsc_bigdata_assets.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_bigdata_assets"
+description: |-
+  Use this data source to get the list of DSC bigdata assets within HuaweiCloud.
+---
+
+# huaweicloud_dsc_bigdata_assets
+
+Use this data source to get the list of DSC bigdata assets within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_bigdata_assets" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the bigdata asset type. Valid values are **Elasticsearch**,
+  **DLI**,**Hive**, **HBase**, **MRS_HIVE**, **ALL**, **LTS**,**HIVE_ONLY** and **JUST_BIG_DATA**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `assets` - The bigdata asset information list.
+
+  The [assets](#assets_struct) structure is documented below.
+
+<a name="assets_struct"></a>
+The `assets` block supports:
+
+* `asset_name` - The asset name.
+
+* `authorize_fail_reason` - The authorization failure reason.
+
+* `authorized` - Whether the asset is authorized.
+
+* `create_time` - The creation timestamp of the asset.
+
+* `default` - Whether the asset is default.
+
+* `ds_address` - The data source address.
+
+* `ds_authorized` - The data source authorization status.
+
+* `ds_name` - The data source name.
+
+* `ds_port` - The data source port.
+
+* `ds_type` - The data source type.
+
+* `ds_user` - The data source username.
+
+* `ds_version` - The data source version.
+
+* `id` - The asset ID.
+
+* `ins_id` - The instance ID.
+
+* `ins_name` - The instance name.
+
+* `ins_type` - The instance type.
+
+* `region` - The region information.
+
+* `security_group_id` - The security group ID.
+
+* `source_type` - The asset source type.
+
+* `subnet_id` - The subnet ID.
+
+* `vpc_id` - The VPC ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1416,6 +1416,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_asset_overview":                   dsc.DataSourceDscAssetOverview(),
 			"huaweicloud_dsc_assets_count":                     dsc.DataSourceDscAssetsCount(),
 			"huaweicloud_dsc_asset_quota":                      dsc.DataSourceDscAssetQuota(),
+			"huaweicloud_dsc_bigdata_assets":                   dsc.DataSourceDscBigdataAssets(),
 			"huaweicloud_dsc_catalog_statistics":               dsc.DataSourceCatalogStatistics(),
 			"huaweicloud_dsc_catalog_details_by_obs":           dsc.DataSourceCatalogDetailsByObs(),
 			"huaweicloud_dsc_catalog_instances":                dsc.DataSourceCatalogInstances(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_bigdata_assets_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_bigdata_assets_test.go
@@ -1,0 +1,52 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscBigdataAssets_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_bigdata_assets.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDscBigdataAssets_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.asset_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.authorized"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.default"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ds_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ds_authorized"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ds_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ds_port"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ds_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ds_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ins_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ins_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.ins_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.region"),
+					resource.TestCheckResourceAttrSet(dataSource, "assets.0.source_type"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceDscBigdataAssets_basic = `
+data "huaweicloud_dsc_bigdata_assets" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_bigdata_assets.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_bigdata_assets.go
@@ -1,0 +1,220 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/sdg/asset/bigdata
+func DataSourceDscBigdataAssets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscBigdataAssetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"assets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     bigdataAssetSchema(),
+			},
+		},
+	}
+}
+
+func bigdataAssetSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"asset_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"authorize_fail_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"authorized": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ds_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ds_authorized": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ds_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ds_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"ds_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ds_user": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ds_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ins_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ins_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ins_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDscBigdataAssetsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+	if v, ok := d.GetOk("type"); ok {
+		queryParams = fmt.Sprintf("?type=%v", v)
+	}
+	return queryParams
+}
+
+func dataSourceDscBigdataAssetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sdg/asset/bigdata"
+		product = "dsc"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildDscBigdataAssetsQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC bigdata assets: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("assets", flattenBigdataAssets(
+			utils.PathSearch("datasources", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBigdataAssets(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"asset_name":            utils.PathSearch("asset_name", v, nil),
+			"authorize_fail_reason": utils.PathSearch("authorize_fail_reason", v, nil),
+			"authorized":            utils.PathSearch("authorized", v, nil),
+			"create_time":           utils.PathSearch("create_time", v, nil),
+			"default":               utils.PathSearch("default", v, nil),
+			"ds_address":            utils.PathSearch("ds_address", v, nil),
+			"ds_authorized":         utils.PathSearch("ds_authorized", v, nil),
+			"ds_name":               utils.PathSearch("ds_name", v, nil),
+			"ds_port":               utils.PathSearch("ds_port", v, nil),
+			"ds_type":               utils.PathSearch("ds_type", v, nil),
+			"ds_user":               utils.PathSearch("ds_user", v, nil),
+			"ds_version":            utils.PathSearch("ds_version", v, nil),
+			"id":                    utils.PathSearch("id", v, nil),
+			"ins_id":                utils.PathSearch("ins_id", v, nil),
+			"ins_name":              utils.PathSearch("ins_name", v, nil),
+			"ins_type":              utils.PathSearch("ins_type", v, nil),
+			"region":                utils.PathSearch("region", v, nil),
+			"security_group_id":     utils.PathSearch("security_group_id", v, nil),
+			"source_type":           utils.PathSearch("source_type", v, nil),
+			"subnet_id":             utils.PathSearch("subnet_id", v, nil),
+			"vpc_id":                utils.PathSearch("vpc_id", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to dsc bigdata assets
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to dsc bigdata assets
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscBigdataAssets_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscBigdataAssets_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscBigdataAssets_basic
=== PAUSE TestAccDataSourceDscBigdataAssets_basic
=== CONT  TestAccDataSourceDscBigdataAssets_basic
--- PASS: TestAccDataSourceDscBigdataAssets_basic (33.77s)
PASS
coverage: 6.7% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       33.911s coverage: 6.7% of statements in ./huaweicloud/services/dsc
```
<img width="992" height="31" alt="image" src="https://github.com/user-attachments/assets/2d230c0a-0f8b-4919-b652-14518d74d027" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
