### PR TITLE
feat(dsc): add data source to dsc watermark embed logs

### DIFF
--- a/docs/data-sources/dsc_watermark_embed_logs.md
+++ b/docs/data-sources/dsc_watermark_embed_logs.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_watermark_embed_logs"
+description: |-
+  Use this data source to get the list of watermark injection task logs within HuaweiCloud.
+---
+
+# huaweicloud_dsc_watermark_embed_logs
+
+Use this data source to get the list of watermark injection task logs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_watermark_embed_logs" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `water_mark_embed_logs` - The list of watermark injection task logs.
+
+  The [water_mark_embed_logs](#water_mark_embed_logs_struct) structure is documented below.
+
+<a name="water_mark_embed_logs_struct"></a>
+The `water_mark_embed_logs` block supports:
+
+* `blind_watermark` - The blind watermark content.
+
+* `dest_url` - The destination URL.
+
+* `doc_path` - The document path.
+
+* `download_url` - The download URL.
+
+* `file_exist` - Whether the file exists.
+
+* `file_url` - The file URL.
+
+* `finish_num` - The number of finished files.
+
+* `project_id` - The project ID.
+
+* `remark` - The remark.
+
+* `state` - The task status.
+
+* `task_id` - The task ID.
+
+* `task_name` - The task name.
+
+* `total_file_num` - The total number of files.
+
+* `visible_watermark` - The visible watermark content.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1465,6 +1465,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_top_risky_assets":                 dsc.DataSourceDscTopRiskyAssets(),
 			"huaweicloud_dsc_user_list":                        dsc.DataSourceDscUserList(),
 			"huaweicloud_dsc_vpc_ep_quotas":                    dsc.DataSourceDscVpcEpQuotas(),
+			"huaweicloud_dsc_watermark_embed_logs":             dsc.DataSourceDscWatermarkEmbedLogs(),
 			"huaweicloud_dsc_watermark_extract_logs":           dsc.DataSourceWatermarkExtractLogs(),
 
 			// EventGrid

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_watermark_embed_logs_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_watermark_embed_logs_test.go
@@ -1,0 +1,47 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscWatermarkEmbedLogs_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_watermark_embed_logs.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDscWatermarkEmbedLogs_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.dest_url"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.doc_path"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.file_exist"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.file_url"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.finish_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.state"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.task_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.task_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "water_mark_embed_logs.0.total_file_num"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceDscWatermarkEmbedLogs_basic = `
+data "huaweicloud_dsc_watermark_embed_logs" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_watermark_embed_logs.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_watermark_embed_logs.go
@@ -1,0 +1,191 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/sdg/watermark/embed-logs
+func DataSourceDscWatermarkEmbedLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscWatermarkEmbedLogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"water_mark_embed_logs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dscWatermarkEmbedLogSchema(),
+			},
+		},
+	}
+}
+
+func dscWatermarkEmbedLogSchema() *schema.Resource {
+	sc := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"blind_watermark": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dest_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"doc_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"download_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_exist": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"file_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"finish_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"remark": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"task_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"task_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"total_file_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"visible_watermark": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+
+	return sc
+}
+
+func buildDscWatermarkEmbedLogsQueryParams(limit, offset int) string {
+	return fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+}
+
+func dataSourceDscWatermarkEmbedLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v1/{project_id}/sdg/watermark/embed-logs"
+		limit   = 1000
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	for {
+		currentPath := requestPath + buildDscWatermarkEmbedLogsQueryParams(limit, offset)
+		requestOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		requestResp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DSC watermark embed logs: %s", err)
+		}
+
+		requestRespBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		itemsList := utils.PathSearch("water_mark_log", requestRespBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, itemsList...)
+		if len(itemsList) < limit {
+			break
+		}
+		offset += len(itemsList)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("water_mark_embed_logs", flattenDscWatermarkEmbedLogs(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDscWatermarkEmbedLogs(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"blind_watermark":   utils.PathSearch("blind_watermark", v, nil),
+			"dest_url":          utils.PathSearch("dest_url", v, nil),
+			"doc_path":          utils.PathSearch("doc_path", v, nil),
+			"download_url":      utils.PathSearch("download_url", v, nil),
+			"file_exist":        utils.PathSearch("file_exist", v, nil),
+			"file_url":          utils.PathSearch("file_url", v, nil),
+			"finish_num":        utils.PathSearch("finish_num", v, nil),
+			"project_id":        utils.PathSearch("project_id", v, nil),
+			"remark":            utils.PathSearch("remark", v, nil),
+			"state":             utils.PathSearch("state", v, nil),
+			"task_id":           utils.PathSearch("task_id", v, nil),
+			"task_name":         utils.PathSearch("task_name", v, nil),
+			"total_file_num":    utils.PathSearch("total_file_num", v, nil),
+			"visible_watermark": utils.PathSearch("visible_watermark", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to dsc watermark embed logs
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to dsc watermark embed logs
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dsc -f TestAccDataSourceDscWatermarkEmbedLogs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscWatermarkEmbedLogs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscWatermarkEmbedLogs_basic
=== PAUSE TestAccDataSourceDscWatermarkEmbedLogs_basic
=== CONT  TestAccDataSourceDscWatermarkEmbedLogs_basic
--- PASS: TestAccDataSourceDscWatermarkEmbedLogs_basic (23.89s)
PASS
coverage: 6.4% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       24.004s coverage: 6.4% of statements in ./huaweicloud/services/dsc
```
<img width="981" height="25" alt="image" src="https://github.com/user-attachments/assets/be13fd67-4f6e-4ab7-ab4d-053bf2926f7a" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
