### PR TITLE
feat(dsc): add data source to dsc db mask_tasks

### DIFF
--- a/docs/data-sources/dsc_db_mask_tasks.md
+++ b/docs/data-sources/dsc_db_mask_tasks.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_db_mask_tasks"
+description: |-
+  Use this data source to get the list of DSC database mask tasks within HuaweiCloud.
+---
+
+# huaweicloud_dsc_db_mask_tasks
+
+Use this data source to get the list of DSC database mask tasks within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "template_id" {}
+
+data "huaweicloud_dsc_db_mask_tasks" "test" {
+  template_id = var.template_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `template_id` - (Required, String) Specifies the template ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - The database mask task list.
+
+  The [tasks](#tasks_struct) structure is documented below.
+
+<a name="tasks_struct"></a>
+The `tasks` block supports:
+
+* `db_type` - The database type.
+
+* `end_time` - The task end time.
+
+* `execute_line` - The number of executed lines.
+
+* `id` - The task ID.
+
+* `progress` - The task progress.
+
+* `run_status` - The task running status.
+
+* `start_time` - The task start time.
+
+* `task_template_id` - The task template ID.
+
+* `type` - The task type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1433,6 +1433,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_data_map_score":                   dsc.DataSourceDscDataMapScore(),
 			"huaweicloud_dsc_data_map_security_level":          dsc.DataSourceDscDataMapSecurityLevel(),
 			"huaweicloud_dsc_data_map_risk_level_info":         dsc.DataSourceDataMapRiskLevelInfo(),
+			"huaweicloud_dsc_db_mask_tasks":                    dsc.DataSourceDscDbMaskTasks(),
 			"huaweicloud_dsc_dbss_ins_info":                    dsc.DataSourceDscDbssInsInfo(),
 			"huaweicloud_dsc_devices":                          dsc.DataSourceDscDevices(),
 			"huaweicloud_dsc_device_monitor_infos":             dsc.DataSourceDscDeviceMonitorInfos(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_db_mask_tasks_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_db_mask_tasks_test.go
@@ -1,0 +1,51 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscDbMaskTasks_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_db_mask_tasks.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDSCScanTemplateID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDscDbMaskTasks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.db_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.end_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.execute_line"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.progress"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.run_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.start_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.task_template_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.type"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDscDbMaskTasks_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_db_mask_tasks" "test" {
+  template_id = "%s"
+}
+`, acceptance.HW_DSC_SCAN_TEMPLATE_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_db_mask_tasks.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_db_mask_tasks.go
@@ -1,0 +1,169 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/sdg/server/mask/dbs/templates/{template_id}/tasks
+func DataSourceDscDbMaskTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscDbMaskTasksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tasks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dbMaskTaskSchema(),
+			},
+		},
+	}
+}
+
+func dbMaskTaskSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"db_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"execute_line": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"progress": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"run_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"task_template_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDbMaskTasksQueryParams(limit, offset int) string {
+	return fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+}
+
+func dataSourceDscDbMaskTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sdg/server/mask/dbs/templates/{template_id}/tasks"
+		product = "dsc"
+		limit   = 1000
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{template_id}", d.Get("template_id").(string))
+
+	for {
+		currentPath := requestPath + buildDbMaskTasksQueryParams(limit, offset)
+		requestOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		requestResp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DSC db mask tasks: %s", err)
+		}
+
+		requestRespBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		tasksList := utils.PathSearch("tasks", requestRespBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, tasksList...)
+		if len(tasksList) < limit {
+			break
+		}
+		offset += len(tasksList)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tasks", flattenDbMaskTasks(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDbMaskTasks(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"db_type":          utils.PathSearch("db_type", v, nil),
+			"end_time":         utils.PathSearch("end_time", v, nil),
+			"execute_line":     utils.PathSearch("execute_line", v, nil),
+			"id":               utils.PathSearch("id", v, nil),
+			"progress":         utils.PathSearch("progress", v, nil),
+			"run_status":       utils.PathSearch("run_status", v, nil),
+			"start_time":       utils.PathSearch("start_time", v, nil),
+			"task_template_id": utils.PathSearch("task_template_id", v, nil),
+			"type":             utils.PathSearch("type", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to dsc db mask tasks
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to dsc db mask tasks
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscDbMaskTasks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscDbMaskTasks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscDbMaskTasks_basic
=== PAUSE TestAccDataSourceDscDbMaskTasks_basic
=== CONT  TestAccDataSourceDscDbMaskTasks_basic
--- PASS: TestAccDataSourceDscDbMaskTasks_basic (23.90s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       24.020s coverage: 6.3% of statements in ./huaweicloud/services/dsc
```
<img width="964" height="25" alt="image" src="https://github.com/user-attachments/assets/f70893df-8782-4f4c-8ab1-e55938d297c8" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
