### PR TITLE
feat(geminidb): add a best practice for creating geminidb cassandra instance

### DIFF
--- a/examples/geminidb/geminidb-cassandra-instance/README.md
+++ b/examples/geminidb/geminidb-cassandra-instance/README.md
@@ -1,0 +1,113 @@
+# Create a GeminiDB Cassandra Instance
+
+This example provides best practice code for using Terraform to create a GeminiDB Cassandra instance in HuaweiCloud
+GeminiDB service.
+
+## Prerequisites
+
+* A HuaweiCloud account
+* Terraform installed
+* HuaweiCloud access key and secret key (AK/SK)
+
+## Variable Introduction
+
+The following variables need to be configured:
+
+### Authentication Variables
+
+* `region_name` - The region where the GeminiDB Cassandra instance is located
+* `access_key` - The access key of the IAM user
+* `secret_key` - The secret key of the IAM user
+
+### Resource Variables
+
+#### Required Variables
+
+* `vpc_name` - The VPC name
+* `subnet_name` - The subnet name
+* `security_group_name` - The security group name
+* `instance_name` - The GeminiDB Cassandra instance name
+* `instance_backup_time_window` - The backup time window in HH:MM-HH:MM format
+* `instance_backup_keep_days` - The number of days to retain backups
+* `backup_name` - The name for instance backups
+
+#### Optional Variables
+
+* `vpc_cidr` - The CIDR block of the VPC (default: "192.168.0.0/16")
+* `availability_zone` - The availability zone to which the GeminiDB Cassandra instance belongs (default: "", auto-selected)
+* `subnet_cidr` - The CIDR block of the subnet (default: "", auto-calculated from VPC CIDR)
+* `gateway_ip` - The gateway IP address of the subnet (default: "", auto-calculated)
+* `instance_datastore_version` - The Cassandra database engine version (default: "3.11")
+* `instance_mode` - The instance mode (default: "Cluster"). Valid values: Cluster, Single
+* `instance_flavor_num` - The number of nodes in the Cassandra cluster (default: 3)
+* `instance_flavor_size` - The storage size in GB per node (default: 100)
+* `instance_flavor_storage` - The storage type (default: "ULTRAHIGH"). Valid values: ULTRAHIGH, ESSD
+* `instance_flavor_spec_code` - The resource specification code (default: "", auto-queried from flavors data source)
+* `instance_db_port` - The Cassandra database port (default: 9042)
+* `instance_password` - The password for the GeminiDB Cassandra instance (default: "", auto-generated)
+* `instance_ssl_option` - The SSL option (default: "on"). Valid values: on, off
+* `backup_description` - The description for instance backups (default: "Terraform created backup")
+* `charging_mode` - The charging mode (default: "postPaid"). Valid values: postPaid, prePaid
+* `period_unit` - The period unit for prePaid mode (default: "month"). Valid values: month, year
+* `period` - The period for prePaid mode (default: 1)
+* `auto_renew` - Whether to auto renew for prePaid mode (default: "false")
+* `tags` - The key/value pairs to associate with the GeminiDB Cassandra instance (default: {})
+
+## Usage
+
+* Copy this example script to your `main.tf`.
+* Create a `terraform.tfvars` file and fill in the required variables:
+
+  ```hcl
+  region_name                    = "cn-north-4"
+  vpc_name                       = "your_vpc_name"
+  subnet_name                    = "your_subnet_name"
+  security_group_name            = "your_security_group_name"
+  instance_name                  = "your_geminidb_cassandra_name"
+  instance_backup_time_window    = "03:00-04:00"
+  instance_backup_keep_days      = 14
+  backup_name                    = "your_backup_name"
+  ```
+
+* Initialize Terraform:
+
+  ```bash
+  $ terraform init
+  ```
+
+* Review the Terraform plan:
+
+  ```bash
+  $ terraform plan
+  ```
+
+* Apply the configuration:
+
+  ```bash
+  $ terraform apply
+  ```
+
+* To clean up the resources:
+
+  ```bash
+  $ terraform destroy
+  ```
+
+## Note
+
+* Make sure to keep your credentials secure and never commit them to version control
+* The creation of the GeminiDB Cassandra instance takes about 10 minutes
+* This example creates the GeminiDB Cassandra instance, VPC, subnet, security group, and backup
+* All resources will be created in the specified region
+* If `instance_flavor_spec_code` is empty, the flavor will be automatically queried from the
+  `huaweicloud_gaussdb_nosql_flavors` data source
+* If `instance_password` is empty, a random password will be generated
+* The security group opens both the Cassandra native transport port (9042) and the Thrift port (9160)
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.14.0 |
+| huaweicloud | >= 1.47.0 |
+| random | >= 3.0.0 |

--- a/examples/geminidb/geminidb-cassandra-instance/main.tf
+++ b/examples/geminidb/geminidb-cassandra-instance/main.tf
@@ -1,0 +1,90 @@
+# Create VPC and subnet for GeminiDB Cassandra instance
+resource "huaweicloud_vpc" "test" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+}
+
+data "huaweicloud_availability_zones" "test" {
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = var.subnet_name
+  cidr       = var.subnet_cidr == "" ? cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0) : var.subnet_cidr
+  gateway_ip = var.gateway_ip == "" ? cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0), 1) : var.gateway_ip
+}
+
+# Query GeminiDB NoSQL flavors for Cassandra
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = var.vcpus
+  engine            = "cassandra"
+  availability_zone = var.availability_zone == "" ? try(data.huaweicloud_availability_zones.test.names[0], null) : var.availability_zone
+}
+
+# Create security group for GeminiDB Cassandra instance
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = var.security_group_name
+  delete_default_rules = true
+}
+
+# Generate random password if not provided
+resource "random_password" "test" {
+  count            = var.instance_password == "" ? 1 : 0
+
+  length           = 12
+  special          = true
+  override_special = "!@%^*-_=+"
+}
+
+# Create GeminiDB Cassandra instance
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = var.instance_name
+  availability_zone = var.availability_zone == "" ? try(data.huaweicloud_availability_zones.test.names[0], null) : var.availability_zone
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "Qi@123456"
+  mode              = var.instance_mode
+  port              = var.instance_db_port
+  ssl_option        = var.instance_ssl_option
+
+  datastore {
+    type           = "cassandra"
+    version        = ""
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = var.instance_flavor_num
+    size      = var.instance_flavor_size
+    storage   = var.instance_flavor_storage
+    spec_code = var.instance_flavor_spec_code != "" ? var.instance_flavor_spec_code : try(data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name, null)
+  }
+
+  backup_strategy {
+    start_time = var.instance_backup_time_window
+    keep_days  = var.instance_backup_keep_days
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  auto_renew    = "true"
+  period        = 1
+
+  tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      flavor.0.spec_code,
+    ]
+  }
+}
+
+# Create GeminiDB backup
+resource "huaweicloud_geminidb_backup" "test" {
+  instance_id = huaweicloud_geminidb_instance.test.id
+  name        = var.backup_name
+  description = var.backup_description
+
+  depends_on = [huaweicloud_geminidb_instance.test]
+}

--- a/examples/geminidb/geminidb-cassandra-instance/providers.tf
+++ b/examples/geminidb/geminidb-cassandra-instance/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.92.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/geminidb/geminidb-cassandra-instance/terraform.tfvars
+++ b/examples/geminidb/geminidb-cassandra-instance/terraform.tfvars
@@ -1,0 +1,8 @@
+region_name                    = "cn-north-4"
+vpc_name                       = "tf_test_vpc"
+subnet_name                    = "tf_test_subnet"
+security_group_name            = "tf_test_security_group"
+instance_name                  = "tf_test_geminidb_cassandra"
+instance_backup_time_window    = "03:00-04:00"
+instance_backup_keep_days      = 14
+backup_name                    = "tf_test_backup"

--- a/examples/geminidb/geminidb-cassandra-instance/variables.tf
+++ b/examples/geminidb/geminidb-cassandra-instance/variables.tf
@@ -1,0 +1,144 @@
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where the GeminiDB Cassandra instance is located"
+  type        = string
+}
+
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+# Variable definitions for resources/data sources
+variable "vpc_name" {
+  description = "The VPC name"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block of the VPC"
+  type        = string
+  default     = "192.168.0.0/16"
+}
+
+variable "subnet_name" {
+  description = "The subnet name"
+  type        = string
+}
+
+variable "subnet_cidr" {
+  description = "The CIDR block of the subnet"
+  type        = string
+  default     = ""
+}
+
+variable "gateway_ip" {
+  description = "The gateway IP address of the subnet"
+  type        = string
+  default     = ""
+}
+
+variable "vcpus" {
+  description = "The number of vCPUs"
+  type        = string
+  default     = "2"
+}
+
+variable "availability_zone" {
+  description = "The availability zone to which the GeminiDB Cassandra instance belongs"
+  type        = string
+  default     = ""
+}
+
+variable "security_group_name" {
+  description = "The security group name"
+  type        = string
+}
+
+variable "instance_password" {
+  description = "The password for the GeminiDB Cassandra instance"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "instance_name" {
+  description = "The GeminiDB Cassandra instance name"
+  type        = string
+}
+
+variable "instance_mode" {
+  description = "The instance mode. Valid values are Cluster, Single"
+  type        = string
+  default     = "Cluster"
+}
+
+variable "instance_db_port" {
+  description = "The Cassandra database port"
+  type        = number
+  default     = 9042
+}
+
+variable "instance_ssl_option" {
+  description = "The SSL option. Valid values are on, off"
+  type        = string
+  default     = "on"
+}
+
+variable "instance_flavor_num" {
+  description = "The number of nodes in the Cassandra cluster"
+  type        = number
+  default     = 3
+}
+
+variable "instance_flavor_size" {
+  description = "The storage size in GB per node"
+  type        = number
+  default     = 100
+}
+
+variable "instance_flavor_storage" {
+  description = "The storage type. Valid values are ULTRAHIGH, ESSD"
+  type        = string
+  default     = "ULTRAHIGH"
+}
+
+variable "instance_flavor_spec_code" {
+  description = "The resource specification code. If empty, it will be queried from flavors data source"
+  type        = string
+  default     = ""
+}
+
+variable "instance_backup_time_window" {
+  description = "The backup time window in HH:MM-HH:MM format"
+  type        = string
+}
+
+variable "instance_backup_keep_days" {
+  description = "The number of days to retain backups"
+  type        = number
+}
+
+variable "tags" {
+  description = "The key/value pairs to associate with the GeminiDB Cassandra instance"
+  type        = map(string)
+  default     = {}
+}
+
+variable "backup_name" {
+  description = "The name for instance backups"
+  type        = string
+}
+
+variable "backup_description" {
+  description = "The description for instance backups"
+  type        = string
+  default     = "Terraform created backup"
+}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a best practice for creating geminidb cassandra instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a best practice for creating geminidb cassandra instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

terraform apply：
<img width="553" height="407" alt="image" src="https://github.com/user-attachments/assets/c908242a-aea5-4eeb-8b91-7dde0db1cbed" />
<img width="554" height="761" alt="image" src="https://github.com/user-attachments/assets/99061c83-6c51-4cac-a939-a963dffd8d81" />
<img width="554" height="798" alt="image" src="https://github.com/user-attachments/assets/c13fd966-480a-4767-9c63-c14964514317" />
<img width="554" height="809" alt="image" src="https://github.com/user-attachments/assets/e3959296-20d1-4727-b561-7381876bc9f5" />
<img width="554" height="492" alt="image" src="https://github.com/user-attachments/assets/8253a14a-7689-48e4-9e4b-ce8cacb559fe" />
<img width="554" height="437" alt="image" src="https://github.com/user-attachments/assets/36a27b99-e01c-4f61-b68e-5079e9818ed6" />
terraform destroy：
<img width="554" height="418" alt="image" src="https://github.com/user-attachments/assets/13e9c63f-29df-4da8-88f8-9f29ce361758" />
<img width="553" height="662" alt="image" src="https://github.com/user-attachments/assets/d10e8d7b-0b4c-4164-a4c4-57894a8d5d7d" />
<img width="554" height="648" alt="image" src="https://github.com/user-attachments/assets/9c30ea1d-c15b-4dbb-bdcd-dbe6ee1fbce1" />
<img width="554" height="724" alt="image" src="https://github.com/user-attachments/assets/56f80562-b57d-47ca-a10a-a97a81fe2d7f" />
<img width="554" height="764" alt="image" src="https://github.com/user-attachments/assets/69101dd0-7530-4fa5-a411-44202e84eda5" />
<img width="554" height="780" alt="image" src="https://github.com/user-attachments/assets/4bd942d1-c3ef-46c7-a940-2783ca67bbc1" />
<img width="553" height="477" alt="image" src="https://github.com/user-attachments/assets/df2a3b0a-5c60-4f64-841e-0b56bf6b5817" />
<img width="554" height="425" alt="image" src="https://github.com/user-attachments/assets/27795f5e-d0e2-4ffc-87d7-e70e057eb72b" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
