### PR TITLE
fix(dws): add HasChanges guard to cluster user update to avoid unneccessary API calls

### DIFF
--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_user.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_user.go
@@ -482,19 +482,12 @@ func resourceClusterUserRead(_ context.Context, d *schema.ResourceData, meta int
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateClusterUser(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	var (
-		cfg       = meta.(*config.Config)
-		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}"
 		clusterId = d.Get("cluster_id").(string)
 		name      = d.Get("name").(string)
-		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}"
 	)
-
-	client, err := cfg.NewServiceClient("dws", region)
-	if err != nil {
-		return diag.Errorf("error creating DWS client: %s", err)
-	}
 
 	updatePath := client.Endpoint + httpUrl
 	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
@@ -503,7 +496,7 @@ func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	updateBody := utils.RemoveNil(buildClusterUserUpdateBodyParams(d))
 	if len(updateBody) < 1 {
-		return resourceClusterUserRead(ctx, d, meta)
+		return nil
 	}
 
 	updateOpt := golangsdk.RequestOpts{
@@ -512,9 +505,27 @@ func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta
 		JSONBody:         updateBody,
 	}
 
-	_, err = client.Request("POST", updatePath, &updateOpt)
+	_, err := client.Request("POST", updatePath, &updateOpt)
+	return err
+}
+
+func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
 	if err != nil {
-		return diag.Errorf("error updating cluster user: %s", err)
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	if d.HasChanges("login", "create_role", "create_db", "system_admin", "audit_admin", "inherit",
+		"use_ft", "conn_limit", "replication", "valid_begin", "valid_until", "lock") {
+		err = updateClusterUser(client, d)
+		if err != nil {
+			return diag.Errorf("error updating cluster user: %s", err)
+		}
 	}
 
 	return resourceClusterUserRead(ctx, d, meta)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix multi-request issue in resource update.

**Which issue this PR fixes**:
Add HasChanges guard to cluster user update to avoid unneccessary API calls.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the logic of the update action of  `dws_cluster_user`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccResourceClusterUser_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceClusterUser_basic
=== PAUSE TestAccResourceClusterUser_basic
=== CONT  TestAccResourceClusterUser_basic
--- PASS: TestAccResourceClusterUser_basic (76.52s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       76.666s coverage: 4.8% of statements in ./huaweicloud/services/dws
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.