### PR TITLE
fix(css): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/css/resource_huaweicloud_css_ai_ops_setting.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_ai_ops_setting.go
@@ -98,7 +98,10 @@ func resourceAiOpsSettingCreate(ctx context.Context, d *schema.ResourceData, met
 
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildAiOpsSettingBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildAiOpsSettingBodyParams(d)),
 	}
 
 	createResp, err := client.Request("POST", createPath, &createOpt)
@@ -152,6 +155,9 @@ func GetAiOpsSettingInfo(client *golangsdk.ServiceClient, clusterId string) (int
 	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
 	getOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	resp, err := client.Request("GET", getPath, &getOpts)
@@ -185,18 +191,23 @@ func resourceAiOpsSettingUpdate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error creating CSS client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", d.Id())
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", d.Id())
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildAiOpsSettingBodyParams(d)),
-	}
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildAiOpsSettingBodyParams(d)),
+		}
 
-	_, err = client.Request("POST", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating the auto ai-ops setting: %s", err)
+		_, err = client.Request("POST", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating the auto ai-ops setting: %s", err)
+		}
 	}
 
 	return resourceAiOpsSettingRead(ctx, d, meta)
@@ -219,6 +230,9 @@ func resourceAiOpsSettingDelete(_ context.Context, d *schema.ResourceData, meta 
 	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", d.Id())
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	_, err = client.Request("PUT", deletePath, &deleteOpt)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Skip update API calls when only enable_force_new changes for the resource:
+ huaweicloud_css_ai_ops_setting

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. define the trigger boundaries of enable_force_new.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccResourceAiOpsSetting_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccResourceAiOpsSetting_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceAiOpsSetting_basic
=== PAUSE TestAccResourceAiOpsSetting_basic
=== CONT  TestAccResourceAiOpsSetting_basic
--- PASS: TestAccResourceAiOpsSetting_basic (23.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       23.789s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
