### PR TITLE
fix(modelarts): define the trigger boundaries of enable_force_new

### DIFF
--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_algorithm.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_algorithm.go
@@ -1193,8 +1193,10 @@ func resourceAlgorithmUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	if err := updateAlgorithm(client, d.Id(), buildUpdateAlgorithm(d)); err != nil {
-		return diag.Errorf("error updating ModelArts algorithm (%s): %s", d.Id(), err)
+	if d.HasChangeExcept("enable_force_new") {
+		if err := updateAlgorithm(client, d.Id(), buildUpdateAlgorithm(d)); err != nil {
+			return diag.Errorf("error updating ModelArts algorithm (%s): %s", d.Id(), err)
+		}
 	}
 
 	return resourceAlgorithmRead(ctx, d, meta)

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_dataset.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_dataset.go
@@ -691,9 +691,11 @@ func resourceDatasetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	err = updateDataset(client, d)
-	if err != nil {
-		return diag.Errorf("error updating ModelArts dataset: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateDataset(client, d)
+		if err != nil {
+			return diag.Errorf("error updating ModelArts dataset: %s", err)
+		}
 	}
 
 	return resourceDatasetRead(ctx, d, meta)

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_training_experiment.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_training_experiment.go
@@ -268,9 +268,11 @@ func resourceTrainingExperimentUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	err = updateTrainingExperiment(client, trainingExperimentId, buildTrainingExperimentUpdateBodyParams(d.Get("metadata").([]interface{})))
-	if err != nil {
-		return diag.Errorf("error updating training experiment (%s): %s", trainingExperimentId, err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateTrainingExperiment(client, trainingExperimentId, buildTrainingExperimentUpdateBodyParams(d.Get("metadata").([]interface{})))
+		if err != nil {
+			return diag.Errorf("error updating training experiment (%s): %s", trainingExperimentId, err)
+		}
 	}
 
 	return resourceTrainingExperimentRead(ctx, d, meta)

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow.go
@@ -1724,9 +1724,11 @@ func resourceV2WorkflowUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	err = updateV2Workflow(client, d)
-	if err != nil {
-		return diag.Errorf("error updating workflow (%s): %s", d.Id(), err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateV2Workflow(client, d)
+		if err != nil {
+			return diag.Errorf("error updating workflow (%s): %s", d.Id(), err)
+		}
 	}
 
 	return resourceV2WorkflowRead(ctx, d, meta)

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_execution.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_execution.go
@@ -1098,9 +1098,11 @@ func resourceV2WorkflowExecutionUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	err = updateV2WorkflowExecution(client, d)
-	if err != nil {
-		return diag.Errorf("error updating workflow execution: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateV2WorkflowExecution(client, d)
+		if err != nil {
+			return diag.Errorf("error updating workflow execution: %s", err)
+		}
 	}
 
 	return resourceV2WorkflowExecutionRead(ctx, d, meta)

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_subscription.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_subscription.go
@@ -244,9 +244,11 @@ func resourceV2WorkflowSubscriptionUpdate(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	err = updateV2WorkflowSubscription(client, d)
-	if err != nil {
-		return diag.Errorf("error updating ModelArts workflow subscription: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateV2WorkflowSubscription(client, d)
+		if err != nil {
+			return diag.Errorf("error updating ModelArts workflow subscription: %s", err)
+		}
 	}
 
 	return resourceV2WorkflowSubscriptionRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Skip update API calls when only enable_force_new changes for these resources:

- huaweicloud_modelarts_algorithm
- huaweicloud_modelarts_dataset
- huaweicloud_modelarts_training_experiment
- huaweicloud_modelartsv2_workflow
- huaweicloud_modelartsv2_workflow_execution
- huaweicloud_modelartsv2_workflow_subscription

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. define the trigger boundaries of enable_force_new
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

1. huaweicloud_modelarts_algorithm
<img width="1486" height="1319" alt="image" src="https://github.com/user-attachments/assets/5f1fa672-11e6-4189-b183-75c722c8e277" />
<img width="1509" height="1324" alt="image" src="https://github.com/user-attachments/assets/7b06cf88-46bc-4a5c-9298-484f4a1f969b" />

2. huaweicloud_modelarts_training_experiment
<img width="1492" height="1309" alt="image" src="https://github.com/user-attachments/assets/c56fb571-d948-4f5f-8792-5e6b49269c81" />
<img width="1482" height="1312" alt="image" src="https://github.com/user-attachments/assets/2f9b0b10-87c0-4720-bf5e-e6daabf4d8de" />

3. huaweicloud_modelartsv2_workflow
<img width="1515" height="1305" alt="image" src="https://github.com/user-attachments/assets/1e1fd57e-877d-46a5-9177-a1feb32531e6" />
<img width="1502" height="1311" alt="image" src="https://github.com/user-attachments/assets/32106827-cdc2-4969-8758-9dc0406fbb40" />

4. huaweicloud_modelartsv2_workflow_execution
<img width="1507" height="1315" alt="image" src="https://github.com/user-attachments/assets/d44e9294-b55c-4fd3-91d2-d9e8b6948009" />
<img width="1527" height="1321" alt="image" src="https://github.com/user-attachments/assets/78847477-52bf-49c4-b45e-d60e7367808b" />

5. huaweicloud_modelartsv2_workflow_subscription
<img width="1499" height="1263" alt="image" src="https://github.com/user-attachments/assets/c47b3bc7-4730-4b31-aa5a-4114cf7622ae" />
<img width="1495" height="1317" alt="image" src="https://github.com/user-attachments/assets/57e03037-77bf-44d3-83e7-d1d6df82b917" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
