### PR TITLE
fix(dataarts): define the trigger boundaries of enable_force_new

### DIFF
--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_aggregation_logic_table.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_aggregation_logic_table.go
@@ -967,19 +967,22 @@ func resourceArchitectureAggregationLogicTableUpdate(ctx context.Context, d *sch
 		return diag.Errorf("error creating DataArts Studio Client: %s", err)
 	}
 
-	if err := updateArchitectureAggregationLogicTable(client, d); err != nil {
-		return diag.Errorf("error updating aggregation logic table (%s): %s", d.Id(), err)
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		isTableAttributesChanged := d.HasChange("table_attributes")
+		if err := updateArchitectureAggregationLogicTable(client, d); err != nil {
+			return diag.Errorf("error updating aggregation logic table (%s): %s", d.Id(), err)
+		}
 
-	if d.HasChange("table_attributes") {
-		// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
-		// '_origin' attributes for subsequent determination and construction of the request body during next updates.
-		// And whether corresponding parameters are changed, the origin values must be refreshed.
-		err = d.Set("table_attributes_origin", refreshTableAttributesOrigin(utils.GetNestedObjectFromRawConfig(d.GetRawConfig(),
-			"table_attributes")))
-		if err != nil {
-			// Don't report an error if origin refresh fails
-			log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		if isTableAttributesChanged {
+			// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
+			// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+			// And whether corresponding parameters are changed, the origin values must be refreshed.
+			err = d.Set("table_attributes_origin", refreshTableAttributesOrigin(utils.GetNestedObjectFromRawConfig(d.GetRawConfig(),
+				"table_attributes")))
+			if err != nil {
+				// Don't report an error if origin refresh fails
+				log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+			}
 		}
 	}
 

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_dynamic_masking_policy.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_dynamic_masking_policy.go
@@ -421,9 +421,11 @@ func resourceSecurityDynamicMaskingPolicyUpdate(ctx context.Context, d *schema.R
 		return diag.Errorf("error creating DataArts Studio client: %s", err)
 	}
 
-	err = updateSecurityDynamicMaskingPolicy(client, d, d.Get("workspace_id").(string))
-	if err != nil {
-		return diag.Errorf("error updating dynamic masking policy (%s): %s", d.Id(), err)
+	if d.HasChangesExcept("enable_force_new") {
+		err = updateSecurityDynamicMaskingPolicy(client, d, d.Get("workspace_id").(string))
+		if err != nil {
+			return diag.Errorf("error updating dynamic masking policy (%s): %s", d.Id(), err)
+		}
 	}
 
 	return resourceSecurityDynamicMaskingPolicyRead(ctx, d, meta)

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
@@ -384,9 +384,11 @@ func resourceSecurityPermissionSetPrivilegeUpdate(ctx context.Context, d *schema
 		return diag.Errorf("error creating DataArts Studio client: %s", err)
 	}
 
-	_, err = updatePermissionSetPrivilege(client, d)
-	if err != nil {
-		return diag.Errorf("error updating DataArts Security permission set privilege: %s", err)
+	if d.HasChangesExcept("enable_force_new") {
+		_, err = updatePermissionSetPrivilege(client, d)
+		if err != nil {
+			return diag.Errorf("error updating DataArts Security permission set privilege: %s", err)
+		}
 	}
 
 	return resourceSecurityPermissionSetPrivilegeRead(ctx, d, meta)

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_resource_permission_policy.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_resource_permission_policy.go
@@ -359,8 +359,11 @@ func resourceSecurityResourcePermissionPolicyUpdate(ctx context.Context, d *sche
 		return diag.Errorf("error creating DataArts Studio client: %s", err)
 	}
 
-	if err = updateSecurityResourcePermissionPolicy(client, d, workspaceId); err != nil {
-		return diag.Errorf("error updating resource permission policy (%s): %s", d.Id(), err)
+	if d.HasChangesExcept("enable_force_new") {
+		err = updateSecurityResourcePermissionPolicy(client, d, workspaceId)
+		if err != nil {
+			return diag.Errorf("error updating resource permission policy (%s): %s", d.Id(), err)
+		}
 	}
 
 	return resourceSecurityResourcePermissionPolicyRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Skip update API calls when only `enable_force_new` changes for these resources:

- `huaweicloud_dataarts_architecture_aggregation_logic_table`
- `huaweicloud_dataarts_security_dynamic_masking_policy`
- `huaweicloud_dataarts_security_permission_set_privilege`
- `huaweicloud_dataarts_security_resource_permission_policy`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  define the trigger boundaries of enable_force_new
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

huaweicloud_dataarts_security_permission_set_privilege
<img width="1353" height="878" alt="image" src="https://github.com/user-attachments/assets/a2ec8afa-d966-41cf-a373-343a84c9cfd9" />
<img width="1405" height="1321" alt="image" src="https://github.com/user-attachments/assets/429cc9b5-317a-4b2d-b0d3-057f5b08dfb4" />

huaweicloud_dataarts_security_resource_permission_policy
<img width="1274" height="892" alt="image" src="https://github.com/user-attachments/assets/0f80d90a-5a1e-480f-a56e-d62a2a9cb7bf" />
<img width="1188" height="967" alt="image" src="https://github.com/user-attachments/assets/8679a134-fa50-47b2-83fc-ade387e56352" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
