### PR TITLE
fix(er): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -406,22 +406,24 @@ func resourceAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating ER client: %s", err)
 	}
 
-	_, err = changeAssociationRoutePolicy(client, instanceId, routeTableId, associationId, routePolicies)
-	if err != nil {
-		return diag.Errorf("error updating the route policy of association (%s): %s", associationId, err)
-	}
+	if d.HasChanges("route_policy") {
+		_, err = changeAssociationRoutePolicy(client, instanceId, routeTableId, associationId, routePolicies)
+		if err != nil {
+			return diag.Errorf("error updating the route policy of association (%s): %s", associationId, err)
+		}
 
-	stateConf := &retry.StateChangeConf{
-		Pending:      []string{"PENDING"},
-		Target:       []string{"COMPLETED"},
-		Refresh:      associationStatusRefreshFunc(client, instanceId, routeTableId, associationId, []string{"available"}),
-		Timeout:      d.Timeout(schema.TimeoutUpdate),
-		Delay:        10 * time.Second,
-		PollInterval: 10 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.Errorf("error waiting for the association (%s) route policy update to complete: %s", associationId, err)
+		stateConf := &retry.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      associationStatusRefreshFunc(client, instanceId, routeTableId, associationId, []string{"available"}),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			Delay:        10 * time.Second,
+			PollInterval: 10 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error waiting for the association (%s) route policy update to complete: %s", associationId, err)
+		}
 	}
 
 	return resourceAssociationRead(ctx, d, meta)

--- a/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
@@ -407,22 +407,24 @@ func resourcePropagationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating ER client: %s", err)
 	}
 
-	_, err = changePropagationRoutePolicy(client, instanceId, routeTableId, propagationId, routePolicies)
-	if err != nil {
-		return diag.Errorf("error updating the route policy of propagation (%s): %s", propagationId, err)
-	}
+	if d.HasChanges("route_policy") {
+		_, err = changePropagationRoutePolicy(client, instanceId, routeTableId, propagationId, routePolicies)
+		if err != nil {
+			return diag.Errorf("error updating the route policy of propagation (%s): %s", propagationId, err)
+		}
 
-	stateConf := &retry.StateChangeConf{
-		Pending:      []string{"PENDING"},
-		Target:       []string{"COMPLETED"},
-		Refresh:      propagationStatusRefreshFunc(client, instanceId, routeTableId, propagationId, []string{"available"}),
-		Timeout:      d.Timeout(schema.TimeoutUpdate),
-		Delay:        10 * time.Second,
-		PollInterval: 10 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.Errorf("error waiting for the propagation (%s) route policy update to complete: %s", propagationId, err)
+		stateConf := &retry.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      propagationStatusRefreshFunc(client, instanceId, routeTableId, propagationId, []string{"available"}),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			Delay:        10 * time.Second,
+			PollInterval: 10 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error waiting for the propagation (%s) route policy update to complete: %s", propagationId, err)
+		}
 	}
 
 	return resourcePropagationRead(ctx, d, meta)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix multi-request issue in resource update.

**Which issue this PR fixes**:
Add HasChanges guard to cluster user update to avoid unneccessary API calls.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the logic of the update action of  `er_association`
2. change the logic of the update action of  `er_propagation`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

**ER Association**
create resource
<img width="1494" height="1280" alt="26612823683b71b956fef5a5a2b220e2" src="https://github.com/user-attachments/assets/7173900e-2d48-4d24-b69e-b9baa150057d" />

change one optional param will trigger an update request.
<img width="1473" height="1053" alt="f57cad7424e65bfe5d8b5e2392973fea" src="https://github.com/user-attachments/assets/304ab2e0-e2e3-4ffd-98fe-ffc6b48d5493" />
<img width="1503" height="1273" alt="98d50e2789fabe209cf13a2989ebe265" src="https://github.com/user-attachments/assets/4d95d373-97bf-4537-bf87-caf75a04e33f" />

'enable_force_new' change will not trigger the update request of the resource.
<img width="1488" height="1277" alt="3f5e53db8a5fe7484c0085d0502b39f0" src="https://github.com/user-attachments/assets/5462c00c-4cec-49dd-91ec-c6fd63e5d4a9" />
<img width="1449" height="1269" alt="ffed2a14480cab13e6d9f1be27aafb0b" src="https://github.com/user-attachments/assets/38e55d66-b9ff-47df-be12-20ba1bedd8ec" />

**ER Propagation**
create resource
<img width="1499" height="1273" alt="b6e0591b0174a453b3f87ab1b35c113c" src="https://github.com/user-attachments/assets/86f3d335-65bb-42c0-94ac-bbdbf7aa33e6" />

change one optional param will trigger an update request.
<img width="1507" height="1273" alt="a7dfd7bf84d57445848dcd496b474e34" src="https://github.com/user-attachments/assets/c6c6ee25-9009-4012-b9aa-d84b096112b1" />
<img width="1503" height="1270" alt="a099072ace8cc318a8a20894c32af084" src="https://github.com/user-attachments/assets/99be803b-50c9-4840-b759-d645e3789672" />

'enable_force_new' change will not trigger the update request of the resource.
<img width="1495" height="1276" alt="c02f69cb5d6b21b51728d3d2af24b054" src="https://github.com/user-attachments/assets/84480b7b-fbee-482e-9b1a-7d45bbf4cecb" />
<img width="1491" height="1273" alt="1babe4e09c9fc877eca6fa0d2b048a04" src="https://github.com/user-attachments/assets/9716db45-9056-4d9f-bde1-f6fa9c2bfe71" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.