### PR TITLE
fix(mrs): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_scaling_policy_v2.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_scaling_policy_v2.go
@@ -472,19 +472,21 @@ func resourceScalingPolicyV2Update(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating MRS client: %s", err)
 	}
 
-	updatePath := client.Endpoint + "v2/{project_id}/autoscaling-policy/{cluster_id}"
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", d.Get("cluster_id").(string))
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + "v2/{project_id}/autoscaling-policy/{cluster_id}"
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", d.Get("cluster_id").(string))
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-		JSONBody:         utils.RemoveNil(buildScalingPolicyV2Params(d)),
-	}
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+			JSONBody:         utils.RemoveNil(buildScalingPolicyV2Params(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating scaling policy: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating scaling policy: %s", err)
+		}
 	}
 
 	return resourceScalingPolicyV2Read(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes a bug in the MRS (MapReduce Service) scaling policy v2 resource (resource_huaweicloud_mapreduce_scaling_policy_v2.go). Previously, when only the enable_force_new field was changed, the update function would still send an unnecessary PUT API request to the server. This change wraps the update API call logic inside a d.HasChangeExcept("enable_force_new") check, so that the actual update request is skipped when the only change is to the enable_force_new field. This avoids unnecessary API calls and potential errors when toggling the enable_force_new parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
The change is minimal (14 additions, 12 deletions in a single file). It simply adds a conditional check if d.HasChangeExcept("enable_force_new") around the existing update logic in resourceScalingPolicyV2Update. The resourceScalingPolicyV2Read call at the end remains unconditional to ensure state is always refreshed.

When updating both the enable_force_new and rules parameters of the huaweicloud_mapreduce_scaling_policy_v2 resource, the PUT update API was invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1462" height="1015" alt="image" src="https://github.com/user-attachments/assets/10915824-6b43-41ba-91c3-037c09ba877a" />

When updating only the enable_force_new parameter of the huaweicloud_mapreduce_scaling_policy_v2 resource, the PUT update API was not invoked. This behavior meets the expected requirements. The screenshot is shown below:
<img width="1483" height="1004" alt="image" src="https://github.com/user-attachments/assets/3028713c-38d3-47d3-8c6f-751057f38d2f" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix(mrs): skip update API call for `huaweicloud_mapreduce_scaling_policy_v2` when only `enable_force_new` is changed
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
