### PR TITLE
fix(apig): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
@@ -2013,17 +2013,20 @@ func resourceApiUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	body, err := buildApiBodyParams(d)
-	if err != nil {
-		return diag.Errorf("unable to build the API updateOpts: %s", err)
-	}
+	// Skip the update request when only enable_force_new is changed.
+	if d.HasChangeExcept("enable_force_new") {
+		body, err := buildApiBodyParams(d)
+		if err != nil {
+			return diag.Errorf("unable to build the API updateOpts: %s", err)
+		}
 
-	if err = updateApi(client, instanceId, apiId, body); err != nil {
-		return diag.Errorf("error updating API (%s): %s", apiId, err)
-	}
+		if err = updateApi(client, instanceId, apiId, body); err != nil {
+			return diag.Errorf("error updating API (%s): %s", apiId, err)
+		}
 
-	if err = updateAllOriginParameters(d); err != nil {
-		return diag.Errorf("error updating all origin parameters: %s", err)
+		if err = updateAllOriginParameters(d); err != nil {
+			return diag.Errorf("error updating all origin parameters: %s", err)
+		}
 	}
 
 	return resourceApiRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_batch_plugins_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_batch_plugins_associate.go
@@ -377,37 +377,40 @@ func resourceApiBatchPluginsAssociateUpdate(ctx context.Context, d *schema.Resou
 		originPluginIdsList  = d.Get("plugin_ids_origin").([]interface{})
 	)
 
-	// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
-	// failed)
-	config.MutexKV.Lock(resourceId)
-	defer config.MutexKV.Unlock(resourceId)
+	// Skip the update request when only enable_force_new is changed.
+	if d.HasChangeExcept("enable_force_new") {
+		// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
+		// failed)
+		config.MutexKV.Lock(resourceId)
+		defer config.MutexKV.Unlock(resourceId)
 
-	newPluginIds := utils.FindSliceElementsNotInAnother(scriptPluginIdsList, consolePluginIdsList)
-	rmPluginIds := utils.FindSliceElementsNotInAnother(originPluginIdsList, scriptPluginIdsList)
+		newPluginIds := utils.FindSliceElementsNotInAnother(scriptPluginIdsList, consolePluginIdsList)
+		rmPluginIds := utils.FindSliceElementsNotInAnother(originPluginIdsList, scriptPluginIdsList)
 
-	if len(rmPluginIds) > 0 {
-		log.Printf("[DEBUG] Prepare to unbind the specified plugin IDs: %v", rmPluginIds)
-		err := unbindPluginsFromApis(client, instanceId, apiId, envId, rmPluginIds)
-		if err != nil {
-			return diag.FromErr(err)
+		if len(rmPluginIds) > 0 {
+			log.Printf("[DEBUG] Prepare to unbind the specified plugin IDs: %v", rmPluginIds)
+			err := unbindPluginsFromApis(client, instanceId, apiId, envId, rmPluginIds)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
 
-	if len(newPluginIds) > 0 {
-		log.Printf("[DEBUG] Prepare to bind the specified plugin IDs: %v", newPluginIds)
-		err = bindPluginsToApi(client, instanceId, apiId, envId, newPluginIds)
-		if err != nil {
-			return diag.FromErr(err)
+		if len(newPluginIds) > 0 {
+			log.Printf("[DEBUG] Prepare to bind the specified plugin IDs: %v", newPluginIds)
+			err = bindPluginsToApi(client, instanceId, apiId, envId, newPluginIds)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
 
-	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
-	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
-	// And whether corresponding parameters are changed, the origin values must be refreshed.
-	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForApiBatchPluginsAssociate)
-	if err != nil {
-		// Don't fail the update if origin refresh fails
-		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
+		// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+		// And whether corresponding parameters are changed, the origin values must be refreshed.
+		err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForApiBatchPluginsAssociate)
+		if err != nil {
+			// Don't fail the update if origin refresh fails
+			log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		}
 	}
 
 	return resourceApiBatchPluginsAssociateRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member.go
@@ -296,19 +296,22 @@ func resourceChannelMemberUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	// Lock the resource to prevent concurrent updates (error APIG.9999 will be returned if the database data synchronize
-	// failed)
-	config.MutexKV.Lock(lockInfo)
-	defer config.MutexKV.Unlock(lockInfo)
+	// Skip the update request when only enable_force_new is changed.
+	if d.HasChangeExcept("enable_force_new") {
+		// Lock the resource to prevent concurrent updates (error APIG.9999 will be returned if the database data synchronize
+		// failed)
+		config.MutexKV.Lock(lockInfo)
+		defer config.MutexKV.Unlock(lockInfo)
 
-	// The old update API: PUT /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members
-	// The legacy update API cannot update a single entity within the group; it can only perform a full replacement of the
-	// entire instance group.
-	// The new update API: POST /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members
-	// The new API can modify one item by unique index (instance_id, vpc_channel_id, member_group_name, host, port)
-	err = updateChannelMember(client, instanceId, vpcChannelId, d)
-	if err != nil {
-		return diag.Errorf("error updating channel member (%s): %s", d.Id(), err)
+		// The old update API: PUT /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members
+		// The legacy update API cannot update a single entity within the group; it can only perform a full replacement of the
+		// entire instance group.
+		// The new update API: POST /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members
+		// The new API can modify one item by unique index (instance_id, vpc_channel_id, member_group_name, host, port)
+		err = updateChannelMember(client, instanceId, vpcChannelId, d)
+		if err != nil {
+			return diag.Errorf("error updating channel member (%s): %s", d.Id(), err)
+		}
 	}
 
 	return resourceChannelMemberRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member_group.go
@@ -328,9 +328,12 @@ func resourceChannelMemberGroupUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	err = updateChannelMemberGroup(client, instanceId, vpcChannelId, memberGroupId, d)
-	if err != nil {
-		return diag.Errorf("error updating member group (%s): %s", memberGroupId, err)
+	// Skip the update request when only enable_force_new is changed.
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateChannelMemberGroup(client, instanceId, vpcChannelId, memberGroupId, d)
+		if err != nil {
+			return diag.Errorf("error updating member group (%s): %s", memberGroupId, err)
+		}
 	}
 
 	return resourceChannelMemberGroupRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_global_certificate_batch_domains_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_global_certificate_batch_domains_associate.go
@@ -251,10 +251,9 @@ func flattenGlobalCertificateAssociatedDomains(domains []interface{}) []interfac
 
 func resourceGlobalCertificateBatchDomainsAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg                 = meta.(*config.Config)
-		region              = cfg.GetRegion(d)
-		certificateId       = d.Get("certificate_id").(string)
-		addRaws, removeRaws = getUpdateCertificateBatchDomainsAssociateDomainNames(d, "verify_disabled_domain_names")
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		certificateId = d.Get("certificate_id").(string)
 	)
 
 	client, err := cfg.NewServiceClient("apig", region)
@@ -262,26 +261,30 @@ func resourceGlobalCertificateBatchDomainsAssociateUpdate(ctx context.Context, d
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	// Must disassociate domains first, prevent the bound data from containing domains to be unbound.
-	if len(removeRaws) > 0 {
-		if err = disassociateDomainsFromCertificate(client, certificateId, buildGlobalCertificateAssociatedDomains(removeRaws)); err != nil {
-			return diag.FromErr(err)
+	// Skip the update request when only enable_force_new is changed.
+	if d.HasChangeExcept("enable_force_new") {
+		addRaws, removeRaws := getUpdateCertificateBatchDomainsAssociateDomainNames(d, "verify_disabled_domain_names")
+		// Must disassociate domains first, prevent the bound data from containing domains to be unbound.
+		if len(removeRaws) > 0 {
+			if err = disassociateDomainsFromCertificate(client, certificateId, buildGlobalCertificateAssociatedDomains(removeRaws)); err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
 
-	if len(addRaws) > 0 {
-		if err = associateDomainsToCertificate(client, certificateId, buildGlobalCertificateAssociatedDomains(addRaws)); err != nil {
-			return diag.FromErr(err)
+		if len(addRaws) > 0 {
+			if err = associateDomainsToCertificate(client, certificateId, buildGlobalCertificateAssociatedDomains(addRaws)); err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
 
-	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
-	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
-	// And whether corresponding parameters are changed, the origin values must be refreshed.
-	err = utils.RefreshSliceParamOriginValues(d, globalCertificateBatchDomainsAssociateStrSliceParamKeys)
-	if err != nil {
-		// Don't fail the update if origin refresh fails
-		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
+		// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+		// And whether corresponding parameters are changed, the origin values must be refreshed.
+		err = utils.RefreshSliceParamOriginValues(d, globalCertificateBatchDomainsAssociateStrSliceParamKeys)
+		if err != nil {
+			// Don't fail the update if origin refresh fails
+			log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		}
 	}
 
 	return resourceGlobalCertificateBatchDomainsAssociateRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group_domain_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group_domain_associate.go
@@ -255,34 +255,37 @@ func resourceGroupDomainAssociateUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	// Get domain ID if the value of attribute 'domain_id' is empty.
-	if domainId == "" {
-		urlDomain := d.Get("url_domain").(string)
-		associateInfo, err := GetGroupAssociatedDomainByUrl(client, instanceId, groupId, urlDomain)
-		if err != nil {
-			return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying the associated domain information (%s)", urlDomain))
+	// Skip the update request when only enable_force_new is changed.
+	if d.HasChangeExcept("enable_force_new") {
+		// Get domain ID if the value of attribute 'domain_id' is empty.
+		if domainId == "" {
+			urlDomain := d.Get("url_domain").(string)
+			associateInfo, err := GetGroupAssociatedDomainByUrl(client, instanceId, groupId, urlDomain)
+			if err != nil {
+				return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying the associated domain information (%s)", urlDomain))
+			}
+			domainId = utils.PathSearch("id", associateInfo, "").(string)
 		}
-		domainId = utils.PathSearch("id", associateInfo, "").(string)
-	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
-	updatePath = strings.ReplaceAll(updatePath, "{group_id}", groupId)
-	updatePath = strings.ReplaceAll(updatePath, "{domain_id}", domainId)
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
+		updatePath = strings.ReplaceAll(updatePath, "{group_id}", groupId)
+		updatePath = strings.ReplaceAll(updatePath, "{domain_id}", domainId)
 
-	opt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-		JSONBody: utils.RemoveNil(buildDomainAssociateUpdateBodyParams(d)),
-	}
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildDomainAssociateUpdateBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &opt)
-	if err != nil {
-		return diag.Errorf("error updating associate configuration for the domain (%s) and the API group (%s): %s",
-			domainId, groupId, err)
+		_, err = client.Request("PUT", updatePath, &opt)
+		if err != nil {
+			return diag.Errorf("error updating associate configuration for the domain (%s) and the API group (%s): %s",
+				domainId, groupId, err)
+		}
 	}
 	return resourceGroupDomainAssociateRead(ctx, d, meta)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix(apig): skip update logic when only 'enable_force_new' changes
This modification covers 9 resources under the APIG service. The Update logic is now skipped when only the enable_force_new attribute is modified for these resources. Since enable_force_new is a meta-field used solely for testing or controlling resource recreation behavior, and is not an actual business parameter for the backend API, passing it to the Update interface results in unnecessary API calls or potential errors. This fix ensures that no invalid backend update operations are triggered when only this field is changed, thereby improving the robustness and idempotency of the Provider.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
This change affects the Update workflow of 9 resources under the APIG service and does not impact Create, Delete, or Read operations.
No Schema or documentation updates are involved.
Please pay special attention to reviewing the change detection logic for enable_force_new in the Update functions of these 9 resources to ensure consistency and completeness, avoiding missing other similar meta-fields.

When updating both enable_force_new and an updatable field simultaneously for the huaweicloud_apig_api resource, the PUT update API was invoked as expected. The screenshot is shown below:
<img width="1504" height="995" alt="image" src="https://github.com/user-attachments/assets/e975b39d-c1a0-4af1-8b70-49d5b4894459" />

When updating only enable_force_new for the huaweicloud_apig_api resource, the PUT update API was not invoked. This behavior meets the requirements. The screenshot is shown below:
<img width="1490" height="1001" alt="image" src="https://github.com/user-attachments/assets/c29502b6-da13-47c3-900e-b375a46afbad" />

When updating both the enable_force_new and plugin_ids parameters of the huaweicloud_apig_api_batch_plugins_associate resource, the PUT update API was invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1433" height="1002" alt="image" src="https://github.com/user-attachments/assets/3287301b-6e36-4cc2-ad1d-21cfb90a1b8f" />

When updating only the enable_force_new parameter of the huaweicloud_apig_api_batch_plugins_associate resource, the PUT update API was not invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1426" height="993" alt="image" src="https://github.com/user-attachments/assets/ad2912e9-9bc3-4df3-b339-26d37d169193" />

When updating both the enable_force_new and status parameters of the huaweicloud_apig_channel_member resource, the POST update API was invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1487" height="1001" alt="image" src="https://github.com/user-attachments/assets/9aa3c30a-2157-4e60-ae60-14809b6dfb84" />

When updating only the enable_force_new parameter of the huaweicloud_apig_channel_member resource, the POST update API was not invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1457" height="1000" alt="image" src="https://github.com/user-attachments/assets/edf95d23-dbad-4e16-af8e-38aa7061782b" />

When updating both the enable_force_new and description parameters of the huaweicloud_apig_channel_member_group resource, the PUT update API was invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1464" height="1003" alt="image" src="https://github.com/user-attachments/assets/648c32b2-aeb3-406e-9bb2-c34631ec61c9" />

When updating only the enable_force_new parameter of the huaweicloud_apig_channel_member_group resource, the PUT update API was not invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1466" height="1003" alt="image" src="https://github.com/user-attachments/assets/0bf681da-f6f4-42e5-8ae2-cb49d80f4a27" />

When updating both the enable_force_new and verify_disabled_domain_names parameters of the huaweicloud_apig_global_certificate_batch_domains_associate resource, the POST update API was invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1575" height="1000" alt="image" src="https://github.com/user-attachments/assets/1b5cb3e3-7008-44cd-9feb-7717757aa447" />

When updating only the enable_force_new parameter of the huaweicloud_apig_global_certificate_batch_domains_associate resource, the POST update API was not invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1565" height="1005" alt="image" src="https://github.com/user-attachments/assets/9c5580c5-9f9c-46ce-935b-5b7206ab889d" />

When updating both the enable_force_new and ingress_http_port parameters of the huaweicloud_apig_group_domain_associate resource, the PUT update API was invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1468" height="1001" alt="image" src="https://github.com/user-attachments/assets/3f782e4f-6833-450e-87d6-10e3d2ac9c08" />

When updating only the enable_force_new parameter of the huaweicloud_apig_group_domain_associate resource, the PUT update API was not invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1480" height="1009" alt="image" src="https://github.com/user-attachments/assets/9bfed6f8-4079-413f-b6b9-4f811d3f3acb" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
bug-fix(apig): skip backend update call when only `enable_force_new` is changed across 9 APIG resources
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
