### PR TITLE
feat(dsc): add a new one-time action resource to test mask algorithm

### DIFF
--- a/docs/resources/dsc_mask_algorithm_debug.md
+++ b/docs/resources/dsc_mask_algorithm_debug.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_mask_algorithm_debug"
+description: |-
+  Use this resource to test a DSC mask algorithm within HuaweiCloud.
+---
+
+# huaweicloud_dsc_mask_algorithm_debug
+
+Use this resource to test a DSC mask algorithm within HuaweiCloud.
+
+-> This resource is a one-time action resource used to test a DSC mask algorithm. Deleting this resource will not
+  clear the corresponding test record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "data" {}
+variable "parameter" {}
+
+resource "huaweicloud_dsc_mask_algorithm_debug" "test" {
+  data           = var.data
+  algorithm      = "PRESNM"
+  algorithm_type = "MASK_BY_OVERWRITE"
+  parameter      = var.parameter
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the mask algorithm to be tested is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `algorithm` - (Required, String, NonUpdatable) Specifies the mask algorithm.  
+  The valid values are as follows:
+  + **SHA256**
+  + **SHA512**
+  + **PRESNM**
+  + **MASKNM**
+  + **PRESXY**
+  + **MASKXY**
+  + **SYMBOL**
+  + **KEYWORD**
+  + **NULL**
+  + **EMPTY**
+  + **DATE**
+  + **NUMERIC**
+  + **AES**
+  + **EMBED**
+  + **SM4**
+  + **DECRYPT**
+  + **FAKE**
+
+* `algorithm_type` - (Required, String, NonUpdatable) Specifies the type of the mask algorithm.  
+  The valid values are as follows:
+  + **MASK_BY_HASH**
+  + **MASK_BY_ENCRYPT**
+  + **MASK_BY_OVERWRITE**
+  + **MASK_BY_KEYWORDS_EXCHANGE**
+  + **MASK_BY_NULL**
+  + **MASK_BY_BRIEF**
+  + **MASK_BY_DECRYPT**
+  + **MASK_BY_FAKE**
+
+* `data` - (Required, String, NonUpdatable) Specifies the data content to be processed by the mask algorithm.
+
+* `parameter` - (Optional, String, NonUpdatable) Specifies the configuration parameters of the mask algorithm, in JSON
+  format.  
+  This parameter is **required** only when the `algorithm_type` is set to **MASK_BY_OVERWRITE**, **MASK_BY_KEYWORDS_EXCHANGE**,
+  **MASK_BY_BRIEF**, or **MASK_BY_FAKE**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `processed_data` - The data content after the mask algorithm processing.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5049,6 +5049,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_device":                         dsc.ResourceDscDevice(),
 			"huaweicloud_dsc_instance":                       dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_mask_algorithm":                 dsc.ResourceMaskAlgorithm(),
+			"huaweicloud_dsc_mask_algorithm_debug":           dsc.ResourceMaskAlgorithmDebug(),
 			"huaweicloud_dsc_measure_info":                   dsc.ResourceMeasureInfo(),
 			"huaweicloud_dsc_multi_enable_trusted_service":   dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_operate_obs_audit":              dsc.ResourceOperateObsAudit(),

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_mask_algorithm_debug_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_mask_algorithm_debug_test.go
@@ -1,0 +1,61 @@
+package dsc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running the test, please ensure that you have created a DSC instance.
+func TestAccMaskAlgorithmDebug_basic(t *testing.T) {
+	var (
+		rName              = "huaweicloud_dsc_mask_algorithm_debug.test"
+		rNameWithParameter = "huaweicloud_dsc_mask_algorithm_debug.with_parameter"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDscInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMaskAlgorithmDebug_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "algorithm", "SHA256"),
+					resource.TestCheckResourceAttr(rName, "algorithm_type", "MASK_BY_HASH"),
+					resource.TestCheckResourceAttrSet(rName, "processed_data"),
+					// Test the resource with parameter.
+					resource.TestCheckResourceAttr(rNameWithParameter, "data", "1234567890123456789"),
+					resource.TestCheckResourceAttr(rNameWithParameter, "algorithm", "PRESNM"),
+					resource.TestCheckResourceAttr(rNameWithParameter, "algorithm_type", "MASK_BY_OVERWRITE"),
+					resource.TestCheckResourceAttr(rNameWithParameter, "processed_data", "1234***********6789"),
+				),
+			},
+		},
+	})
+}
+
+const testAccMaskAlgorithmDebug_basic = `
+resource "huaweicloud_dsc_mask_algorithm_debug" "test" {
+  data           = "test"
+  algorithm      = "SHA256"
+  algorithm_type = "MASK_BY_HASH"
+}
+
+resource "huaweicloud_dsc_mask_algorithm_debug" "with_parameter" {
+  data           = "1234567890123456789"
+  algorithm      = "PRESNM"
+  algorithm_type = "MASK_BY_OVERWRITE"
+  parameter      = jsonencode({
+    type   = "CHAR"
+    first  = 4
+    second = 4
+    method = "*"
+  })
+}
+`

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_mask_algorithm_debug.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_mask_algorithm_debug.go
@@ -1,0 +1,173 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var maskAlgorithmDebugNonUpdatableParams = []string{
+	"algorithm",
+	"algorithm_type",
+	"data",
+	"parameter",
+}
+
+// @API DSC POST /v1/{project_id}/sdg/server/mask/algorithms/test
+func ResourceMaskAlgorithmDebug() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceMaskAlgorithmDebugCreate,
+		ReadContext:   resourceMaskAlgorithmDebugRead,
+		UpdateContext: resourceMaskAlgorithmDebugUpdate,
+		DeleteContext: resourceMaskAlgorithmDebugDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(maskAlgorithmDebugNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the mask algorithm to be tested is located.`,
+			},
+
+			// Required parameters.
+			"algorithm": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The mask algorithm.`,
+			},
+			"algorithm_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the mask algorithm.`,
+			},
+			"data": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: `The data content to be processed by the mask algorithm.`,
+			},
+
+			// Optional parameters.
+			"parameter": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The configuration parameters of the mask algorithm, in JSON format.`,
+			},
+
+			// Attributes.
+			"processed_data": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data content after the mask algorithm processing.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildMaskAlgorithmDebugBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Required parameters.
+		"algorithm":      d.Get("algorithm"),
+		"algorithm_type": d.Get("algorithm_type"),
+		"data":           d.Get("data"),
+		// Optional parameters.
+		"parameter": utils.ValueIgnoreEmpty(d.Get("parameter")),
+	}
+}
+
+func debugMaskAlgorithm(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v1/{project_id}/sdg/server/mask/algorithms/test"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildMaskAlgorithmDebugBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceMaskAlgorithmDebugCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	respBody, err := debugMaskAlgorithm(client, d)
+	if err != nil {
+		return diag.Errorf("error testing mask algorithm: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("processed_data", utils.PathSearch("processed_data", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceMaskAlgorithmDebugRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceMaskAlgorithmDebugUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceMaskAlgorithmDebugDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to test a DSC mask algorithm. Deleting this resource
+will not clear the corresponding test record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time action resource to test mask algorithm.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new one-time action resource for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccMaskAlgorithmDebug_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccMaskAlgorithmDebug_basic -timeout 360m -parallel 10
=== RUN   TestAccMaskAlgorithmDebug_basic
=== PAUSE TestAccMaskAlgorithmDebug_basic
=== CONT  TestAccMaskAlgorithmDebug_basic
--- PASS: TestAccMaskAlgorithmDebug_basic (16.53s)
PASS
coverage: 7.7% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       16.671s coverage: 7.7% of statements in ./huaweicloud/services/dsc
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
