### PR TITLE
feat(dsc): add a new resource to manage classification under template

### DIFF
--- a/docs/resources/dsc_scan_template_classification.md
+++ b/docs/resources/dsc_scan_template_classification.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_scan_template_classification"
+description: |-
+  Manages a DSC scan template classification resource within HuaweiCloud.
+---
+
+# huaweicloud_dsc_scan_template_classification
+
+Manages a DSC scan template classification resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a parent classification
+
+```hcl
+variable "template_id" {}
+variable "classification_name" {}
+
+resource "huaweicloud_dsc_scan_template_classification" "test" {
+  template_id         = var.template_id
+  classification_name = var.classification_name
+}
+```
+
+### Create a classification under the specified parent classification
+
+```hcl
+variable "template_id" {}
+variable "classification_name" {}
+variable "parent_id" {}
+
+resource "huaweicloud_dsc_scan_template_classification" "test" {
+  template_id         = var.template_id
+  classification_name = var.classification_name
+  parent_id           = var.parent_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the scan template classification is located.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `template_id` - (Required, String, NonUpdatable) Specifies the ID of the scan template.
+
+* `classification_name` - (Required, String) Specifies the name of the classification.  
+  Only Chinese characters, letters, digits, underscores (_) and hyphens (-) are allowed, and it must start with
+  a Chinese character and letter.
+
+* `parent_id` - (Optional, String, NonUpdatable) Specifies the parent classification ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `depth` - The depth of the classification.
+
+* `root_id` - The ID of the root to which the classification belongs.
+
+* `create_time` - The time when the classification is created, in RFC3339 format.
+
+* `update_time` - The latest update time of the classification, in RFC3339 format.
+
+## Import
+
+The resource can be imported using the `template_id` and `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_dsc_scan_template_classification.test <template_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5026,6 +5026,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_instance":                       dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_multi_enable_trusted_service":   dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_scan_template":                  dsc.ResourceScanTemplate(),
+			"huaweicloud_dsc_scan_template_classification":   dsc.ResourceScanTemplateClassification(),
 			"huaweicloud_dsc_stop_scan_job":                  dsc.ResourceStopScanJob(),
 			"huaweicloud_dsc_switch_job":                     dsc.ResourceDscSwitchJob(),
 			"huaweicloud_dsc_update_security_levels_sort":    dsc.ResourceDscUpdateSecurityLevelsSort(),

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_scan_template_classification_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_scan_template_classification_test.go
@@ -1,0 +1,151 @@
+package dsc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dsc"
+)
+
+func getScanTemplateClassificationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dsc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DSC client: %s", err)
+	}
+
+	return dsc.GetScanTemplateClassificationById(client, state.Primary.Attributes["template_id"], state.Primary.ID)
+}
+
+// Before this test, please ensure that the DSC instance has been created.
+func TestAccResourceScanTemplateClassification_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dsc_scan_template_classification.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getScanTemplateClassificationResourceFunc)
+
+		rNameWithChild = "huaweicloud_dsc_scan_template_classification.test2"
+		rcWithChild    = acceptance.InitResourceCheck(rNameWithChild, &obj, getScanTemplateClassificationResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDscInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rcWithChild.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceScanTemplateClassification_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "classification_name", name),
+					resource.TestCheckResourceAttrSet(rName, "template_id"),
+					resource.TestCheckResourceAttr(rName, "depth", "1"),
+					resource.TestMatchResourceAttr(rName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					rcWithChild.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rNameWithChild, "parent_id", rName, "id"),
+					resource.TestCheckResourceAttr(rNameWithChild, "depth", "2"),
+				),
+			},
+			{
+				Config: testAccResourceScanTemplateClassification_basic_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "classification_name", updateName),
+					resource.TestCheckResourceAttrSet(rName, "template_id"),
+					rcWithChild.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rNameWithChild, "parent_id", rName, "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccScanTemplateClassificationImportStateIdFunc(rName),
+			},
+			{
+				ResourceName:      rNameWithChild,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccScanTemplateClassificationImportStateIdFunc(rNameWithChild),
+			},
+		},
+	})
+}
+
+func testAccScanTemplateClassificationImportStateIdFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", rName)
+		}
+
+		templateId := rs.Primary.Attributes["template_id"]
+		classificationId := rs.Primary.ID
+		if templateId == "" || classificationId == "" {
+			return "", fmt.Errorf("missing some attributes, want '<template_id>/<id>', but got '%s/%s'", templateId, classificationId)
+		}
+
+		return fmt.Sprintf("%s/%s", templateId, classificationId), nil
+	}
+}
+
+func testAccResourceScanTemplateClassification_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_scan_template" "test" {
+  action      = "ADD"
+  name        = "%[1]s"
+  description = "Created_by_terraform_script"
+}
+`, name)
+}
+
+func testAccResourceScanTemplateClassification_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_scan_template_classification" "test" {
+  template_id         = huaweicloud_dsc_scan_template.test.id
+  classification_name = "%[2]s"
+}
+
+resource "huaweicloud_dsc_scan_template_classification" "test2" {
+  template_id         = huaweicloud_dsc_scan_template.test.id
+  classification_name = "%[2]s_child"
+  parent_id           = huaweicloud_dsc_scan_template_classification.test.id
+}
+`, testAccResourceScanTemplateClassification_base(name), name)
+}
+
+func testAccResourceScanTemplateClassification_basic_step2(name, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_scan_template_classification" "test" {
+  template_id         = huaweicloud_dsc_scan_template.test.id
+  classification_name = "%[2]s"
+}
+
+resource "huaweicloud_dsc_scan_template_classification" "test2" {
+  template_id         = huaweicloud_dsc_scan_template.test.id
+  classification_name = "%[2]s_child"
+  parent_id           = huaweicloud_dsc_scan_template_classification.test.id
+}
+`, testAccResourceScanTemplateClassification_base(name), updateName)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_template_classification.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_template_classification.go
@@ -1,0 +1,393 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	scanTemplateClassificationNonUpdatableParams = []string{
+		"template_id",
+		"parent_id",
+	}
+
+	scanTemplateClassificationNotFoundErrCodes = []string{
+		"dsc.600000025", // The template does not exist.
+		"dsc.10000009",  // The DSC instance does not exist.
+	}
+)
+
+// @API DSC POST /v1/{project_id}/scan-templates/{template_id}/classifications
+// @API DSC GET /v1/{project_id}/scan-templates/{template_id}/classifications
+// @API DSC PUT /v1/{project_id}/scan-templates/{template_id}/classifications/{classification_id}
+// @API DSC POST /v1/{project_id}/scan-templates/{template_id}/classifications/batch-delete
+func ResourceScanTemplateClassification() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScanTemplateClassificationCreate,
+		ReadContext:   resourceScanTemplateClassificationRead,
+		UpdateContext: resourceScanTemplateClassificationUpdate,
+		DeleteContext: resourceScanTemplateClassificationDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(scanTemplateClassificationNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceScanTemplateClassificationImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the scan template classification is located.`,
+			},
+
+			// Required parameters.
+			"template_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the scan template.`,
+			},
+			"classification_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the classification.`,
+			},
+
+			// Optional parameters.
+			"parent_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The parent classification ID.`,
+			},
+
+			// Attributes.
+			"depth": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The depth of the classification.`,
+			},
+			"root_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the root to which the classification belongs.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the classification is created, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the classification, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildCreateScanTemplateClassificationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"classification_name": d.Get("classification_name"),
+		"parent_id":           utils.ValueIgnoreEmpty(d.Get("parent_id")),
+	}
+}
+
+func createScanTemplateClassification(client *golangsdk.ServiceClient, templateId string, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/scan-templates/{template_id}/classifications"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{template_id}", templateId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateScanTemplateClassificationBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourceScanTemplateClassificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		templateId = d.Get("template_id").(string)
+		name       = d.Get("classification_name").(string)
+	)
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = createScanTemplateClassification(client, templateId, d)
+	if err != nil {
+		return diag.Errorf("error creating scan classification under template (%s): %s", templateId, err)
+	}
+
+	// After creation, query the classification list to get corresponding classification ID.
+	respBody, err := listScanTemplateClassifications(client, templateId)
+	if err != nil {
+		return diag.Errorf("error getting classifications under template (%s): %s", templateId, err)
+	}
+
+	classification := findScanTemplateClassificationByNameAndParentId(utils.PathSearch("classification_trees",
+		respBody, make([]interface{}, 0)).([]interface{}), name, d.Get("parent_id").(string))
+	classificationId := utils.PathSearch("id", classification, "").(string)
+	if classificationId == "" {
+		return diag.Errorf("unable to find the classification ID from API response")
+	}
+
+	d.SetId(classificationId)
+
+	return resourceScanTemplateClassificationRead(ctx, d, meta)
+}
+
+func findScanTemplateClassificationByNameAndParentId(classification []interface{}, name, parentId string) interface{} {
+	if len(classification) == 0 {
+		return nil
+	}
+
+	for _, item := range classification {
+		isMatch := utils.PathSearch("name", item, "").(string) == name
+		if parentId != "" {
+			isMatch = isMatch && utils.PathSearch("parent_id", item, "").(string) == parentId
+		}
+
+		if isMatch {
+			return item
+		}
+
+		children := findScanTemplateClassificationByNameAndParentId(utils.PathSearch("children", item, make([]interface{}, 0)).([]interface{}),
+			name, parentId)
+		if children != nil {
+			return children
+		}
+	}
+
+	return nil
+}
+
+func listScanTemplateClassifications(client *golangsdk.ServiceClient, templateId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/scan-templates/{template_id}/classifications"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{template_id}", templateId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func GetScanTemplateClassificationById(client *golangsdk.ServiceClient, templateId, classificationId string) (interface{}, error) {
+	respBody, err := listScanTemplateClassifications(client, templateId)
+	if err != nil {
+		return nil, err
+	}
+
+	classification := findScanTemplateClassificationById(utils.PathSearch("classification_trees",
+		respBody, make([]interface{}, 0)).([]interface{}), classificationId)
+	if classification == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/scan-templates/{template_id}/classifications",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the classification (%s) does not exist", classificationId)),
+			},
+		}
+	}
+
+	return classification, nil
+}
+
+func resourceScanTemplateClassificationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		templateId       = d.Get("template_id").(string)
+		classificationId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	classification, err := GetScanTemplateClassificationById(client, templateId, classificationId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(
+				common.ConvertExpected400ErrInto404Err(err, "error_code", scanTemplateClassificationNotFoundErrCodes...),
+				"error_code",
+				scanTemplateClassificationNotFoundErrCodes...,
+			),
+			fmt.Sprintf("error retrieving scan template classifications (%s)", classificationId),
+		)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Required parameters.
+		d.Set("template_id", templateId),
+		d.Set("classification_name", utils.PathSearch("name", classification, nil)),
+		// Optional parameters.
+		d.Set("parent_id", utils.PathSearch("parent_id", classification, nil)),
+		// Attributes.
+		d.Set("depth", utils.PathSearch("depth", classification, nil)),
+		d.Set("root_id", utils.PathSearch("root_id", classification, nil)),
+		d.Set("create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+			classification, float64(0)).(float64))/1000, false)),
+		d.Set("update_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+			classification, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func findScanTemplateClassificationById(classifications []interface{}, classificationId string) interface{} {
+	for _, classification := range classifications {
+		if utils.PathSearch("id", classification, "").(string) == classificationId {
+			return classification
+		}
+
+		children := utils.PathSearch("children", classification, make([]interface{}, 0)).([]interface{})
+		if result := findScanTemplateClassificationById(children, classificationId); result != nil {
+			return result
+		}
+	}
+
+	return nil
+}
+
+func resourceScanTemplateClassificationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg              = meta.(*config.Config)
+		templateId       = d.Get("template_id").(string)
+		classificationId = d.Id()
+		name             = d.Get("classification_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateScanTemplateClassificationName(client, templateId, classificationId, name)
+		if err != nil {
+			return diag.Errorf("error updating classification (%s) under the template (%s): %s", classificationId, templateId, err)
+		}
+	}
+
+	return resourceScanTemplateClassificationRead(ctx, d, meta)
+}
+
+func updateScanTemplateClassificationName(client *golangsdk.ServiceClient, templateId, classificationId, name string) error {
+	httpUrl := "v1/{project_id}/scan-templates/{template_id}/classifications/{classification_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{template_id}", templateId)
+	updatePath = strings.ReplaceAll(updatePath, "{classification_id}", classificationId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"classification_name": name,
+		},
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func deleteScanTemplateClassification(client *golangsdk.ServiceClient, templateId string, classificationId string) error {
+	httpUrl := "v1/{project_id}/scan-templates/{template_id}/classifications/batch-delete"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{template_id}", templateId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"classification_ids": []string{classificationId},
+		},
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourceScanTemplateClassificationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		templateId = d.Get("template_id").(string)
+	)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = deleteScanTemplateClassification(client, templateId, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", scanTemplateClassificationNotFoundErrCodes...),
+			fmt.Sprintf("error deleting classification (%v) under template (%s)", d.Get("classification_name"), templateId),
+		)
+	}
+
+	return nil
+}
+
+func resourceScanTemplateClassificationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<template_id>/<id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("template_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage classification under the specified scan template.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccResourceScanTemplateClassification_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccResourceScanTemplateClassification_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceScanTemplateClassification_basic
=== PAUSE TestAccResourceScanTemplateClassification_basic
=== CONT  TestAccResourceScanTemplateClassification_basic
--- PASS: TestAccResourceScanTemplateClassification_basic (27.20s)
PASS
coverage: 9.0% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       27.387s coverage: 9.0% of statements in ./huaweicloud/services/dsc
```
<img width="1281" height="40" alt="image" src="https://github.com/user-attachments/assets/3b1c6b6f-fefa-4f61-b61d-586f03c8ecba" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1178" height="865" alt="image" src="https://github.com/user-attachments/assets/a8ba2de4-e1ae-49c1-83ab-ed885166169e" />

    ab. Related resources (parent resources) not found
    The template does not exist.
    <img width="1239" height="880" alt="image" src="https://github.com/user-attachments/assets/608e254b-e914-4a3d-a100-0239e45a3b37" />

    The DSC instance does not exist.
    <img width="1206" height="898" alt="image" src="https://github.com/user-attachments/assets/c9d4474f-6464-4720-b2f5-0036a8d1c3ea" />
    
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
     The delete interface always returns a status code of `200` when the resource does not exist.

    bb. Related resources (parent resources) not found
    The template does not exist.
     <img width="1324" height="831" alt="image" src="https://github.com/user-attachments/assets/5de2f245-5b19-474d-8ede-2d2a7cec6567" />

    The DSC instance does not exist.
    <img width="1189" height="876" alt="image" src="https://github.com/user-attachments/assets/2c1fe7cb-74ec-4a17-8e13-3857a87254ee" />

