### PR TITLE
feat(dsc): add data source to dsc asset last job

### DIFF
--- a/docs/data-sources/dsc_asset_last_job.md
+++ b/docs/data-sources/dsc_asset_last_job.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_asset_last_job"
+description: |-
+  Use this data source to get the latest scan job details of a DSC asset within HuaweiCloud.
+---
+
+# huaweicloud_dsc_asset_last_job
+
+Use this data source to get the latest scan job details of a DSC asset within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "asset_id" {}
+
+data "huaweicloud_dsc_asset_last_job" "test" {
+  asset_id = var.asset_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `asset_id` - (Required, String) Specifies the asset ID. The asset ID is used to
+  uniquely identify the asset to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `job_id` - The job ID.
+
+* `job_name` - The job name.
+
+* `task_id` - The task ID.
+
+* `type` - The job type. Valid values are **OBS**, **DATABASE**, **BIGDATA**, **GIT**,
+  **MRS**, **MRS_HIVE**, **LTS**, **UNKNOWN** and **ALL**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1414,6 +1414,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_dsc_alarms":                           dsc.DataSourceDscAlarms(),
 			"huaweicloud_dsc_alarm_handling_trend":             dsc.DataSourceDscAlarmHandlingTrend(),
+			"huaweicloud_dsc_asset_last_job":                   dsc.DataSourceDscAssetLastJob(),
 			"huaweicloud_dsc_authorize_databases":              dsc.DataSourceDscAuthorizeDatabases(),
 			"huaweicloud_dsc_asset_overview":                   dsc.DataSourceDscAssetOverview(),
 			"huaweicloud_dsc_assets_count":                     dsc.DataSourceDscAssetsCount(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -462,6 +462,7 @@ var (
 
 	HW_DSC_INSTANCE_ID              = os.Getenv("HW_DSC_INSTANCE_ID")
 	HW_DSC_ALARM_TOPIC_ID           = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
+	HW_DSC_ASSET_ID                 = os.Getenv("HW_DSC_ASSET_ID")
 	HW_DSC_ENABLE_FLAG              = os.Getenv("HW_DSC_ENABLE_FLAG")
 	HW_DSC_TYPE_ID                  = os.Getenv("HW_DSC_TYPE_ID")
 	HW_DSC_SCAN_TEMPLATE_ID         = os.Getenv("HW_DSC_SCAN_TEMPLATE_ID")
@@ -5326,6 +5327,13 @@ func TestAccPrecheckDscInstance(t *testing.T) {
 func TestAccPrecheckDscAlarmTopicID(t *testing.T) {
 	if HW_DSC_ALARM_TOPIC_ID == "" {
 		t.Skip("HW_DSC_ALARM_TOPIC_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDscAssetId(t *testing.T) {
+	if HW_DSC_ASSET_ID == "" {
+		t.Skip("HW_DSC_ASSET_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_asset_last_job_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_asset_last_job_test.go
@@ -1,0 +1,41 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscAssetLastJob_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_asset_last_job.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscAssetId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDscAssetLastJob_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDscAssetLastJob_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_asset_last_job" "test" {
+  asset_id = "%[1]s"
+}
+`, acceptance.HW_DSC_ASSET_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_asset_last_job.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_asset_last_job.go
@@ -1,0 +1,100 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/sdg/asset/{asset_id}/last-job
+func DataSourceDscAssetLastJob() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscAssetLastJobRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"asset_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"job_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"task_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDscAssetLastJobRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sdg/asset/{asset_id}/last-job"
+		product = "dsc"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{asset_id}", d.Get("asset_id").(string))
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC asset last job: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("job_id", utils.PathSearch("job_id", respBody, nil)),
+		d.Set("job_name", utils.PathSearch("job_name", respBody, nil)),
+		d.Set("task_id", utils.PathSearch("task_id", respBody, nil)),
+		d.Set("type", utils.PathSearch("type", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to dsc asset last job
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to dsc asset last job
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscAssetLastJob_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscAssetLastJob_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscAssetLastJob_basic
=== PAUSE TestAccDataSourceDscAssetLastJob_basic
=== CONT  TestAccDataSourceDscAssetLastJob_basic
--- PASS: TestAccDataSourceDscAssetLastJob_basic (23.60s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       23.724s coverage: 6.1% of statements in ./huaweicloud/services/dsc
```
<img width="984" height="23" alt="image" src="https://github.com/user-attachments/assets/b0bca5af-24d4-46eb-aa31-280e37b1650f" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
