### PR TITLE
feat(dsc): add a new resource to manage scan rule

### DIFF
--- a/docs/resources/dsc_scan_rule.md
+++ b/docs/resources/dsc_scan_rule.md
@@ -1,0 +1,226 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_scan_rule"
+description: |-
+  Manages a DSC scan rule resource within HuaweiCloud.
+---
+
+# huaweicloud_dsc_scan_rule
+
+Manages a DSC scan rule resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a scan rule with rule matching
+
+```hcl
+variable "rule_name" {}
+variable "contents" {
+  type = list(object({
+    effective_mode = string
+    location       = string
+    rule_content   = string
+  }))
+}
+variable "templates" {
+  type = list(object({
+    template_id       = string
+    classification_id = string
+    security_level_id = string
+    is_used           = optional(string, "true")
+  }))
+}
+
+resource "huaweicloud_dsc_scan_rule" "test" {
+  rule_name      = var.rule_name
+  rule_type      = "REGEX"
+  category       = "BUILT_SELF"
+  logic_operator = "AND"
+  match_rate     = 1
+  min_match      = 1
+
+  dynamic "content" {
+    for_each = var.contents
+
+    content {
+      effective_mode = content.value.effective_mode
+      location       = content.value.location
+      rule_content   = content.value.rule_content
+    }
+  }
+
+  dynamic "templates" {
+    for_each = var.templates
+
+    content {
+      template_id       = templates.value.template_id
+      classification_id = templates.value.classification_id
+      security_level_id = templates.value.security_level_id
+      is_used           = templates.value.is_used
+    }
+  }
+}
+```
+
+### Create a scan rule with keyword matching
+
+```hcl
+variable "rule_name" {}
+variable "contents" {
+  type = list(object({
+    rule_content = string
+  }))
+}
+variable "templates" {
+  type = list(object({
+    template_id       = string
+    classification_id = string
+    security_level_id = string
+    is_used           = optional(string, "true")
+  }))
+}
+
+resource "huaweicloud_dsc_scan_rule" "test" {
+  rule_name      = var.rule_name
+  rule_type      = "KEYWORD"
+  category       = "BUILT_SELF"
+  logic_operator = "AND"
+  match_rate     = 1
+  min_match      = 1
+
+  dynamic "content" {
+    for_each = var.contents
+
+    content {
+      effective_mode = "KEYWORD"
+      location       = "CONTENT"
+      rule_content   = content.value.rule_content
+    }
+  }
+
+  dynamic "templates" {
+    for_each = var.templates
+
+    content {
+      template_id       = templates.value.template_id
+      classification_id = templates.value.classification_id
+      security_level_id = templates.value.security_level_id
+      is_used           = templates.value.is_used
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the scan rule is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `rule_name` - (Required, String) Specifies the name of the scan rule.  
+  The maximum length is `255` characters, only letters, Chinese characters, digits, parentheses (`()`), hyphens (`-`),
+  and underscores (`_`) are allowed.
+
+* `rule_type` - (Required, String) Specifies the type of the scan rule.  
+  The valid values are as follows:
+  + **KEYWORD**
+  + **REGEX**
+
+* `category` - (Required, String, NonUpdatable) Specifies the category of the scan rule.  
+  The valid values are as follows:
+  + **BUILT_SELF**: User-defined rule.
+
+* `logic_operator` - (Required, String) Specifies the logic operator of the scan rule.  
+  The valid values are as follows:
+  + **AND**
+  + **OR**
+
+* `match_rate` - (Required, Int) Specifies the match rate of the scan rule.  
+  The valid value ranges from `1` to `100`.
+
+* `min_match` - (Required, Int) Specifies the minimum match count of the scan rule.  
+  The valid value ranges from `1` to `100`.
+
+* `content` - (Required, List) Specifies the content list of the scan rule.  
+  The [content](#dsc_scan_rule_content) structure is documented below.  
+  When the `rule_type` is **KEYWORD**, the `content` block only supports one item.
+
+* `rule_desc` - (Optional, String) Specifies the description of the scan rule.  
+  The description maximum length is `255` characters, only letters, Chinese characters, digits, parentheses (`()`),
+  hyphens (`-`), and underscores (`_`) are allowed.
+
+* `templates` - (Optional, List) Specifies the template list associated with the scan rule.  
+  The [templates](#dsc_scan_rule_templates) structure is documented below.
+
+<a name="dsc_scan_rule_content"></a>
+The `content` block supports:
+
+* `effective_mode` - (Required, String) Specifies the effective mode of the rule content.  
+  The valid values are as follows:
+  + **IN**
+  + **NOT_IN**
+  + **REGEX**
+  + **KEYWORD**
+
+  When the `rule_type` is **KEYWORD**, this parameter must be **KEYWORD**.
+
+* `location` - (Required, String) Specifies the application location of the rule content.  
+  The valid values are as follows:
+  + **NAME**: Column name.
+  + **REMARK**: Column remark.
+  + **CONTENT**: Column content.
+  + **TABLE_NAME**: Table name.
+  + **TABLE_REMARK**: Table remark.
+
+  When the `rule_type` is **KEYWORD**, this parameter must be **CONTENT**.
+
+* `rule_content` - (Required, String) Specifies the content of the rule.  
+  When the `rule_type` is **KEYWORD**, multiple contents are separated by commas (`,`).
+
+<a name="dsc_scan_rule_templates"></a>
+The `templates` block supports:
+
+* `template_id` - (Required, String) Specifies the template ID associated with the rule.
+
+* `classification_id` - (Required, String) Specifies the classification ID associated with the rule.
+
+* `security_level_id` - (Required, String) Specifies the security level ID associated with the rule.
+
+* `is_used` - (Optional, String) Specifies whether the rule is enabled in the template.  
+  The valid values are as follows:
+  + **true**
+  + **false**
+
+  Defaults to **true**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `templates` - The template list associated with the scan rule.  
+  The [templates](#dsc_scan_rule_templates_attr) structure is documented below.
+
+<a name="dsc_scan_rule_templates_attr"></a>
+The `templates` block supports:
+
+* `id` - The ID of the rule template.
+
+* `template_name` - The name of the template.
+
+* `classification_name` - The classification name associated with the rule.
+
+* `security_level_color` - The color number corresponding to the security level.
+
+* `security_level_name` - The name of the security level.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dsc_scan_rule.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5028,6 +5028,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_instance":                       dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_multi_enable_trusted_service":   dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_operate_obs_audit":              dsc.ResourceOperateObsAudit(),
+			"huaweicloud_dsc_scan_rule":                      dsc.ResourceScanRule(),
 			"huaweicloud_dsc_scan_template":                  dsc.ResourceScanTemplate(),
 			"huaweicloud_dsc_scan_template_classification":   dsc.ResourceScanTemplateClassification(),
 			"huaweicloud_dsc_stop_scan_job":                  dsc.ResourceStopScanJob(),

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_scan_rule_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_scan_rule_test.go
@@ -1,0 +1,274 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dsc"
+)
+
+func getScanRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dsc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DSC client: %s", err)
+	}
+
+	return dsc.GetScanRuleById(client, state.Primary.ID)
+}
+
+// Before running the test, please ensure that you have created a DSC instance.
+func TestAccScanRule_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dsc_scan_rule.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getScanRuleResourceFunc)
+
+		rNameImportWithTemplate = "huaweicloud_dsc_scan_rule.import_with_template"
+		rcImportWithTemplate    = acceptance.InitResourceCheck(rNameImportWithTemplate, &obj, getScanRuleResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscSecurityLevelId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rcImportWithTemplate.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScanRule_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "rule_name", name),
+					resource.TestCheckResourceAttr(rName, "rule_type", "REGEX"),
+					resource.TestCheckResourceAttr(rName, "category", "BUILT_SELF"),
+					resource.TestCheckResourceAttr(rName, "logic_operator", "AND"),
+					resource.TestCheckResourceAttr(rName, "match_rate", "1"),
+					resource.TestCheckResourceAttr(rName, "min_match", "1"),
+					resource.TestCheckResourceAttr(rName, "content.#", "2"),
+					resource.TestCheckResourceAttr(rName, "content.0.effective_mode", "NOT_IN"),
+					resource.TestCheckResourceAttr(rName, "content.0.location", "NAME"),
+					resource.TestCheckResourceAttr(rName, "content.0.rule_content", "bphone"),
+					resource.TestCheckResourceAttr(rName, "content.1.effective_mode", "IN"),
+					resource.TestCheckResourceAttr(rName, "content.1.location", "REMARK"),
+					resource.TestCheckResourceAttr(rName, "content.1.rule_content", "telephone number"),
+					resource.TestCheckResourceAttr(rName, "rule_desc", "Created_by_acceptance_test"),
+					resource.TestCheckResourceAttr(rName, "templates.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "templates.0.template_id",
+						"huaweicloud_dsc_scan_template_classification.test.0", "template_id"),
+					resource.TestCheckResourceAttrPair(rName, "templates.0.classification_id",
+						"huaweicloud_dsc_scan_template_classification.test.0", "id"),
+					resource.TestCheckResourceAttr(rName, "templates.0.security_level_id", acceptance.HW_DSC_SECURITY_LEVEL_ID),
+					resource.TestCheckResourceAttr(rName, "templates.0.is_used", "true"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.template_name"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.classification_name"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.security_level_color"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.security_level_name"),
+					resource.TestCheckResourceAttrPair(rName, "templates.1.template_id",
+						"huaweicloud_dsc_scan_template_classification.test.1", "template_id"),
+					resource.TestCheckResourceAttrPair(rName, "templates.1.classification_id",
+						"huaweicloud_dsc_scan_template_classification.test.1", "id"),
+					resource.TestCheckResourceAttr(rName, "templates.1.security_level_id", acceptance.HW_DSC_SECURITY_LEVEL_ID),
+				),
+			},
+			{
+				Config: testAccScanRule_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "rule_name", updateName),
+					resource.TestCheckResourceAttr(rName, "rule_type", "KEYWORD"),
+					resource.TestCheckResourceAttr(rName, "category", "BUILT_SELF"),
+					resource.TestCheckResourceAttr(rName, "logic_operator", "OR"),
+					resource.TestCheckResourceAttr(rName, "match_rate", "10"),
+					resource.TestCheckResourceAttr(rName, "min_match", "10"),
+					resource.TestCheckResourceAttr(rName, "content.#", "1"),
+					resource.TestCheckResourceAttr(rName, "content.0.effective_mode", "KEYWORD"),
+					resource.TestCheckResourceAttr(rName, "content.0.location", "CONTENT"),
+					resource.TestCheckResourceAttr(rName, "content.0.rule_content", "content1,content2,content3"),
+					resource.TestCheckResourceAttr(rName, "rule_desc", "Updated_by_acceptance_test"),
+					resource.TestCheckResourceAttr(rName, "templates.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "templates.0.template_id",
+						"huaweicloud_dsc_scan_template_classification.test.1", "template_id"),
+					resource.TestCheckResourceAttrPair(rName, "templates.0.classification_id",
+						"huaweicloud_dsc_scan_template_classification.test.1", "id"),
+					resource.TestCheckResourceAttr(rName, "templates.0.security_level_id", acceptance.HW_DSC_SECURITY_LEVEL_ID),
+					resource.TestCheckResourceAttrPair(rName, "templates.1.template_id",
+						"huaweicloud_dsc_scan_template_classification.test.2", "template_id"),
+					resource.TestCheckResourceAttrPair(rName, "templates.1.classification_id",
+						"huaweicloud_dsc_scan_template_classification.test.2", "id"),
+					resource.TestCheckResourceAttr(rName, "templates.1.security_level_id", acceptance.HW_DSC_SECURITY_LEVEL_ID),
+					resource.TestCheckResourceAttr(rName, "templates.1.is_used", "false"),
+				),
+			},
+			{
+				Config: testAccScanRule_step3(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "rule_desc", ""),
+					resource.TestCheckResourceAttr(rName, "templates.#", "0"),
+					rcImportWithTemplate.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameImportWithTemplate, "templates.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// The API may return templates in a different order than the configuration, so importing
+			// a resource with multiple templates can cause a plan diff. Cover the import case with
+			// templates configured by using a separate resource that has only one template.
+			{
+				ResourceName:      rNameImportWithTemplate,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Ignore `templates_origin` only for this test, real terraform import is unaffected and will not
+				// cause a configuration drift.
+				ImportStateVerifyIgnore: []string{"templates_origin"},
+			},
+		},
+	})
+}
+
+func testAccScanRule_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_scan_template" "test" {
+  count = 3
+
+  action      = "ADD"
+  name        = "%[1]s_${count.index}"
+  description = "Created_by_terraform_script"
+}
+
+resource "huaweicloud_dsc_scan_template_classification" "test" {
+  count = 3
+
+  template_id         = huaweicloud_dsc_scan_template.test[count.index].id
+  classification_name = "%[1]s"
+}
+`, name)
+}
+
+func testAccScanRule_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_scan_rule" "test" {
+  rule_name      = "%[2]s"
+  rule_type      = "REGEX"
+  category       = "BUILT_SELF"
+  logic_operator = "AND"
+  match_rate     = 1
+  min_match      = 1
+  rule_desc      = "Created_by_acceptance_test"
+
+  content {
+    effective_mode = "NOT_IN"
+    location       = "NAME"
+    rule_content   = "bphone"
+  }
+  content {
+    effective_mode = "IN"
+    location       = "REMARK"
+    rule_content   = "telephone number"
+  }
+
+  dynamic "templates" {
+    for_each = slice(huaweicloud_dsc_scan_template_classification.test[*], 0, 2)
+
+    content {
+      template_id       = templates.value.template_id
+      classification_id = templates.value.id
+      security_level_id = "%[3]s"
+    }
+  }
+}
+`, testAccScanRule_base(name), name, acceptance.HW_DSC_SECURITY_LEVEL_ID)
+}
+
+func testAccScanRule_step2(name, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_scan_rule" "test" {
+  rule_name      = "%[2]s"
+  rule_type      = "KEYWORD"
+  category       = "BUILT_SELF"
+  logic_operator = "OR"
+  match_rate     = 10
+  min_match      = 10
+  rule_desc      = "Updated_by_acceptance_test"
+
+  content {
+    effective_mode = "KEYWORD"
+    location       = "CONTENT"
+    rule_content   = "content1,content2,content3"
+  }
+
+  dynamic "templates" {
+    for_each = slice(huaweicloud_dsc_scan_template_classification.test[*], 1, 3)
+
+    content {
+      template_id       = templates.value.template_id
+      classification_id = templates.value.id
+      security_level_id = "%[3]s"
+      is_used           = "false"
+    }
+  }
+}
+`, testAccScanRule_base(name), updateName, acceptance.HW_DSC_SECURITY_LEVEL_ID)
+}
+
+func testAccScanRule_step3(name, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_scan_rule" "test" {
+  rule_name      = "%[2]s"
+  rule_type      = "KEYWORD"
+  category       = "BUILT_SELF"
+  logic_operator = "OR"
+  match_rate     = 10
+  min_match      = 10
+
+  content {
+    effective_mode = "KEYWORD"
+    location       = "CONTENT"
+    rule_content   = "content1,content2,content3"
+  }
+}
+
+resource "huaweicloud_dsc_scan_rule" "import_with_template" {
+  rule_name      = "%[2]s_import_with_template"
+  rule_type      = "KEYWORD"
+  category       = "BUILT_SELF"
+  logic_operator = "OR"
+  match_rate     = 10
+  min_match      = 10
+
+  content {
+    effective_mode = "KEYWORD"
+    location       = "CONTENT"
+    rule_content   = "content1,content2,content3"
+  }
+
+  templates {
+    template_id       = try(huaweicloud_dsc_scan_template_classification.test[0].template_id, null)
+    classification_id = try(huaweicloud_dsc_scan_template_classification.test[0].id, null)
+    security_level_id = "%[3]s"
+  }
+}
+`, testAccScanRule_base(name), updateName, acceptance.HW_DSC_SECURITY_LEVEL_ID)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_rule.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_rule.go
@@ -1,0 +1,596 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	scanRuleNonUpdatableParams = []string{"category"}
+
+	scanRuleNotFoundErrCodes = []string{
+		"dsc.10000009", // Current instance does not exist.
+	}
+)
+
+// @API DSC POST /v1/{project_id}/scan-rules
+// @API DSC GET /v1/{project_id}/scan-rules
+// @API DSC GET /v1/{project_id}/scan-rules/{rule_id}
+// @API DSC PUT /v1/{project_id}/scan-rules/{rule_id}
+// @API DSC DELETE /v1/{project_id}/scan-rules/{rule_id}
+func ResourceScanRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScanRuleCreate,
+		ReadContext:   resourceScanRuleRead,
+		UpdateContext: resourceScanRuleUpdate,
+		DeleteContext: resourceScanRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(scanRuleNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the scan rule is located.`,
+			},
+
+			// Required parameters.
+			"rule_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the scan rule.`,
+			},
+			"rule_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the scan rule.`,
+			},
+			"category": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The category of the scan rule.`,
+			},
+			"logic_operator": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The logic operator of the scan rule.`,
+			},
+			"match_rate": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The match rate of the scan rule.`,
+			},
+			"min_match": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The minimum match count of the scan rule.`,
+			},
+			"content": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        scanRuleContentSchema(),
+				Description: `The content list of the scan rule.`,
+			},
+
+			// Optional parameters.
+			"rule_desc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the scan rule.`,
+			},
+			"templates": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        scanRuleTemplateSchema(),
+				Description: `The template list associated with the scan rule.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+
+			// Internal attributes.
+			"templates_origin": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"template_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The template ID associated with the rule.`,
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+ the new value next time the change is made. The corresponding parameter name is 'templates'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func scanRuleContentSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"effective_mode": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The effective mode of the rule content.`,
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The application location of the rule content.`,
+			},
+			"rule_content": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The content of the rule.`,
+			},
+		},
+	}
+}
+
+func scanRuleTemplateSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"template_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The template ID associated with the rule.`,
+			},
+			"classification_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The classification ID associated with the rule.`,
+			},
+			"security_level_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The security level ID associated with the rule.`,
+			},
+
+			// Optional parameters.
+			"is_used": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  `Whether the rule is enabled in the template.`,
+			},
+
+			// Attributes.
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the rule template.`,
+			},
+			"template_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the template.`,
+			},
+			"classification_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The classification name associated with the rule.`,
+			},
+			"security_level_color": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The color number corresponding to the security level.`,
+			},
+			"security_level_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the security level.`,
+			},
+		},
+	}
+}
+
+func buildScanRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := utils.RemoveNil(map[string]interface{}{
+		// Required parameters.
+		"rule_name":      d.Get("rule_name"),
+		"rule_type":      d.Get("rule_type"),
+		"category":       d.Get("category"),
+		"logic_operator": d.Get("logic_operator"),
+		"match_rate":     d.Get("match_rate"),
+		"min_match":      d.Get("min_match"),
+		"content":        buildScanRuleContentBodyParams(d.Get("content").([]interface{})),
+		// Optional parameters.
+		"rule_desc": utils.ValueIgnoreEmpty(d.Get("rule_desc")),
+		"templates": buildScanRuleTemplatesBodyParams(d.Get("templates").([]interface{})),
+	})
+
+	// When 'templates' field is not specified, the API must receive an empty list.
+	if _, ok := params["templates"]; !ok {
+		params["templates"] = make([]map[string]interface{}, 0)
+	}
+
+	return params
+}
+
+func buildScanRuleContentBodyParams(contents []interface{}) []map[string]interface{} {
+	if len(contents) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(contents))
+	for _, v := range contents {
+		rst = append(rst, map[string]interface{}{
+			"effective_mode": utils.PathSearch("effective_mode", v, nil),
+			"location":       utils.PathSearch("location", v, nil),
+			"rule_content":   utils.PathSearch("rule_content", v, nil),
+		})
+	}
+	return rst
+}
+
+func buildScanRuleTemplatesBodyParams(templates []interface{}) []map[string]interface{} {
+	if len(templates) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(templates))
+	for _, v := range templates {
+		rst = append(rst, map[string]interface{}{
+			"template_id":       utils.PathSearch("template_id", v, nil),
+			"classification_id": utils.PathSearch("classification_id", v, nil),
+			"security_level_id": utils.PathSearch("security_level_id", v, nil),
+			"is_used":           utils.ValueIgnoreEmpty(convertStringToBool(utils.PathSearch("is_used", v, "").(string))),
+		})
+	}
+
+	return rst
+}
+
+func convertStringToBool(str string) interface{} {
+	if str == "" {
+		return nil
+	}
+
+	boolValue, err := strconv.ParseBool(str)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert string (%s) to boolean: %s", str, err)
+		return nil
+	}
+
+	return boolValue
+}
+
+func createScanRule(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/scan-rules"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildScanRuleBodyParams(d),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func resourceScanRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		ruleName = d.Get("rule_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = createScanRule(client, d)
+	if err != nil {
+		return diag.Errorf("error creating scan rule (%s): %s", ruleName, err)
+	}
+
+	respBody, err := listScanRules(client)
+	if err != nil {
+		return diag.Errorf("error getting the scan rules: %s", err)
+	}
+
+	ruleId := utils.PathSearch(fmt.Sprintf("scan_rules_list[?rule_name=='%s']|[0].rule_id", ruleName), respBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the ID to the scan rule (%s) from API response", ruleName)
+	}
+
+	d.SetId(ruleId)
+
+	err = d.Set("templates_origin", refreshScanRuleTemplateOrigin(utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "templates")))
+	if err != nil {
+		return diag.Errorf("unable to refresh 'templates_origin' values: %s", err)
+	}
+
+	return resourceScanRuleRead(ctx, d, meta)
+}
+
+func refreshScanRuleTemplateOrigin(scriptTemplates interface{}) []interface{} {
+	templates, ok := scriptTemplates.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	rest := make([]interface{}, 0, len(templates))
+	for _, v := range templates {
+		rest = append(rest, map[string]interface{}{
+			"template_id": utils.PathSearch("template_id", v, nil),
+		})
+	}
+
+	return rest
+}
+
+func listScanRules(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v1/{project_id}/scan-rules"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func GetScanRuleById(client *golangsdk.ServiceClient, ruleId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/scan-rules/{rule_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", ruleId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceScanRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		ruleId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	respBody, err := GetScanRuleById(client, ruleId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", scanRuleNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving scan rule (%s)", ruleId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rule_name", utils.PathSearch("rule_name", respBody, nil)),
+		d.Set("rule_type", utils.PathSearch("rule_type", respBody, nil)),
+		d.Set("category", utils.PathSearch("category", respBody, nil)),
+		d.Set("logic_operator", utils.PathSearch("logic_operator", respBody, nil)),
+		d.Set("match_rate", utils.PathSearch("match_rate", respBody, nil)),
+		d.Set("min_match", utils.PathSearch("min_match", respBody, nil)),
+		d.Set("content", flattenScanRuleContent(utils.PathSearch("content", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("rule_desc", utils.PathSearch("rule_desc", respBody, nil)),
+		d.Set("templates", flattenScanRuleTemplates(
+			utils.PathSearch("templates", respBody, make([]interface{}, 0)).([]interface{}),
+			d.Get("templates_origin").([]interface{})),
+		),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenScanRuleContent(contents []interface{}) []map[string]interface{} {
+	if len(contents) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(contents))
+	for _, v := range contents {
+		rst = append(rst, map[string]interface{}{
+			"effective_mode": utils.PathSearch("effective_mode", v, nil),
+			"location":       utils.PathSearch("location", v, nil),
+			"rule_content":   utils.PathSearch("rule_content", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenScanRuleTemplates(templates []interface{}, templatesOrigin []interface{}) []map[string]interface{} {
+	if len(templates) < 1 {
+		return nil
+	}
+
+	associatedTemplates := make([]map[string]interface{}, 0, len(templates))
+	for _, v := range templates {
+		associatedTemplates = append(associatedTemplates, map[string]interface{}{
+			// Required parameters.
+			"template_id":       utils.PathSearch("template_id", v, nil),
+			"classification_id": utils.PathSearch("classification_id", v, nil),
+			"security_level_id": utils.PathSearch("security_level_id", v, nil),
+			"is_used":           strconv.FormatBool(utils.PathSearch("is_used", v, false).(bool)),
+			// Attributes.
+			"id":                   utils.PathSearch("id", v, nil),
+			"classification_name":  utils.PathSearch("classification_name", v, nil),
+			"security_level_color": utils.PathSearch("security_level_color", v, nil),
+			"security_level_name":  utils.PathSearch("security_level_name", v, nil),
+			"template_name":        utils.PathSearch("template_name", v, nil),
+		})
+	}
+
+	return orderScanRuleTemplatesByTemplatesOrigin(associatedTemplates, templatesOrigin)
+}
+
+func orderScanRuleTemplatesByTemplatesOrigin(templates []map[string]interface{}, templatesOrigin []interface{}) []map[string]interface{} {
+	if len(templatesOrigin) < 1 {
+		return templates
+	}
+
+	sortedTemplates := make([]map[string]interface{}, 0, len(templates))
+	templatesCopy := templates
+	for _, templateOrigin := range templatesOrigin {
+		templateIdOrigin := utils.PathSearch("template_id", templateOrigin, "").(string)
+		for index, template := range templatesCopy {
+			if utils.PathSearch("template_id", template, "").(string) != templateIdOrigin {
+				continue
+			}
+
+			sortedTemplates = append(sortedTemplates, templatesCopy[index])
+			templatesCopy = append(templatesCopy[:index], templatesCopy[index+1:]...)
+			break
+		}
+	}
+
+	// Add any remaining unsorted templates to the end of the sorted list.
+	sortedTemplates = append(sortedTemplates, templatesCopy...)
+	return sortedTemplates
+}
+
+func updateScanRule(client *golangsdk.ServiceClient, ruleId string, params map[string]interface{}) error {
+	httpUrl := "v1/{project_id}/scan-rules/{rule_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{rule_id}", ruleId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         params,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceScanRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		ruleId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateScanRule(client, ruleId, buildScanRuleBodyParams(d))
+		if err != nil {
+			return diag.Errorf("error updating scan rule (%s): %s", ruleId, err)
+		}
+
+		err = d.Set("templates_origin", refreshScanRuleTemplateOrigin(utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "templates")))
+		if err != nil {
+			return diag.Errorf("unable to refresh 'templates_origin' values: %s", err)
+		}
+	}
+
+	return resourceScanRuleRead(ctx, d, meta)
+}
+
+func deleteScanRule(client *golangsdk.ServiceClient, ruleId string) error {
+	httpUrl := "v1/{project_id}/scan-rules/{rule_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{rule_id}", ruleId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceScanRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = deleteScanRule(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", scanRuleNotFoundErrCodes...),
+			fmt.Sprintf("error deleting scan rule (%v)", d.Get("rule_name")))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage scan rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dsc -f TestAccScanRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccScanRule_basic -timeout 360m -parallel 10
=== RUN   TestAccScanRule_basic
=== PAUSE TestAccScanRule_basic
=== CONT  TestAccScanRule_basic
--- PASS: TestAccScanRule_basic (32.70s)
PASS
coverage: 13.3% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       32.848s coverage: 13.3% of statements in ./huaweicloud/services/dsc
```
<img width="1019" height="62" alt="image" src="https://github.com/user-attachments/assets/923f8dd1-5021-42bb-89d3-202532deefb7" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1283" height="776" alt="image" src="https://github.com/user-attachments/assets/a403e545-7e12-40cb-879c-5e373f32a125" />

    ab. Related resources (parent resources) not found
     The instance does not exist.
     <img width="1444" height="844" alt="image" src="https://github.com/user-attachments/assets/511db6ee-73ad-46f1-9499-e0bb4ac3a379" />


  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1205" height="797" alt="image" src="https://github.com/user-attachments/assets/5d0ec225-d3ef-4e7f-b5a0-c89a94372e7e" />

    bb. Related resources (parent resources) not found
    The instance does not exist.
    <img width="1444" height="844" alt="image" src="https://github.com/user-attachments/assets/511db6ee-73ad-46f1-9499-e0bb4ac3a379" />
