### PR TITLE
feat(dsc): add data source to dsc top attacks info

### DIFF
--- a/docs/data-sources/dsc_attacked_top.md
+++ b/docs/data-sources/dsc_attacked_top.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_attacked_top"
+description: |-
+  Use this data source to get the top attacked assets information within HuaweiCloud.
+---
+
+# huaweicloud_dsc_attacked_top
+
+Use this data source to get the top attacked assets information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dsc_attacked_top" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `attacked_api_num` - The number of attacked APIs.
+
+* `attacked_api_top` - The top attacked API information.
+
+  The [attacked_api_top](#attacked_api_top_struct) structure is documented below.
+
+* `attacked_asset_num` - The number of attacked assets.
+
+* `attacked_asset_top` - The top attacked asset information.
+
+  The [attacked_asset_top](#attacked_asset_top_struct) structure is documented below.
+
+<a name="attacked_api_top_struct"></a>
+The `attacked_api_top` block supports:
+
+* `api_name` - The API name.
+
+* `application_type` - The application type.
+
+* `attacked_num` - The number of attacks.
+
+* `instance_id` - The instance ID.
+
+<a name="attacked_asset_top_struct"></a>
+The `attacked_asset_top` block supports:
+
+* `attacked_num` - The number of attacks.
+
+* `db_ip` - The database IP.
+
+* `db_name` - The database name.
+
+* `db_type` - The database type.
+
+* `instance_id` - The instance ID.
+
+* `instance_name` - The instance name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1415,6 +1415,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_alarms":                           dsc.DataSourceDscAlarms(),
 			"huaweicloud_dsc_alarm_handling_trend":             dsc.DataSourceDscAlarmHandlingTrend(),
 			"huaweicloud_dsc_asset_last_job":                   dsc.DataSourceDscAssetLastJob(),
+			"huaweicloud_dsc_attacked_top":                     dsc.DataSourceDscAttackedTop(),
 			"huaweicloud_dsc_authorize_databases":              dsc.DataSourceDscAuthorizeDatabases(),
 			"huaweicloud_dsc_asset_overview":                   dsc.DataSourceDscAssetOverview(),
 			"huaweicloud_dsc_assets_count":                     dsc.DataSourceDscAssetsCount(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_attacked_top_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_attacked_top_test.go
@@ -1,0 +1,40 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscAttackedTop_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_attacked_top.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDscAttackedTop_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "attacked_api_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "attacked_api_top.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "attacked_asset_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "attacked_asset_top.#"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceDscAttackedTop_basic = `
+data "huaweicloud_dsc_attacked_top" "test" {}
+`

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_attacked_top.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_attacked_top.go
@@ -1,0 +1,191 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v2/{project_id}/sec-ops/situation-dashboard/top-attacks-info
+func DataSourceDscAttackedTop() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscAttackedTopRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"attacked_api_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"attacked_api_top": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     attackedApiTopSchema(),
+			},
+			"attacked_asset_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"attacked_asset_top": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     attackedAssetTopSchema(),
+			},
+		},
+	}
+}
+
+func attackedApiTopSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"api_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"application_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attacked_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func attackedAssetTopSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"attacked_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"db_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDscAttackedTopRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/sec-ops/situation-dashboard/top-attacks-info"
+		product = "dsc"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC attacked top: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("attacked_api_num", utils.PathSearch("attacked_api_num", respBody, nil)),
+		d.Set("attacked_api_top", flattenAttackedApiTop(
+			utils.PathSearch("attacked_api_top", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("attacked_asset_num", utils.PathSearch("attacked_asset_num", respBody, nil)),
+		d.Set("attacked_asset_top", flattenAttackedAssetTop(
+			utils.PathSearch("attacked_asset_top", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAttackedApiTop(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"api_name":         utils.PathSearch("api_name", v, nil),
+			"application_type": utils.PathSearch("application_type", v, nil),
+			"attacked_num":     utils.PathSearch("attacked_num", v, nil),
+			"instance_id":      utils.PathSearch("instance_id", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenAttackedAssetTop(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"attacked_num":  utils.PathSearch("attacked_num", v, nil),
+			"db_ip":         utils.PathSearch("db_ip", v, nil),
+			"db_name":       utils.PathSearch("db_name", v, nil),
+			"db_type":       utils.PathSearch("db_type", v, nil),
+			"instance_id":   utils.PathSearch("instance_id", v, nil),
+			"instance_name": utils.PathSearch("instance_name", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to dsc top attacks info
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to dsc top attacks info
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscAttackedTop_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscAttackedTop_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscAttackedTop_basic
=== PAUSE TestAccDataSourceDscAttackedTop_basic
=== CONT  TestAccDataSourceDscAttackedTop_basic
--- PASS: TestAccDataSourceDscAttackedTop_basic (23.92s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       24.064s coverage: 6.1% of statements in ./huaweicloud/services/dsc
```
<img width="972" height="26" alt="image" src="https://github.com/user-attachments/assets/984c4b91-e382-4f64-adfa-6382e28327a5" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
