### PR TITLE
feat(obs): obs bucket support new fields

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -303,6 +303,13 @@ The following arguments are supported:
 
   -> When creating or updating the OBS bucket user domain names, the original user domain names will be overwritten.
 
+* `ies_location` - (Optional, String, ForceNew) Specifies the OBS ies location of the bucket.
+  This field is required when creating bucket in CloudPond site, its value should be the AZ ID of the CloudPond site.
+
+* `edge_location` - (Optional, String, ForceNew) Specifies the OBS edge location of the bucket.
+  This field is required when creating bucket in Intelligent Edge Cloud site, its value should be the AZ ID of the
+  Intelligent Edge Cloud site.
+
 The `logging` object supports the following:
 
 * `target_bucket` - (Required, String) The name of the bucket that will receive the log objects. The acl policy of the
@@ -443,8 +450,8 @@ $ terraform import huaweicloud_obs_bucket.bucket_with_s3_policy <bucket-name>/s3
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response. The missing attributes include `acl` and `force_destroy`. It is generally recommended
-running `terraform plan` after importing an OBS bucket. Also you can ignore changes as below.
+API response. The missing attributes include `acl`, `force_destroy`, `ies_location`, `edge_location`. It is generally
+recommended running `terraform plan` after importing an OBS bucket. Also you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_obs_bucket" "bucket" {
@@ -452,7 +459,7 @@ resource "huaweicloud_obs_bucket" "bucket" {
 
   lifecycle {
     ignore_changes = [
-      acl, force_destroy,
+      acl, force_destroy, ies_location, edge_location,
     ]
   }
 }

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -384,7 +384,17 @@ func ResourceObsBucket() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
+			// Fields `ies_location` and `edge_location` only support in specified site.
+			"ies_location": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"edge_location": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"bucket_domain_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -488,6 +498,8 @@ func resourceObsBucketCreate(ctx context.Context, d *schema.ResourceData, meta i
 		obs.WithCustomHeader("x-obs-server-side-encryption-kms-key-id", buildSideEncryptionKmsKeyIdParam(d)),
 		obs.WithCustomHeader("x-obs-server-side-encryption-bucket-key-enabled", buildSideEncryptionBucketKeyEnabledParam(d)),
 		obs.WithCustomHeader("x-obs-sse-kms-key-project-id", buildKmsKeyProjectIdParam(d)),
+		obs.WithCustomHeader("x-obs-ies-location", d.Get("ies_location").(string)),
+		obs.WithCustomHeader("x-obs-edge-location", d.Get("edge_location").(string)),
 	)
 	if err != nil {
 		return diag.FromErr(getObsError("Error creating bucket", bucket, err))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

obs bucket support new fields。
The two newly added fields can only be used on specific sites and cannot be tested for the time being.

The newly added fields do not affect existing functionality and are not included in request construction by default.
An error will occur if this field is configured for the Dayun site; this information has been added to the documentation.
<img width="1566" height="238" alt="image" src="https://github.com/user-attachments/assets/6c629867-b867-4d94-9497-c7a74bceea2e" />



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o obs -f TestAccObsBucket_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucket_basic -timeout 360m -parallel 10
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (23.58s)
PASS
coverage: 16.8% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       23.700s coverage: 16.8% of statements in ./huaweicloud/services/obs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
