### PR TITLE
fix(kafka): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic.go
@@ -466,10 +466,12 @@ func resourceTopicUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
-	instanceId := d.Get("instance_id").(string)
-	err = updateTopic(client, instanceId, buildUpdateTopicBodyParams(d))
-	if err != nil {
-		return diag.Errorf("error updating topic (%s) of the kafka instance (%s): %s", d.Id(), instanceId, err)
+	if d.HasChangeExcept("enable_force_new") {
+		instanceId := d.Get("instance_id").(string)
+		err = updateTopic(client, instanceId, buildUpdateTopicBodyParams(d))
+		if err != nil {
+			return diag.Errorf("error updating topic (%s) of the kafka instance (%s): %s", d.Id(), instanceId, err)
+		}
 	}
 
 	return resourceTopicRead(ctx, d, meta)

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic_quota.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic_quota.go
@@ -245,36 +245,38 @@ func resourceTopicQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
-	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
-	httpUrl = strings.ReplaceAll(httpUrl, "{instance_id}", instanceId)
-	updatePath := client.Endpoint + httpUrl
+	if d.HasChanges("consumer_byte_rate", "producer_byte_rate") {
+		httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
+		httpUrl = strings.ReplaceAll(httpUrl, "{instance_id}", instanceId)
+		updatePath := client.Endpoint + httpUrl
 
-	opt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=utf-8",
-		},
-		JSONBody: utils.RemoveNil(buildTopicQuotaBodyParams(d)),
-	}
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json;charset=utf-8",
+			},
+			JSONBody: utils.RemoveNil(buildTopicQuotaBodyParams(d)),
+		}
 
-	resp, err := client.Request("PUT", updatePath, &opt)
-	if err != nil {
-		return diag.Errorf("error updating topic (%s) quota of the instance (%s): %s", topic, instanceId, err)
-	}
+		resp, err := client.Request("PUT", updatePath, &opt)
+		if err != nil {
+			return diag.Errorf("error updating topic (%s) quota of the instance (%s): %s", topic, instanceId, err)
+		}
 
-	respBody, err := utils.FlattenResponse(resp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
-	jobId := utils.PathSearch("job_id", respBody, "").(string)
-	if jobId == "" {
-		return diag.Errorf("unable to find the job ID from the API response")
-	}
+		jobId := utils.PathSearch("job_id", respBody, "").(string)
+		if jobId == "" {
+			return diag.Errorf("unable to find the job ID from the API response")
+		}
 
-	err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutUpdate))
-	if err != nil {
-		return diag.Errorf("error waiting for the topic (%s) quota of the instance (%s) to be updated: %s", topic, instanceId, err)
+		err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.Errorf("error waiting for the topic (%s) quota of the instance (%s) to be updated: %s", topic, instanceId, err)
+		}
 	}
 
 	return resourceTopicQuotaRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add the `d.HasChangeExcept` or `d.HasChanges` constraint to the update method.
+ When only enable_force_new is changed, skip the update logic to avoid sending unnecessary requests.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccTopic_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccTopic_basic -timeout 360m -parallel 10
=== RUN   TestAccTopic_basic
=== PAUSE TestAccTopic_basic
=== CONT  TestAccTopic_basic
--- PASS: TestAccTopic_basic (30.88s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     31.151s coverage: 4.9% of statements in ./huaweicloud/services/kafka
```

```
./scripts/coverage.sh -o kafka -f TestAccTopicQuota_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccTopicQuota_basic -timeout 360m -parallel 10
=== RUN   TestAccTopicQuota_basic
=== PAUSE TestAccTopicQuota_basic
=== CONT  TestAccTopicQuota_basic
--- PASS: TestAccTopicQuota_basic (104.16s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     104.354s        coverage: 6.9% of statements in ./huaweicloud/services/kafka
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
