### PR TITLE
feat(dsc): add a new data source to get encryption configurations

### DIFF
--- a/docs/data-sources/dsc_encrypt_configurations.md
+++ b/docs/data-sources/dsc_encrypt_configurations.md
@@ -1,0 +1,94 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_encrypt_configurations"
+description: |-
+  Use this data source to get the list of DSC encryption configurations within HuaweiCloud.
+---
+
+# huaweicloud_dsc_encrypt_configurations
+
+Use this data source to get the list of DSC encryption configurations within HuaweiCloud.
+
+## Example Usage
+
+### Query all encryption configurations under the specified algorithm type
+
+```hcl
+variable "algorithm_type" {}
+
+data "huaweicloud_dsc_encrypt_configurations" "test" {
+  algorithm_type = var.algorithm_type
+}
+```
+
+### Query encryption configurations by name
+
+```hcl
+variable "configuration_name" {}
+variable "algorithm_type" {}
+
+data "huaweicloud_dsc_encrypt_configurations" "test" {
+  algorithm_type     = var.algorithm_type
+  configuration_name = var.configuration_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the encryption configurations are located.  
+  If omitted, the provider-level region will be used.
+
+* `algorithm_type` - (Required, String) Specifies the type of the encryption algorithm.  
+  The valid values are as follows:
+  + **AES**
+  + **SM4**
+
+* `configuration_name` - (Optional, String) Specifies the name of the encryption configuration.  
+  Fuzzy search is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `configurations` - The list of the encryption configurations.  
+  The [configurations](#dsc_encrypt_configurations) structure is documented below.
+
+* `access_permission` - Whether the user has the access permission.
+
+<a name="dsc_encrypt_configurations"></a>
+The `configurations` block supports:
+
+* `id` - The ID of the encryption configuration.
+
+* `configuration_name` - The name of the encryption configuration.
+
+* `algorithm_name` - The name of the encryption algorithm.
+
+* `algorithm_type` - The type of the encryption algorithm.
+
+* `enable_rotate` - Whether the key rotation is enabled.
+
+* `encrypt_mode` - The encryption mode.
+
+* `filling_method` - The filling method used for encryption masking.
+
+* `kms_context` - The KMS context information.  
+  The [kms_context](#dsc_encrypt_configurations_kms_context) structure is documented below.
+
+* `mask_task_num` - The number of the masking tasks.
+
+* `rotate_period` - The key rotation period, in days.
+
+<a name="dsc_encrypt_configurations_kms_context"></a>
+The `kms_context` block supports:
+
+* `kms_key_alias` - The alias of the KMS key.
+
+* `kms_key_id` - The ID of the KMS key.
+
+* `kms_region` - The region where the KMS key is located.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1442,6 +1442,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_threat_trend":                     dsc.DataSourceDscThreatTrend(),
 			"huaweicloud_dsc_database_instances":               dsc.DataSourceDatabaseInstances(),
 			"huaweicloud_dsc_bigdata_instance_databases":       dsc.DataSourceBigdataInstanceDatabases(),
+			"huaweicloud_dsc_encrypt_configurations":           dsc.DataSourceEncryptConfigurations(),
 			"huaweicloud_dsc_mask_algorithms":                  dsc.DataSourceMaskAlgorithms(),
 			"huaweicloud_dsc_scan_jobs":                        dsc.DataSourceScanJobs(),
 			"huaweicloud_dsc_scan_tasks":                       dsc.DataSourceDscScanTasks(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_encrypt_configurations_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_encrypt_configurations_test.go
@@ -1,0 +1,78 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running the test, please ensure that you have created a DSC instance and a AES encryption configuration.
+func TestAccDataSourceEncryptConfigurations_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dsc_encrypt_configurations.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byConfigurationName   = "data.huaweicloud_dsc_encrypt_configurations.filter_by_configuration_name"
+		dcByConfigurationName = acceptance.InitDataSourceCheck(byConfigurationName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDscInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEncryptConfigurations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "configurations.#"),
+					resource.TestCheckResourceAttrSet(all, "configurations.0.id"),
+					resource.TestCheckResourceAttrSet(all, "configurations.0.configuration_name"),
+					resource.TestCheckResourceAttrSet(all, "configurations.0.algorithm_name"),
+					resource.TestCheckResourceAttrSet(all, "configurations.0.algorithm_type"),
+					resource.TestCheckResourceAttrSet(all, "configurations.0.encrypt_mode"),
+					resource.TestCheckResourceAttrSet(all, "configurations.0.filling_method"),
+					resource.TestCheckResourceAttrSet(all, "configurations.0.kms_context.0.kms_key_id"),
+					// Filter by 'configuration_name' parameter.
+					dcByConfigurationName.CheckResourceExists(),
+					resource.TestCheckOutput("is_configuration_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEncryptConfigurations_basic() string {
+	return `
+# Without any filter parameters.
+data "huaweicloud_dsc_encrypt_configurations" "test" {
+  algorithm_type = "AES"
+}
+
+locals {
+  configuration_name = try(data.huaweicloud_dsc_encrypt_configurations.test.configurations[0].configuration_name, "NOT_FOUND")
+}
+
+# Filter by 'configuration_name' parameter.
+data "huaweicloud_dsc_encrypt_configurations" "filter_by_configuration_name" {
+  algorithm_type     = "AES"
+  configuration_name = local.configuration_name
+}
+
+locals {
+  configuration_name_filter_result = [
+    for v in data.huaweicloud_dsc_encrypt_configurations.filter_by_configuration_name.configurations[*].configuration_name :
+    strcontains(v, local.configuration_name)
+  ]
+}
+
+output "is_configuration_name_filter_useful" {
+  value = length(local.configuration_name_filter_result) > 0 && alltrue(local.configuration_name_filter_result)
+}
+`
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_encrypt_configurations.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_encrypt_configurations.go
@@ -1,0 +1,265 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/sdg/server/mask/algorithms/encryption-configurations
+func DataSourceEncryptConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEncryptConfigurationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the encryption configurations are located.`,
+			},
+
+			// Required parameters.
+			"algorithm_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the encryption algorithm.`,
+			},
+
+			// Optional parameters.
+			"configuration_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the encryption configuration.`,
+			},
+
+			// Attributes.
+			"configurations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        encryptConfigurationsSchema(),
+				Description: `The list of the encryption configurations.`,
+			},
+			"access_permission": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the user has the access permission.`,
+			},
+		},
+	}
+}
+
+func encryptConfigurationsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the encryption configuration.`,
+			},
+			"configuration_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the encryption configuration.`,
+			},
+			"algorithm_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the encryption algorithm.`,
+			},
+			"algorithm_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the encryption algorithm.`,
+			},
+			"enable_rotate": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the key rotation is enabled.`,
+			},
+			"encrypt_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The encryption mode.`,
+			},
+			"filling_method": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The filling method used for encryption masking.`,
+			},
+			"kms_context": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The KMS context information.`,
+				Elem:        encryptConfigurationsKmsContextSchema(),
+			},
+			"mask_task_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of the masking tasks.`,
+			},
+			"rotate_period": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The key rotation period, in days.`,
+			},
+		},
+	}
+}
+
+func encryptConfigurationsKmsContextSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"kms_key_alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The alias of the KMS key.`,
+			},
+			"kms_key_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the KMS key.`,
+			},
+			"kms_region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The region where the KMS key is located.`,
+			},
+		},
+	}
+}
+
+func buildEncryptConfigurationsQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("&algorithm_type=%v", d.Get("algorithm_type"))
+	if v, ok := d.GetOk("configuration_name"); ok {
+		queryParams = fmt.Sprintf("%s&configuration_name=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func listEncryptConfigurations(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, interface{}, error) {
+	var (
+		httpUrl          = "v1/{project_id}/sdg/server/mask/algorithms/encryption-configurations"
+		limit            = 200
+		offset           = 0
+		results          = make([]interface{}, 0)
+		accessPermission interface{}
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%d%s", listPath, limit, buildEncryptConfigurationsQueryParams(d))
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if offset == 0 {
+			accessPermission = utils.PathSearch("access_permission", respBody, nil)
+		}
+
+		configuration := utils.PathSearch("configuration_list", respBody, make([]interface{}, 0)).([]interface{})
+		results = append(results, configuration...)
+		if len(configuration) < limit {
+			break
+		}
+
+		offset += len(configuration)
+	}
+
+	return results, accessPermission, nil
+}
+
+func dataSourceEncryptConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	encryptConfigs, accessPermission, err := listEncryptConfigurations(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving encryption configurations: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("access_permission", accessPermission),
+		d.Set("configurations", flattenEncryptConfigurations(encryptConfigs)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEncryptConfigurations(encryptConfigs []interface{}) []map[string]interface{} {
+	if len(encryptConfigs) < 1 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(encryptConfigs))
+	for _, v := range encryptConfigs {
+		rst = append(rst, map[string]interface{}{
+			"id":                 utils.PathSearch("id", v, nil),
+			"configuration_name": utils.PathSearch("configuration_name", v, nil),
+			"algorithm_name":     utils.PathSearch("algorithm_name", v, nil),
+			"algorithm_type":     utils.PathSearch("algorithm_type", v, nil),
+			"enable_rotate":      utils.PathSearch("enable_rotate", v, nil),
+			"encrypt_mode":       utils.PathSearch("encrypt_mode", v, nil),
+			"filling_method":     utils.PathSearch("filling_method", v, nil),
+			"kms_context": flattenEncryptConfigurationsKmsContext(utils.PathSearch("kms_context",
+				v, make(map[string]interface{}, 0)).(map[string]interface{})),
+			"mask_task_num": utils.PathSearch("mask_task_num", v, nil),
+			"rotate_period": utils.PathSearch("rotate_period", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenEncryptConfigurationsKmsContext(kmsContext map[string]interface{}) []map[string]interface{} {
+	if len(kmsContext) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"kms_key_alias": utils.PathSearch("kms_key_alias", kmsContext, nil),
+			"kms_key_id":    utils.PathSearch("kms_key_id", kmsContext, nil),
+			"kms_region":    utils.PathSearch("kms_region", kmsContext, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source to get encryption configuration list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The enumeration values for `algorithm_type` in the API are incorrect, Only supports creating encryption configurations of types `AES `and `SM4`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceEncryptConfigurations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceEncryptConfigurations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEncryptConfigurations_basic
=== PAUSE TestAccDataSourceEncryptConfigurations_basic
=== CONT  TestAccDataSourceEncryptConfigurations_basic
--- PASS: TestAccDataSourceEncryptConfigurations_basic (11.36s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       11.502s coverage: 6.6% of statements in ./huaweicloud/services/dsc
```
<img width="1049" height="39" alt="image" src="https://github.com/user-attachments/assets/697ddcc1-7910-490b-8b1e-b7fda83df4f7" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
