### PR TITLE
feat(dsc): add a new resource to manage mask algorithm

### DIFF
--- a/docs/resources/dsc_mask_algorithm.md
+++ b/docs/resources/dsc_mask_algorithm.md
@@ -1,0 +1,136 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_mask_algorithm"
+description: |-
+  Manages a DSC mask algorithm resource within HuaweiCloud.
+---
+
+# huaweicloud_dsc_mask_algorithm
+
+Manages a DSC mask algorithm resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a character mask algorithm
+
+```hcl
+variable "algorithm_name" {}
+
+resource "huaweicloud_dsc_mask_algorithm" "test" {
+  algorithm_name = var.algorithm_name
+  algorithm      = "PRESNM"
+  algorithm_type = "MASK_BY_OVERWRITE"
+  category       = "BUILT_SELF"
+  parameter      = jsonencode({
+    type   = "CHAR"
+    first  = 6
+    second = 4
+    method = "*"
+  })
+}
+```
+
+### Create a keyword replace mask algorithm
+
+```hcl
+variable "algorithm_name" {}
+
+resource "huaweicloud_dsc_mask_algorithm" "test" {
+  algorithm_name = var.algorithm_name
+  algorithm      = "KEYWORD"
+  algorithm_type = "MASK_BY_KEYWORDS_EXCHANGE"
+  category       = "BUILT_SELF"
+  parameter      = jsonencode({
+    key    = "keyword"
+    target = "replace content"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the mask algorithm is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `algorithm_name` - (Required, String) Specifies the name of the mask algorithm.  
+  The maximum length is `255` characters.  
+  Only Chinese Characters, letters, digits, underscores (_), or hyphens (-) are allowed.  
+  The name must be unique.
+
+* `algorithm` - (Required, String) Specifies the encryption mask algorithm type.  
+  The valid values are as follows:
+  + **SHA256**
+  + **SHA512**
+  + **PRESNM**
+  + **MASKNM**
+  + **PRESXY**
+  + **MASKXY**
+  + **SYMBOL**
+  + **KEYWORD**
+  + **NULL**
+  + **EMPTY**
+  + **DATE**
+  + **NUMERIC**
+  + **AES**
+  + **EMBED**
+  + **SM4**
+  + **DECRYPT**
+  + **FAKE**
+
+* `algorithm_type` - (Required, String) Specifies the type of the mask algorithm.  
+  The valid values are as follows:
+  + **MASK_BY_HASH**
+  + **MASK_BY_ENCRYPT**
+  + **MASK_BY_OVERWRITE**
+  + **MASK_BY_KEYWORDS_EXCHANGE**
+  + **MASK_BY_NULL**
+  + **MASK_BY_BRIEF**
+  + **MASK_BY_DECRYPT**
+  + **MASK_BY_FAKE**
+
+* `category` - (Required, String, NonUpdatable) Specifies the category of the mask algorithm.  
+  The valid values are as follows:
+  + **BUILT_SELF**
+
+* `parameter` - (Required, String) Specifies the configuration parameters of the mask algorithm, in JSON format.
+
+* `data` - (Optional, String) Specifies the data content processed by the mask algorithm.  
+  This parameter is available when the algorithm type is `MASK_BY_OVERWRITE`.
+
+* `processed_data` - (Optional, String) Specifies the data content after masking.  
+  This parameter is available when the algorithm type is `MASK_BY_OVERWRITE`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dsc_mask_algorithm.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `algorithm_type`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the mask algorithm, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dsc_mask_algorithm" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      algorithm_type,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5033,6 +5033,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_data_map_score_update":          dsc.ResourceDscDataMapScoreUpdate(),
 			"huaweicloud_dsc_device":                         dsc.ResourceDscDevice(),
 			"huaweicloud_dsc_instance":                       dsc.ResourceDscInstance(),
+			"huaweicloud_dsc_mask_algorithm":                 dsc.ResourceMaskAlgorithm(),
 			"huaweicloud_dsc_multi_enable_trusted_service":   dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_operate_obs_audit":              dsc.ResourceOperateObsAudit(),
 			"huaweicloud_dsc_scan_template":                  dsc.ResourceScanTemplate(),

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_mask_algorithm_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_mask_algorithm_test.go
@@ -1,0 +1,115 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dsc"
+)
+
+func getMaskAlgorithmResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dsc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DSC client: %s", err)
+	}
+
+	return dsc.GetMaskAlgorithmById(client, state.Primary.ID)
+}
+
+// Before this test, please ensure that the DSC instance has been created.
+func TestAccResourceMaskAlgorithm_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dsc_mask_algorithm.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getMaskAlgorithmResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDscInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceMaskAlgorithm_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "algorithm_name", name),
+					resource.TestCheckResourceAttr(rName, "algorithm", "PRESNM"),
+					resource.TestCheckResourceAttr(rName, "algorithm_type", "MASK_BY_OVERWRITE"),
+					resource.TestCheckResourceAttr(rName, "category", "BUILT_SELF"),
+					resource.TestCheckResourceAttrSet(rName, "parameter"),
+					resource.TestCheckResourceAttr(rName, "data", "110108012345671"),
+					resource.TestCheckResourceAttr(rName, "processed_data", "110108*****5671"),
+				),
+			},
+			{
+				Config: testAccResourceMaskAlgorithm_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "algorithm_name", updateName),
+					resource.TestCheckResourceAttr(rName, "algorithm", "KEYWORD"),
+					resource.TestCheckResourceAttr(rName, "algorithm_type", "MASK_BY_KEYWORDS_EXCHANGE"),
+					resource.TestCheckResourceAttrSet(rName, "parameter"),
+					resource.TestCheckResourceAttr(rName, "data", ""),
+					resource.TestCheckResourceAttr(rName, "processed_data", ""),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"algorithm_type",
+				},
+			},
+		},
+	})
+}
+
+func testAccResourceMaskAlgorithm_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_mask_algorithm" "test" {
+  algorithm_name = "%[1]s"
+  algorithm      = "PRESNM"
+  algorithm_type = "MASK_BY_OVERWRITE"
+  category       = "BUILT_SELF"
+
+  parameter = jsonencode({
+    type   = "CHAR"
+    first  = 6
+    second = 4
+    method = "*"
+  })
+
+  data           = "110108012345671"
+  processed_data = "110108*****5671"
+}
+`, name)
+}
+
+func testAccResourceMaskAlgorithm_basic_step2(updateName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_mask_algorithm" "test" {
+  algorithm_name = "%[1]s"
+  algorithm      = "KEYWORD"
+  algorithm_type = "MASK_BY_KEYWORDS_EXCHANGE"
+  category       = "BUILT_SELF"
+
+  parameter = jsonencode({
+    key    = "keyword"
+    target = "TF"
+  })
+}
+`, updateName)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_mask_algorithm.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_mask_algorithm.go
@@ -1,0 +1,347 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	maskAlgorithmNonUpdatableParams = []string{
+		"category",
+	}
+	maskAlgorithmNotFoundErrCodes = []string{
+		"dsc.10000009", // The DSC instance does not exist.
+	}
+)
+
+// @API DSC POST /v1/{project_id}/sdg/server/mask/algorithms
+// @API DSC GET /v2/{project_id}/mask/algorithms
+// @API DSC PUT /v1/{project_id}/sdg/server/mask/algorithms/{algorithm_id}
+// @API DSC DELETE /v1/{project_id}/sdg/server/mask/algorithms/{algorithm_id}
+func ResourceMaskAlgorithm() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceMaskAlgorithmCreate,
+		ReadContext:   resourceMaskAlgorithmRead,
+		UpdateContext: resourceMaskAlgorithmUpdate,
+		DeleteContext: resourceMaskAlgorithmDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(maskAlgorithmNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the mask algorithm is located.`,
+			},
+
+			// Required parameters.
+			"algorithm_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the mask algorithm.`,
+			},
+			"algorithm": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The encryption mask algorithm type.`,
+			},
+			"algorithm_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the mask algorithm.`,
+			},
+			"category": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The category of the mask algorithm.`,
+			},
+			"parameter": {
+				Type:     schema.TypeString,
+				Required: true,
+				// The order of fields in the JSON strings returned by the creation and query is inconsistent, we need to ignore the differences.
+				DiffSuppressFunc: func(_, o, n string, _ *schema.ResourceData) bool {
+					equal, _ := utils.CompareJsonTemplateAreEquivalent(o, n)
+					return equal
+				},
+				Description: `The configuration parameters of the mask algorithm, in JSON format.`,
+			},
+
+			// Optional parameters.
+			"data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The data content processed by the mask algorithm.`,
+			},
+			"processed_data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The data content after masking.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildMaskAlgorithmBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Required parameters.
+		"algorithm_name": d.Get("algorithm_name"),
+		"algorithm":      d.Get("algorithm"),
+		"algorithm_type": d.Get("algorithm_type"),
+		"category":       d.Get("category"),
+		"parameter":      d.Get("parameter").(string),
+		// Optional parameters.
+		"data":           utils.ValueIgnoreEmpty(d.Get("data")),
+		"processed_data": utils.ValueIgnoreEmpty(d.Get("processed_data")),
+	}
+}
+
+func createMaskAlgorithm(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/sdg/server/mask/algorithms"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildMaskAlgorithmBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func resourceMaskAlgorithmCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg  = meta.(*config.Config)
+		name = d.Get("algorithm_name").(string)
+	)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = createMaskAlgorithm(client, d)
+	if err != nil {
+		return diag.Errorf("error creating mask algorithm: %s", err)
+	}
+
+	// The create API does not return the algorithm ID, query the list to get it.
+	algorithms, err := listMaskAlgorithms(client)
+	if err != nil {
+		return diag.Errorf("error getting mask algorithm (%s): %s", name, err)
+	}
+
+	algorithmId := utils.PathSearch(fmt.Sprintf("[?algorithm_name=='%s']|[0].algorithm_id", name), algorithms, "").(string)
+	if algorithmId == "" {
+		return diag.Errorf("unable to find the mask algorithm ID from API response")
+	}
+
+	d.SetId(algorithmId)
+
+	return resourceMaskAlgorithmRead(ctx, d, meta)
+}
+
+func listMaskAlgorithms(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/mask/algorithms"
+		limit   = 200
+		// The offset is the page number.
+		offset        = 1
+		allAlgorithms = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%v", listPath, limit)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		algorithms := utils.PathSearch("algorithms", respBody, make([]interface{}, 0)).([]interface{})
+		allAlgorithms = append(allAlgorithms, algorithms...)
+		if len(algorithms) < limit {
+			break
+		}
+
+		offset++
+	}
+
+	return allAlgorithms, nil
+}
+
+func GetMaskAlgorithmById(client *golangsdk.ServiceClient, algorithmId string) (interface{}, error) {
+	algorithms, err := listMaskAlgorithms(client)
+	if err != nil {
+		return nil, err
+	}
+
+	algorithm := utils.PathSearch(fmt.Sprintf("[?algorithm_id=='%s']|[0]", algorithmId), algorithms, nil)
+	if algorithm == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/mask/algorithms",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the mask algorithm (%s) does not exist", algorithmId)),
+			},
+		}
+	}
+
+	return algorithm, nil
+}
+
+func resourceMaskAlgorithmRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		algorithmId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	algorithm, err := GetMaskAlgorithmById(client, algorithmId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", maskAlgorithmNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving mask algorithm (%s)", algorithmId),
+		)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Required parameters.
+		d.Set("algorithm_name", utils.PathSearch("algorithm_name", algorithm, nil)),
+		d.Set("algorithm", utils.PathSearch("algorithm", algorithm, nil)),
+		d.Set("category", utils.PathSearch("category", algorithm, nil)),
+		d.Set("parameter", utils.PathSearch("parameter", algorithm, nil)),
+		// Optional parameters.
+		d.Set("data", utils.PathSearch("data", algorithm, nil)),
+		d.Set("processed_data", utils.PathSearch("processed_data", algorithm, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func updateMaskAlgorithm(client *golangsdk.ServiceClient, algorithmId string, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/sdg/server/mask/algorithms/{algorithm_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{algorithm_id}", algorithmId)
+
+	bodyParams := buildMaskAlgorithmBodyParams(d)
+	bodyParams["algorithm_id"] = algorithmId
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(bodyParams),
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceMaskAlgorithmUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	if d.HasChangesExcept("enable_force_new") {
+		err = updateMaskAlgorithm(client, d.Id(), d)
+		if err != nil {
+			return diag.Errorf("error updating mask algorithm (%v): %s", d.Get("algorithm_name"), err)
+		}
+	}
+
+	return resourceMaskAlgorithmRead(ctx, d, meta)
+}
+
+func deleteMaskAlgorithm(client *golangsdk.ServiceClient, algorithmId string) error {
+	httpUrl := "v1/{project_id}/sdg/server/mask/algorithms/{algorithm_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{algorithm_id}", algorithmId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceMaskAlgorithmDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = deleteMaskAlgorithm(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", maskAlgorithmNotFoundErrCodes...),
+			fmt.Sprintf("error deleting mask algorithm (%v)", d.Get("algorithm_name")),
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 Add a new resource to manage mask algorithm.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dsc -f TestAccResourceMaskAlgorithm_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccResourceMaskAlgorithm_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceMaskAlgorithm_basic
=== PAUSE TestAccResourceMaskAlgorithm_basic
=== CONT  TestAccResourceMaskAlgorithm_basic
--- PASS: TestAccResourceMaskAlgorithm_basic (25.49s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       25.629s coverage: 7.9% of statements in ./huaweicloud/services/dsc
```
<img width="1259" height="36" alt="image" src="https://github.com/user-attachments/assets/37c0067c-898e-4649-a049-4e27174ae07a" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1222" height="831" alt="image" src="https://github.com/user-attachments/assets/5996d522-98cf-441e-80b5-fe69a9f18c61" />

    ab. Related resources (parent resources) not found
     The DSC instance does not exist.
    <img width="1210" height="865" alt="image" src="https://github.com/user-attachments/assets/bfa16b1f-a7ed-4eab-8bbb-696249daf5a5" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    The deletion API returns a status code of 200 when the resource does not exist.

    bb. Related resources (parent resources) not found
    The DSC instance does not exist.
    <img width="1245" height="879" alt="image" src="https://github.com/user-attachments/assets/4bbb6d89-f16e-4ea9-94a7-a947dc797c13" />
