### PR TITLE
fix(dws): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_user.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_user.go
@@ -482,19 +482,12 @@ func resourceClusterUserRead(_ context.Context, d *schema.ResourceData, meta int
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateClusterUser(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	var (
-		cfg       = meta.(*config.Config)
-		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}"
 		clusterId = d.Get("cluster_id").(string)
 		name      = d.Get("name").(string)
-		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}"
 	)
-
-	client, err := cfg.NewServiceClient("dws", region)
-	if err != nil {
-		return diag.Errorf("error creating DWS client: %s", err)
-	}
 
 	updatePath := client.Endpoint + httpUrl
 	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
@@ -503,7 +496,7 @@ func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	updateBody := utils.RemoveNil(buildClusterUserUpdateBodyParams(d))
 	if len(updateBody) < 1 {
-		return resourceClusterUserRead(ctx, d, meta)
+		return nil
 	}
 
 	updateOpt := golangsdk.RequestOpts{
@@ -512,9 +505,26 @@ func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta
 		JSONBody:         updateBody,
 	}
 
-	_, err = client.Request("POST", updatePath, &updateOpt)
+	_, err := client.Request("POST", updatePath, &updateOpt)
+	return err
+}
+
+func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
 	if err != nil {
-		return diag.Errorf("error updating cluster user: %s", err)
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateClusterUser(client, d)
+		if err != nil {
+			return diag.Errorf("error updating cluster user: %s", err)
+		}
 	}
 
 	return resourceClusterUserRead(ctx, d, meta)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix multi-request issue in resource update.

**Which issue this PR fixes**:
Add HasChanges guard to cluster user update to avoid unneccessary API calls.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the logic of the update action of  `dws_cluster_user`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

create resource.
<img width="1446" height="1204" alt="bccf61b5b5abcfba0eff1420da1a44bb" src="https://github.com/user-attachments/assets/677ba973-9e09-40a6-a0cb-074377271313" />

change one optional param will trigger an update request.
<img width="1455" height="1253" alt="564edf7a9953ef19c93dd421bdc7833f" src="https://github.com/user-attachments/assets/d00cb267-9969-4f4a-a705-0fc7509ead9a" />
<img width="2229" height="562" alt="798e5b3366cfd1cbd26ce08ff12189e4" src="https://github.com/user-attachments/assets/bafa89d3-45db-4d2b-8444-20578494b0c2" />

'enable_force_new' change will not trigger the update request of the resource.
<img width="1975" height="941" alt="82f220f13f36b8d43b8cd2e9e12d7d30" src="https://github.com/user-attachments/assets/ea23c9aa-7ddc-4a4a-b122-f0e56004d381" />
<img width="1901" height="1203" alt="5791494c2337b9ecef8c5ebbee387f5f" src="https://github.com/user-attachments/assets/789c92e4-8ba9-4f82-838d-0b14d231ddb6" />
<img width="2307" height="853" alt="6b12a8eda72dbde2ec9d2bcf6a72fdc5" src="https://github.com/user-attachments/assets/84ed4773-6f7c-42c0-a936-7469836dad77" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.