### PR TITLE
feat(cce): node pool supports omit extension scaling groups

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -700,7 +700,7 @@ $ terraform import huaweicloud_cce_node_pool.my_node_pool <cluster_id>/<id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`password`, `extend_params`, `taints`, `ignore_initial_node_count` and `pod_security_groups`.
+`password`, `extend_params`, `taints`, `ignore_initial_node_count`, `pod_security_groups` and `partition`.
 It is generally recommended running `terraform plan` after importing a node pool.
 You can then decide if changes should be applied to the node pool, or the resource
 definition should be updated to align with the node pool. Also you can ignore changes as below.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.13
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
 	github.com/ProtonMail/go-crypto v1.3.0
-	github.com/chnsz/golangsdk v0.0.0-20260514121205-83ad1d270e52
+	github.com/chnsz/golangsdk v0.0.0-20260716092605-2db777a6564f
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20260514121205-83ad1d270e52 h1:1cIHImncCyWwtSCDpU85zPdnNbMh3zN9Y+S6Fj7Evk4=
-github.com/chnsz/golangsdk v0.0.0-20260514121205-83ad1d270e52/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20260716092605-2db777a6564f h1:7rqJU3BCc0YNr3mmuEXDHADnAMqjzMbMTXF5vo6A6nE=
+github.com/chnsz/golangsdk v0.0.0-20260716092605-2db777a6564f/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pool_test.go
@@ -64,16 +64,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 1
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
-  max_node_count           = 0
+  max_node_count           = 2
+  initial_node_count       = 1
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -90,14 +92,22 @@ resource "huaweicloud_cce_node_pool" "test" {
     }
 
     spec {
-      flavor = data.huaweicloud_compute_flavors.test.ids[0]
-      az     = data.huaweicloud_availability_zones.test.names[1]
+      flavor = local.flavor_specifications
+      az     = try(data.huaweicloud_availability_zones.test.names[0], null)
 
       autoscaling {
         extension_priority = 1
         enable             = true
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pools_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pools_test.go
@@ -111,16 +111,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "Huawei Cloud EulerOS 2.0"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 0
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
   max_node_count           = 0
+  initial_node_count       = 0
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
   runtime                  = "containerd"
   subnet_id                = huaweicloud_vpc_subnet.test.id
   security_groups          = [huaweicloud_networking_secgroup.test.id]
@@ -196,14 +198,22 @@ resource "huaweicloud_cce_node_pool" "test" {
     }
 
     spec {
-      flavor = data.huaweicloud_compute_flavors.test.ids[0]
-      az     = data.huaweicloud_availability_zones.test.names[1]
+      flavor = local.flavor_specifications
+      az     = try(data.huaweicloud_availability_zones.test.names[0], null)
 
       autoscaling {
         extension_priority = 1
         enable             = true
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_test.go
@@ -166,18 +166,20 @@ func testAccAddon_values_base(name string) string {
 %[1]s
 
 resource "huaweicloud_cce_node_pool" "test" {
-  cluster_id         = huaweicloud_cce_cluster.test.id
-  name               = "%[2]s"
-  os                 = "EulerOS 2.9"
-  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count = 4
-  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
-  key_pair           = huaweicloud_kps_keypair.test.name
-  scall_enable       = true
-  min_node_count     = 2
-  max_node_count     = 10
-  priority           = 1
-  type               = "vm"
+  cluster_id            = huaweicloud_cce_cluster.test.id
+  name                  = "%[2]s"
+  os                    = "EulerOS 2.9"
+  flavor_id             = local.flavor_specifications
+  availability_zone     = try(data.huaweicloud_availability_zones.test.names[0], null)
+  key_pair              = huaweicloud_kps_keypair.test.name
+  scall_enable          = true
+  min_node_count        = 2
+  max_node_count        = 10
+  initial_node_count    = 4
+  priority              = 1
+  type                  = "vm"
+  partition             = "center"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -186,6 +188,14 @@ resource "huaweicloud_cce_node_pool" "test" {
   data_volumes {
     size       = 100
     volumetype = "SSD"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -73,39 +73,66 @@ func TestAccNodePool_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccNodePoolImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"ignore_initial_node_count", "extend_params", "enable_force_new",
+					"ignore_initial_node_count", "extend_params", "enable_force_new", "partition",
 				},
 			},
 		},
 	})
 }
 
-func testAccNodePool_base(rName string) string {
+func testAccNodePool_base(name string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 data "huaweicloud_availability_zones" "test" {}
 
-data "huaweicloud_compute_flavors" "test" {
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  performance_type  = "normal"
-  cpu_core_count    = 2
-  memory_size       = 4
+%[1]s
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = "%[2]s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  cluster_version        = "v1.34"
+  enterprise_project_id  = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  enable_distribute_management = true
+  container_network_type       = "eni"
+  // eni_subnet_id is required if you want to enable the distribute cloud.
+  eni_subnet_id                = join(",", [
+    huaweicloud_vpc_subnet.test.ipv4_subnet_id, // Center subnet should be used.
+  ])
+
+  dynamic "masters" {
+    for_each = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+
+    content {
+      availability_zone = masters.value
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      // After cluster created, the IEC subnet ID will append to the eni container subnet list.
+      eni_subnet_id,
+    ]
+  }
+}
+
+data "huaweicloud_cce_flavor_specifications" "test" {
+  cluster_type = "VirtualMachine"
+}
+
+locals {
+  flavor_specifications = try(coalesce([
+      for v in data.huaweicloud_cce_flavor_specifications.test.cluster_flavor_specs : try([
+        for vv in v.available_master_flavors: vv.name if contains(vv.azs, data.huaweicloud_availability_zones.test.names[0])
+      ][0], "") if v.name == huaweicloud_cce_cluster.test.flavor_id && !v.is_sold_out
+    ])[0], null)
 }
 
 resource "huaweicloud_kps_keypair" "test" {
   name = "%[2]s"
 }
-
-resource "huaweicloud_cce_cluster" "test" {
-  name                   = "%[2]s"
-  cluster_type           = "VirtualMachine"
-  flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc.test.id
-  subnet_id              = huaweicloud_vpc_subnet.test.id
-  container_network_type = "overlay_l2"
-}
-`, common.TestVpc(rName), rName)
+`, common.TestVpc(name), name)
 }
 
 func testAccNodePool_basic_step1(name, baseConfig string) string {
@@ -116,16 +143,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 1
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
   max_node_count           = 0
+  initial_node_count       = 1
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -146,7 +175,7 @@ EOF
 
   lifecycle {
     ignore_changes = [
-      extend_params
+      labels, extend_params
     ]
   }
 }
@@ -161,17 +190,19 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id                = huaweicloud_cce_cluster.test.id
   name                      = "%[2]s"
   os                        = "EulerOS 2.9"
-  flavor_id                 = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count        = 2
-  ignore_initial_node_count = false
-  availability_zone         = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                 = local.flavor_specifications
+  availability_zone         = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                  = huaweicloud_kps_keypair.test.name
   scall_enable              = true
   min_node_count            = 2
   max_node_count            = 9
+  initial_node_count        = 2
+  ignore_initial_node_count = false
   scale_down_cooldown_time  = 100
   priority                  = 1
   type                      = "vm"
+  partition                 = "center"
+  enterprise_project_id     = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -192,7 +223,7 @@ EOF
 
   lifecycle {
     ignore_changes = [
-      extend_params
+      labels, extend_params
     ]
   }
 }
@@ -243,6 +274,9 @@ func TestAccNodePool_tagsLabelsTaints(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.test2", "val2"),
 					resource.TestCheckResourceAttr(resourceName, "labels.test1", "val1"),
 					resource.TestCheckResourceAttr(resourceName, "labels.test2", "val2"),
+					resource.TestCheckResourceAttr(resourceName, "labels.distribution.io/category", "Default"),
+					resource.TestCheckResourceAttr(resourceName, "labels.distribution.io/partition", "center"),
+					resource.TestCheckResourceAttr(resourceName, "labels.distribution.io/publicbordergroup", "center"),
 					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "test_key"),
 					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "test_value"),
 					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoSchedule"),
@@ -260,6 +294,9 @@ func TestAccNodePool_tagsLabelsTaints(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.test2_update", "val2_update"),
 					resource.TestCheckResourceAttr(resourceName, "labels.test1", "val1_update"),
 					resource.TestCheckResourceAttr(resourceName, "labels.test2_update", "val2_update"),
+					resource.TestCheckResourceAttr(resourceName, "labels.distribution.io/category", "Default"),
+					resource.TestCheckResourceAttr(resourceName, "labels.distribution.io/partition", "center"),
+					resource.TestCheckResourceAttr(resourceName, "labels.distribution.io/publicbordergroup", "center"),
 					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "test_key"),
 					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "test_value_update"),
 					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoSchedule"),
@@ -283,16 +320,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 1
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
-  max_node_count           = 0
+  max_node_count           = 2
+  initial_node_count       = 1
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   tag_policy_on_existing_nodes   = "ignore"
   label_policy_on_existing_nodes = "ignore"
@@ -313,8 +352,11 @@ resource "huaweicloud_cce_node_pool" "test" {
   }
 
   labels = {
-    test1 = "val1"
-    test2 = "val2"
+    "distribution.io/category"          = "Default"
+    "distribution.io/partition"         = "center"
+    "distribution.io/publicbordergroup" = "center"
+    "test1"                             = "val1"
+    "test2"                             = "val2"
   }
 
   taints {
@@ -322,7 +364,6 @@ resource "huaweicloud_cce_node_pool" "test" {
     value  = "test_value"
     effect = "NoSchedule"
   }
-
 }
 `, testAccNodePool_base(name), name)
 }
@@ -335,16 +376,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 1
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
-  max_node_count           = 0
+  max_node_count           = 2
+  initial_node_count       = 1
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   tag_policy_on_existing_nodes   = "refresh"
   label_policy_on_existing_nodes = "refresh"
@@ -365,8 +408,11 @@ resource "huaweicloud_cce_node_pool" "test" {
   }
 
   labels = {
-    test1        = "val1_update"
-    test2_update = "val2_update"
+    "distribution.io/category"          = "Default"
+    "distribution.io/partition"         = "center"
+    "distribution.io/publicbordergroup" = "center"
+    "test1"                             = "val1_update"
+    "test2_update"                      = "val2_update"
   }
 
   taints {
@@ -432,16 +478,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 1
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
-  max_node_count           = 0
+  max_node_count           = 2
+  initial_node_count       = 1
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -452,6 +500,14 @@ resource "huaweicloud_cce_node_pool" "test" {
     size       = 100
     volumetype = "SSD"
     kms_key_id = huaweicloud_kms_key.test.id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 `, testAccNodePool_base(name), name)
@@ -509,16 +565,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 0
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
   max_node_count           = 0
+  initial_node_count       = 0
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   charging_mode = "prePaid"
   period_unit   = "month"
@@ -532,6 +590,14 @@ resource "huaweicloud_cce_node_pool" "test" {
   data_volumes {
     size       = 100
     volumetype = "SSD"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 `, testAccNodePool_base(rName), rName, autoRenew)
@@ -559,7 +625,7 @@ func TestAccNodePool_SecurityGroups(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNodePool_SecurityGroups(name),
+				Config: testAccNodePool_SecurityGroups_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -570,7 +636,7 @@ func TestAccNodePool_SecurityGroups(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNodePool_SecurityGroups_update(name),
+				Config: testAccNodePool_SecurityGroups_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -596,7 +662,7 @@ resource "huaweicloud_networking_secgroup" "test" {
 `, testAccNodePool_base(name), name)
 }
 
-func testAccNodePool_SecurityGroups(name string) string {
+func testAccNodePool_SecurityGroups_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -604,16 +670,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 0
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
   max_node_count           = 0
+  initial_node_count       = 0
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   security_groups = [
     huaweicloud_networking_secgroup.test[0].id,
@@ -632,12 +700,20 @@ resource "huaweicloud_cce_node_pool" "test" {
   data_volumes {
     size       = 100
     volumetype = "SSD"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 `, testAccNodePool_SecurityGroups_base(name), name)
 }
 
-func testAccNodePool_SecurityGroups_update(name string) string {
+func testAccNodePool_SecurityGroups_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -645,16 +721,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 0
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   password                 = "test_123456"
   scall_enable             = false
   min_node_count           = 0
   max_node_count           = 0
+  initial_node_count       = 0
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   security_groups = [
     huaweicloud_networking_secgroup.test[2].id,
@@ -673,6 +751,14 @@ resource "huaweicloud_cce_node_pool" "test" {
   data_volumes {
     size       = 100
     volumetype = "SSD"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 `, testAccNodePool_SecurityGroups_base(name), name)
@@ -725,17 +811,19 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 1
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
   max_node_count           = 0
+  initial_node_count       = 1
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
   ecs_group_id             = huaweicloud_compute_servergroup.test.id
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -744,6 +832,14 @@ resource "huaweicloud_cce_node_pool" "test" {
   data_volumes {
     size       = 100
     volumetype = "SSD"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 `, testAccNodePool_base(rName), rName)
@@ -771,7 +867,7 @@ func TestAccNodePool_storage(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNodePool_storage(name),
+				Config: testAccNodePool_storage_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -780,7 +876,7 @@ func TestAccNodePool_storage(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNodePool_storage_update(name),
+				Config: testAccNodePool_storage_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -792,7 +888,7 @@ func TestAccNodePool_storage(t *testing.T) {
 	})
 }
 
-func testAccNodePool_storage(rName string) string {
+func testAccNodePool_storage_step1(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -805,16 +901,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 1
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
-  max_node_count           = 0
+  max_node_count           = 2
+  initial_node_count       = 1
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -879,11 +977,19 @@ resource "huaweicloud_cce_node_pool" "test" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
+  }
 }
 `, testAccNodePool_base(rName), rName)
 }
 
-func testAccNodePool_storage_update(rName string) string {
+func testAccNodePool_storage_step2(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -896,16 +1002,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 1
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
-  max_node_count           = 0
+  max_node_count           = 2
+  initial_node_count       = 1
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 50
@@ -970,6 +1078,14 @@ resource "huaweicloud_cce_node_pool" "test" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
+  }
 }
 `, testAccNodePool_base(rName), rName)
 }
@@ -1001,7 +1117,13 @@ func TestAccNodePool_extensionScaleGroups(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					// the order of extension_scale_groups returned by API could be different, so don't need to check
+					resource.TestCheckResourceAttr(resourceName, "scall_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "min_node_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "max_node_count", "10"),
+					resource.TestCheckResourceAttr(resourceName, "scale_down_cooldown_time", "100"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "partition", "center"),
+					resource.TestCheckResourceAttr(resourceName, "extension_scale_groups.#", "0"),
 				),
 			},
 			{
@@ -1009,7 +1131,23 @@ func TestAccNodePool_extensionScaleGroups(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					// the order of extension_scale_groups returned by API could be different, so don't need to check
+					resource.TestCheckResourceAttr(resourceName, "extension_scale_groups.#", "2"),
+				),
+			},
+			{
+				Config: testAccNodePool_extensionScaleGroups_step3(updateName, baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "extension_scale_groups.#", "2"),
+				),
+			},
+			{
+				Config: testAccNodePool_extensionScaleGroups_step4(updateName, baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "extension_scale_groups.#", "0"),
 				),
 			},
 			{
@@ -1018,7 +1156,7 @@ func TestAccNodePool_extensionScaleGroups(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccNodePoolImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"initial_node_count", "ignore_initial_node_count",
+					"initial_node_count", "ignore_initial_node_count", "partition",
 				},
 			},
 		},
@@ -1033,16 +1171,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 0
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
-  scall_enable             = false
-  min_node_count           = 0
-  max_node_count           = 0
-  scale_down_cooldown_time = 0
-  priority                 = 0
+  scall_enable             = true
+  min_node_count           = 1
+  max_node_count           = 10
+  initial_node_count       = 2
+  scale_down_cooldown_time = 100
+  priority                 = 1
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -1053,19 +1193,12 @@ resource "huaweicloud_cce_node_pool" "test" {
     volumetype = "SSD"
   }
 
-  extension_scale_groups {
-    metadata {
-      name = "%[2]s-group1"
-    }
-
-    spec {
-      flavor = data.huaweicloud_compute_flavors.test.ids[0]
-      az     = data.huaweicloud_availability_zones.test.names[1]
-      autoscaling {
-        extension_priority = 1
-        enable             = true
-      }
-    }
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 `, baseConfig, name)
@@ -1079,16 +1212,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 0
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = true
-  min_node_count           = 0
-  max_node_count           = 0
+  min_node_count           = 1
+  max_node_count           = 10
+  initial_node_count       = 2
   scale_down_cooldown_time = 100
   priority                 = 1
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -1101,51 +1236,130 @@ resource "huaweicloud_cce_node_pool" "test" {
 
   extension_scale_groups {
     metadata {
-      name = "%[2]s-group1"
+      name = "group1"
     }
 
     spec {
-      flavor = data.huaweicloud_compute_flavors.test.ids[0]
-      az     = data.huaweicloud_availability_zones.test.names[1]
+      flavor = local.flavor_specifications
+      az     = try(data.huaweicloud_availability_zones.test.names[0], null)
+
       autoscaling {
         extension_priority = 1
         enable             = true
+        min_node_count     = 1
+        max_node_count     = 3
       }
     }
   }
 
   extension_scale_groups {
     metadata {
-      name = "%[2]s-group2"
+      name = "group2"
     }
 
     spec {
-      flavor = data.huaweicloud_compute_flavors.test.ids[1]
-      az     = data.huaweicloud_availability_zones.test.names[0]
+      flavor = local.flavor_specifications
+      az     = try(data.huaweicloud_availability_zones.test.names[0], null)
+
       autoscaling {
-        extension_priority = 1
+        extension_priority = 2
         enable             = true
+        min_node_count     = 1
+        max_node_count     = 3
       }
     }
   }
 
-  extension_scale_groups {
-    metadata {
-      name = "%[2]s-group3"
-    }
-
-    spec {
-      flavor = data.huaweicloud_compute_flavors.test.ids[1]
-      az     = data.huaweicloud_availability_zones.test.names[1]
-
-      autoscaling {
-        extension_priority = 1
-        enable             = true
-      }
-    }
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 `, baseConfig, name)
+}
+
+func testAccNodePool_extensionScaleGroups_step3(name, baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cce_node_pool" "test" {
+  cluster_id               = huaweicloud_cce_cluster.test.id
+  name                     = "%[2]s"
+  os                       = "EulerOS 2.9"
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
+  key_pair                 = huaweicloud_kps_keypair.test.name
+  scall_enable             = true
+  min_node_count           = 1
+  max_node_count           = 10
+  initial_node_count       = 2
+  scale_down_cooldown_time = 100
+  priority                 = 1
+  type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  extension_scale_groups {
+    metadata {
+      name = "group1"
+    }
+
+    spec {
+      flavor = local.flavor_specifications
+      az     = try(data.huaweicloud_availability_zones.test.names[0], null)
+
+      autoscaling {
+        extension_priority = 1
+        enable             = true
+        min_node_count     = 1
+        max_node_count     = 5
+      }
+    }
+  }
+
+  extension_scale_groups {
+    metadata {
+      name = "group2"
+    }
+
+    spec {
+      flavor = local.flavor_specifications
+      az     = try(data.huaweicloud_availability_zones.test.names[0], null)
+
+      autoscaling {
+        extension_priority = 3
+        enable             = true
+        min_node_count     = 1
+        max_node_count     = 4
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
+  }
+}
+`, baseConfig, name)
+}
+
+func testAccNodePool_extensionScaleGroups_step4(name, baseConfig string) string {
+	return testAccNodePool_extensionScaleGroups_step1(name, baseConfig)
 }
 
 func TestAccNodePool_without_data_volumes(t *testing.T) {
@@ -1188,16 +1402,18 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
   os                       = "EulerOS 2.9"
-  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
-  initial_node_count       = 0
-  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id                = local.flavor_specifications
+  availability_zone        = try(data.huaweicloud_availability_zones.test.names[0], null)
   key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
   max_node_count           = 0
+  initial_node_count       = 0
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+  partition                = "center"
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   root_volume {
     size       = 40
@@ -1229,14 +1445,22 @@ resource "huaweicloud_cce_node_pool" "test" {
     }
 
     spec {
-      flavor = data.huaweicloud_compute_flavors.test.ids[0]
-      az     = data.huaweicloud_availability_zones.test.names[1]
+      flavor = local.flavor_specifications
+      az     = try(data.huaweicloud_availability_zones.test.names[0], null)
 
       autoscaling {
         extension_priority = 1
         enable             = true
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # When creating a node pool, the tags "distribution.io/category", "distribution.io/partition", and
+      # "distribution.io/publicbordergroup" are automatically added.
+      labels
+    ]
   }
 }
 `, baseConfig, name)

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -307,7 +307,6 @@ func resourceExtensionScaleGroupsSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"metadata": {
@@ -465,12 +464,14 @@ func buildPodSecurityGroups(ids []interface{}) []nodepools.PodSecurityGroupSpec 
 }
 
 func buildExtensionScaleGroups(d *schema.ResourceData) []nodepools.ExtensionScaleGroups {
-	_, ok := d.GetOk("extension_scale_groups")
-	if !ok {
-		return nil
+	// Use Get instead of GetOk so that an explicit empty list can be distinguished and sent
+	// as [] on update (clearing all extension scale groups).
+	newGroups := d.Get("extension_scale_groups").([]interface{})
+	if len(newGroups) == 0 {
+		return make([]nodepools.ExtensionScaleGroups, 0)
 	}
 
-	oldRaw, newRaw := d.GetChange("extension_scale_groups")
+	oldRaw, _ := d.GetChange("extension_scale_groups")
 	oldGroups := oldRaw.([]interface{})
 	oldGroupsMap := make(map[string]string)
 	for _, oldGroup := range oldGroups {
@@ -478,14 +479,14 @@ func buildExtensionScaleGroups(d *schema.ResourceData) []nodepools.ExtensionScal
 		uid := utils.PathSearch("metadata[0].uid", oldGroup, "").(string)
 		oldGroupsMap[name] = uid
 	}
-	newGroups := newRaw.([]interface{})
-	res := make([]nodepools.ExtensionScaleGroups, len(newGroups))
-	for i, newGroup := range newGroups {
+
+	res := make([]nodepools.ExtensionScaleGroups, 0, len(newGroups))
+	for _, newGroup := range newGroups {
 		if group, ok := newGroup.(map[string]interface{}); ok {
-			res[i] = nodepools.ExtensionScaleGroups{
+			res = append(res, nodepools.ExtensionScaleGroups{
 				Metadata: buildExtensionScaleGroupsMetadata(utils.PathSearch("metadata", group, make([]interface{}, 0)), oldGroupsMap),
 				Spec:     buildExtensionScaleGroupsSpec(utils.PathSearch("spec", group, make([]interface{}, 0))),
-			}
+			})
 		}
 	}
 
@@ -705,7 +706,6 @@ func resourceNodePoolRead(_ context.Context, d *schema.ResourceData, meta interf
 
 	// The following parameters are not returned:
 	// password, ignore_initial_node_count, pod_security_groups
-	// extension_scale_groups not save, because the order of groups will change and computed not working in TypeSet
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
 		d.Set("name", s.Metadata.Name),

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
@@ -293,7 +293,7 @@ type UpdateSpec struct {
 	// taint policy on existing nodes
 	TaintPolicyOnExistingNodes string `json:"taintPolicyOnExistingNodes,omitempty"`
 	// The list of extension scale groups
-	ExtensionScaleGroups []ExtensionScaleGroups `json:"extensionScaleGroups,omitempty"`
+	ExtensionScaleGroups []ExtensionScaleGroups `json:"extensionScaleGroups"`
 }
 
 // ToNodePoolUpdateMap builds an update body based on UpdateOpts.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/agext/levenshtein
 # github.com/apparentlymart/go-textseg/v15 v15.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v15/textseg
-# github.com/chnsz/golangsdk v0.0.0-20260514121205-83ad1d270e52
+# github.com/chnsz/golangsdk v0.0.0-20260716092605-2db777a6564f
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Enable `huaweicloud_cce_node_pool` to clear all extension scale groups on update by sending an empty `extensionScaleGroups` array, and refresh related acceptance tests / docs accordingly.

**1. Core behavior**

- Remove top-level `Computed` from `extension_scale_groups`, so Terraform can plan an empty list when the attribute is omitted or set to `[]`.
- Update `buildExtensionScaleGroups` to use `d.Get` instead of `d.GetOk`, and return an empty non-nil slice when no groups are configured.
- Drop `omitempty` from `UpdateSpec.ExtensionScaleGroups` in golangsdk so update requests can serialize `"extensionScaleGroups": []` and clear existing extension groups.

**2. Revelant acceptance tests**

- Extend `TestAccNodePool_extensionScaleGroups` with create → update → clear (`extension_scale_groups = []`) steps, and assert `extension_scale_groups.# = 0`.
- Refresh CCE node pool / related acceptance fixtures (base cluster, flavor selection, partition, addon / node pool data source tests) to align with the current test environment.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #9222 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. node pool supports omit extension scaling groups
2. upgrade the relevant acceptance test especially refactor the cluster script
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

**Acceptance test about Extension Scaling Groups**

```
./scripts/coverage.sh -o cce -f TestAccNodePool_extensionScaleGroups
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_extensionScaleGroups -timeout 360m -parallel 10
=== RUN   TestAccNodePool_extensionScaleGroups
=== PAUSE TestAccNodePool_extensionScaleGroups
=== CONT  TestAccNodePool_extensionScaleGroups
--- PASS: TestAccNodePool_extensionScaleGroups (1203.26s)
PASS
coverage: 15.5% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1203.381s       coverage: 15.5% of statements in ./huaweicloud/services/cce
```

**Revelant acceptance tests:**

```
./scripts/coverage.sh -o cce -f TestAccNodePool_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_basic -timeout 360m -parallel 10
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== CONT  TestAccNodePool_basic
--- PASS: TestAccNodePool_basic (1125.98s)
PASS
coverage: 13.5% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1126.126s       coverage: 13.5% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccNodePool_tagsLabelsTaints
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_tagsLabelsTaints -timeout 360m -parallel 10
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== CONT  TestAccNodePool_tagsLabelsTaints
--- PASS: TestAccNodePool_tagsLabelsTaints (691.05s)
PASS
coverage: 13.3% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       691.171s        coverage: 13.3% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccNodePool_volume_encryption
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_volume_encryption -timeout 360m -parallel 10
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== CONT  TestAccNodePool_volume_encryption
--- PASS: TestAccNodePool_volume_encryption (1033.37s)
PASS
coverage: 12.6% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1033.554s       coverage: 12.6% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccNodePool_prePaid
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_prePaid -timeout 360m -parallel 10
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== CONT  TestAccNodePool_prePaid
--- PASS: TestAccNodePool_prePaid (605.89s)
PASS
coverage: 13.5% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       606.160s        coverage: 13.5% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccNodePool_SecurityGroups
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_SecurityGroups -timeout 360m -parallel 10
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== CONT  TestAccNodePool_SecurityGroups
--- PASS: TestAccNodePool_SecurityGroups (596.08s)
PASS
coverage: 13.5% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       596.208s        coverage: 13.5% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccNodePool_serverGroup
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_serverGroup -timeout 360m -parallel 10
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== CONT  TestAccNodePool_serverGroup
--- PASS: TestAccNodePool_serverGroup (1011.91s)
PASS
coverage: 12.4% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1012.057s       coverage: 12.4% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccNodePool_storage
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_storage -timeout 360m -parallel 10
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== CONT  TestAccNodePool_storage
--- PASS: TestAccNodePool_storage (1048.13s)
PASS
coverage: 14.7% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1048.268s       coverage: 14.7% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccNodePool_without_data_volumes
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccNodePool_without_data_volumes -timeout 360m -parallel 10
=== RUN   TestAccNodePool_without_data_volumes
=== PAUSE TestAccNodePool_without_data_volumes
=== CONT  TestAccNodePool_without_data_volumes
--- PASS: TestAccNodePool_without_data_volumes (553.67s)
PASS
coverage: 14.8% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       553.791s        coverage: 14.8% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccCCENodePoolV3DataSource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccCCENodePoolV3DataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccCCENodePoolV3DataSource_basic
=== PAUSE TestAccCCENodePoolV3DataSource_basic
=== CONT  TestAccCCENodePoolV3DataSource_basic
--- PASS: TestAccCCENodePoolV3DataSource_basic (1030.87s)
PASS
coverage: 15.0% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1031.102s       coverage: 15.0% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccDataNodePools_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccDataNodePools_basic -timeout 360m -parallel 10
=== RUN   TestAccDataNodePools_basic
=== PAUSE TestAccDataNodePools_basic
=== CONT  TestAccDataNodePools_basic
--- PASS: TestAccDataNodePools_basic (534.61s)
PASS
coverage: 18.6% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       534.749s        coverage: 18.6% of statements in ./huaweicloud/services/cce
```
```
./scripts/coverage.sh -o cce -f TestAccAddon_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cce" -v -coverprofile="./huaweicloud/services/acceptance/cce/cce_coverage.cov" -coverpkg="./huaweicloud/services/cce" -run TestAccAddon_basic -timeout 360m -parallel 10
=== RUN   TestAccAddon_basic
=== PAUSE TestAccAddon_basic
=== CONT  TestAccAddon_basic
--- PASS: TestAccAddon_basic (1204.01s)
PASS
coverage: 13.8% of statements in ./huaweicloud/services/cce
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1204.133s       coverage: 13.8% of statements in ./huaweicloud/services/cce
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

