### PR TITLE
feat(dsc): new resource to operate obs audit

### DIFF
--- a/docs/resources/dsc_operate_obs_audit.md
+++ b/docs/resources/dsc_operate_obs_audit.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+pageTitle: "HuaweiCloud: huaweicloud_dsc_operate_obs_audit"
+description: |-
+  Manages a resource to operate DSC OBS audit within HuaweiCloud.
+---
+
+# huaweicloud_dsc_operate_obs_audit
+
+Manages a resource to operate DSC OBS audit within HuaweiCloud.
+
+-> This resource is a one-time action resource used to operate DSC OBS audit.
+Deleting this resource will not restore the audit status or undo the operation, but will only
+remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "bucket_id" {
+  type = string
+}
+
+resource "huaweicloud_dsc_operate_obs_audit" "test" {
+  bucket_id        = var.bucket_id
+  operation_status = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `bucket_id` - (Required, String, NonUpdatable) Specifies the OBS bucket asset ID.
+
+* `operation_status` - (Required, Bool, NonUpdatable) Specifies whether to enable or disable audit.
+  **true** means enabling audit, **false** means disabling audit.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `msg` - The returned message describing the operation result or error information.
+
+* `status` - The returned status, such as '200' or '400'.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5027,6 +5027,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_device":                         dsc.ResourceDscDevice(),
 			"huaweicloud_dsc_instance":                       dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_multi_enable_trusted_service":   dsc.ResourceMultiEnableTrustedService(),
+			"huaweicloud_dsc_operate_obs_audit":              dsc.ResourceOperateObsAudit(),
 			"huaweicloud_dsc_scan_template":                  dsc.ResourceScanTemplate(),
 			"huaweicloud_dsc_stop_scan_job":                  dsc.ResourceStopScanJob(),
 			"huaweicloud_dsc_switch_job":                     dsc.ResourceDscSwitchJob(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -470,6 +470,7 @@ var (
 	HW_DSC_SECURITY_LEVEL_ID_TARGET = os.Getenv("HW_DSC_SECURITY_LEVEL_ID_TARGET")
 	HW_DSC_OBS_ID                   = os.Getenv("HW_DSC_OBS_ID")
 	HW_DSC_DB_ID                    = os.Getenv("HW_DSC_DB_ID")
+	HW_DSC_BUCKET_ID                = os.Getenv("HW_DSC_BUCKET_ID")
 
 	HW_EIP_ID      = os.Getenv("HW_EIP_ID")
 	HW_EIP_ADDRESS = os.Getenv("HW_EIP_ADDRESS")
@@ -5380,6 +5381,13 @@ func TestAccPreCheckDscObsId(t *testing.T) {
 func TestAccPreCheckDscDbId(t *testing.T) {
 	if HW_DSC_DB_ID == "" {
 		t.Skip("HW_DSC_DB_ID must be set for DSC acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDscBucketId(t *testing.T) {
+	if HW_DSC_BUCKET_ID == "" {
+		t.Skip("HW_DSC_BUCKET_ID must be set for DSC acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_operate_obs_audit_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_operate_obs_audit_test.go
@@ -1,0 +1,35 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceOperateObsAudit_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscBucketId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceOperateObsAudit_basic(),
+			},
+		},
+	})
+}
+
+func testAccResourceOperateObsAudit_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_operate_obs_audit" "test" {
+  bucket_id        = "%s"
+  operation_status = true
+}
+`, acceptance.HW_DSC_BUCKET_ID)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_operate_obs_audit.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_operate_obs_audit.go
@@ -1,0 +1,136 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var operateObsAuditNonUpdatableParams = []string{"bucket_id", "operation_status"}
+
+// @API DSC PUT /v1/{project_id}/sdg/asset/obs/buckets/{bucket_id}/audit
+func ResourceOperateObsAudit() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOperateObsAuditCreate,
+		ReadContext:   resourceOperateObsAuditRead,
+		UpdateContext: resourceOperateObsAuditUpdate,
+		DeleteContext: resourceOperateObsAuditDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(operateObsAuditNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"bucket_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"operation_status": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildOperateObsAuditBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"operation_status": d.Get("operation_status").(bool),
+	}
+}
+
+func resourceOperateObsAuditCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sdg/asset/obs/buckets/{bucket_id}/audit"
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{bucket_id}", d.Get("bucket_id").(string))
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildOperateObsAuditBodyParams(d),
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error operating DSC OBS audit: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("msg", utils.PathSearch("msg", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceOperateObsAuditRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceOperateObsAuditUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceOperateObsAuditDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to operate DSC OBS audit.
+Deleting this resource will not restore the audit status or undo the operation, but will only
+remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to operate obs audit

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccResourceOperateObsAudit_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccResourceOperateObsAudit_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceOperateObsAudit_basic
=== PAUSE TestAccResourceOperateObsAudit_basic
=== CONT  TestAccResourceOperateObsAudit_basic
--- PASS: TestAccResourceOperateObsAudit_basic (11.84s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       11.982s coverage: 6.5% of statements in ./huaweicloud/services/dsc
```
<img width="1353" height="87" alt="image" src="https://github.com/user-attachments/assets/c67c2e28-036d-4256-81fc-5c3da2598617" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
