### PR TITLE
fix(geminidb): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_dr_switchover_configuration_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_dr_switchover_configuration_test.go
@@ -23,10 +23,11 @@ func TestAccGeminiDBDRSwitchoverConfiguration_basic(t *testing.T) {
 				Config: testAccGeminiDBDRSwitchoverConfiguration_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "switchover_ratio", "50"),
+					resource.TestCheckResourceAttr(rName, "sync_delay", "10"),
 				),
 			},
 			{
-				Config: testAccGeminiDBDisasterRecoverySettings_withSyncDelay(),
+				Config: testAccGeminiDBDRSwitchoverConfiguration_update(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "switchover_ratio", "60"),
 					resource.TestCheckResourceAttr(rName, "sync_delay", "300"),
@@ -46,11 +47,12 @@ func testAccGeminiDBDRSwitchoverConfiguration_basic() string {
 resource "huaweicloud_geminidb_dr_switchover_configuration" "test" {
   instance_id      = "%s"
   switchover_ratio = 50
+  sync_delay       = 10
 }
 `, acceptance.HW_GEMINIDB_INSATNCE_ID)
 }
 
-func testAccGeminiDBDisasterRecoverySettings_withSyncDelay() string {
+func testAccGeminiDBDRSwitchoverConfiguration_update() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_geminidb_dr_switchover_configuration" "test" {
   instance_id      = "%s"

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_dr_switchover_configuration.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_dr_switchover_configuration.go
@@ -25,9 +25,9 @@ var geminiDbDRSwitchoverConfigurationParams = []string{
 // @API GeminiDB GET /v3/{project_id}/instances/disaster-recovery/settings
 func ResourceGeminiDBDRSwitchoverConfiguration() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceGeminiDBDRSwitchoverConfigurationCreateOrUpdate,
+		CreateContext: resourceGeminiDBDRSwitchoverConfigurationCreate,
 		ReadContext:   resourceGeminiDBDRSwitchoverConfigurationRead,
-		UpdateContext: resourceGeminiDBDRSwitchoverConfigurationCreateOrUpdate,
+		UpdateContext: resourceGeminiDBDRSwitchoverConfigurationUpdate,
 		DeleteContext: resourceGeminiDBDRSwitchoverConfigurationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -64,41 +64,45 @@ func ResourceGeminiDBDRSwitchoverConfiguration() *schema.Resource {
 	}
 }
 
-func resourceGeminiDBDRSwitchoverConfigurationCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+func configurationDRSwitchover(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v3/{project_id}/instances/disaster-recovery/settings"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildDisasterRecoverySettingsBody(d),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceGeminiDBDRSwitchoverConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
 
 	client, err := cfg.NewServiceClient("geminidb", region)
 	if err != nil {
 		return diag.Errorf("error creating GeminiDB client: %s", err)
 	}
 
-	httpUrl := "v3/{project_id}/instances/disaster-recovery/settings"
-	createOrUpdatePath := client.Endpoint + httpUrl
-	createOrUpdatePath = strings.ReplaceAll(createOrUpdatePath, "{project_id}", client.ProjectID)
-
-	createOrUpdateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-		JSONBody:         buildDisasterRecoverySettingsBody(d),
-	}
-
-	_, err = client.Request("PUT", createOrUpdatePath, &createOrUpdateOpt)
+	err = configurationDRSwitchover(client, d)
 	if err != nil {
 		return diag.Errorf("error setting disaster recovery settings: %s", err)
 	}
 
-	instanceID := d.Get("instance_id").(string)
-	d.SetId(instanceID)
+	d.SetId(instanceId)
 
 	return resourceGeminiDBDRSwitchoverConfigurationRead(ctx, d, meta)
 }
 
 func buildDisasterRecoverySettingsBody(d *schema.ResourceData) map[string]interface{} {
-	instanceID := d.Get("instance_id").(string)
-
 	settings := map[string]interface{}{
-		"instance_id":      instanceID,
+		"instance_id":      d.Get("instance_id"),
 		"switchover_ratio": utils.ValueIgnoreEmpty(d.Get("switchover_ratio")),
 		"sync_delay":       utils.ValueIgnoreEmpty(d.Get("sync_delay")),
 	}
@@ -156,6 +160,27 @@ func resourceGeminiDBDRSwitchoverConfigurationRead(_ context.Context, d *schema.
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceGeminiDBDRSwitchoverConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		err = configurationDRSwitchover(client, d)
+		if err != nil {
+			return diag.Errorf("error setting disaster recovery settings: %s", err)
+		}
+	}
+
+	return resourceGeminiDBDRSwitchoverConfigurationRead(ctx, d, meta)
 }
 
 func resourceGeminiDBDRSwitchoverConfigurationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_high_risk_command.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_high_risk_command.go
@@ -190,10 +190,12 @@ func resourceHighRiskCommandUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating GeminiDB client: %s", err)
 	}
 
-	resourceId := strings.Split(d.Id(), "/")
-	err = modifyHighRiskCommand(client, d, resourceId[0])
-	if err != nil {
-		return diag.Errorf("error updating GeminiDB high risk command: %s", err)
+	if d.HasChange("name") {
+		resourceId := strings.Split(d.Id(), "/")
+		err = modifyHighRiskCommand(client, d, resourceId[0])
+		if err != nil {
+			return diag.Errorf("error updating GeminiDB high risk command: %s", err)
+		}
 	}
 
 	return resourceHighRiskCommandRead(ctx, d, meta)

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance_lts_log_associate.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance_lts_log_associate.go
@@ -189,55 +189,61 @@ func resourceGeminiDBInstanceLtsLogAssociateRead(_ context.Context, d *schema.Re
 }
 
 func resourceGeminiDBInstanceLtsLogAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
 
 	client, err := cfg.NewServiceClient("geminidb", region)
 	if err != nil {
 		return diag.Errorf("error creating GeminiDB client: %s", err)
 	}
 
-	instanceID := d.Get("instance_id").(string)
-	logType := d.Get("log_type").(string)
-	ltsGroupID := d.Get("lts_group_id").(string)
-	ltsStreamID := d.Get("lts_stream_id").(string)
+	if d.HasChangeExcept("enable_force_new") {
+		httpUrl := "v3/{project_id}/instances/logs/lts-configs"
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
 
-	httpUrl := "v3/{project_id}/instances/logs/lts-configs"
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+			JSONBody:         buildUpdateLtsLogAssociateBodyParams(d, instanceId),
+		}
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody: map[string]interface{}{
-			"instance_ids":  []string{instanceID},
-			"log_type":      logType,
-			"lts_group_id":  ltsGroupID,
-			"lts_stream_id": ltsStreamID,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
-	}
+		retryFunc := func() (interface{}, bool, error) {
+			res, err := client.Request("POST", updatePath, &updateOpt)
+			retry, err := handleMultiOperationsError(err)
+			return res, retry, err
+		}
 
-	retryFunc := func() (interface{}, bool, error) {
-		res, err := client.Request("POST", updatePath, &updateOpt)
-		retry, err := handleMultiOperationsError(err)
-		return res, retry, err
-	}
+		_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     geminiDbInstanceStatusRefreshFunc(client, instanceId),
+			WaitTarget:   []string{"ACTIVE"},
+			Timeout:      d.Timeout(schema.TimeoutCreate),
+			DelayTimeout: 10 * time.Second,
+			PollInterval: 10 * time.Second,
+		})
 
-	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
-		Ctx:          ctx,
-		RetryFunc:    retryFunc,
-		WaitFunc:     geminiDbInstanceStatusRefreshFunc(client, instanceID),
-		WaitTarget:   []string{"ACTIVE"},
-		Timeout:      d.Timeout(schema.TimeoutCreate),
-		DelayTimeout: 10 * time.Second,
-		PollInterval: 10 * time.Second,
-	})
-
-	if err != nil {
-		return diag.Errorf("error updating LTS log configuration: %s", err)
+		if err != nil {
+			return diag.Errorf("error updating LTS log configuration: %s", err)
+		}
 	}
 
 	return resourceGeminiDBInstanceLtsLogAssociateRead(ctx, d, meta)
+}
+
+func buildUpdateLtsLogAssociateBodyParams(d *schema.ResourceData, instanceId string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"instance_ids":  []string{instanceId},
+		"log_type":      d.Get("log_type"),
+		"lts_group_id":  d.Get("lts_group_id"),
+		"lts_stream_id": d.Get("lts_stream_id"),
+	}
+
+	return bodyParams
 }
 
 func resourceGeminiDBInstanceLtsLogAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_memory_rule.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_memory_rule.go
@@ -268,9 +268,11 @@ func resourceMemoryRuleUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error creating GeminiDB client: %s", err)
 	}
 
-	err = updateMemoryRule(client, d)
-	if err != nil {
-		return diag.Errorf("error updating memory acceleration rule: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateMemoryRule(client, d)
+		if err != nil {
+			return diag.Errorf("error updating memory acceleration rule: %s", err)
+		}
 	}
 
 	return resourceMemoryRuleRead(ctx, d, meta)

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_parameter_template.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_parameter_template.go
@@ -293,8 +293,11 @@ func resourceGeminiDBParameterTemplateUpdate(ctx context.Context, d *schema.Reso
 		return diag.Errorf("error creating GeminiDB client: %s", err)
 	}
 
-	if err := updateGeminiDBParameterTemplate(client, d); err != nil {
-		return diag.FromErr(err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateGeminiDBParameterTemplate(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceGeminiDBParameterTemplateRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Skip update API calls when only enable_force_new changes for these resources:
+ huaweicloud_geminidb_dr_switchover_configuration
+ huaweicloud_geminidb_high_risk_command
+ huaweicloud_geminidb_instance_lts_log_associate
+ huaweicloud_geminidb_memory_rule
+ huaweicloud_geminidb_parameter_template

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. define the trigger boundaries of enable_force_new.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDBDRSwitchoverConfiguration_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDBDRSwitchoverConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBDRSwitchoverConfiguration_basic
=== PAUSE TestAccGeminiDBDRSwitchoverConfiguration_basic
=== CONT  TestAccGeminiDBDRSwitchoverConfiguration_basic
--- PASS: TestAccGeminiDBDRSwitchoverConfiguration_basic (20.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  20.362s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccResourceHighRiskCommand_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccResourceHighRiskCommand_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceHighRiskCommand_basic
=== PAUSE TestAccResourceHighRiskCommand_basic
=== CONT  TestAccResourceHighRiskCommand_basic
--- PASS: TestAccResourceHighRiskCommand_basic (1504.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1504.161s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccResourceGeminidbInstanceLtsLogAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccResourceGeminidbInstanceLtsLogAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceGeminidbInstanceLtsLogAssociate_basic
=== PAUSE TestAccResourceGeminidbInstanceLtsLogAssociate_basic
=== CONT  TestAccResourceGeminidbInstanceLtsLogAssociate_basic
--- PASS: TestAccResourceGeminidbInstanceLtsLogAssociate_basic (39.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  39.118s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccResourceMemoryRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccResourceMemoryRule_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceMemoryRule_basic
=== PAUSE TestAccResourceMemoryRule_basic
=== CONT  TestAccResourceMemoryRule_basic
--- PASS: TestAccResourceMemoryRule_basic (1465.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1465.344s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDBParameterTemplate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDBParameterTemplate_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBParameterTemplate_basic
=== PAUSE TestAccGeminiDBParameterTemplate_basic
=== CONT  TestAccGeminiDBParameterTemplate_basic
--- PASS: TestAccGeminiDBParameterTemplate_basic (22.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  22.942s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
