### PR TITLE
fix(gaussdb): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_client_auth_config.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_client_auth_config.go
@@ -242,54 +242,55 @@ func buildGaussDBClientAuthConfigQueryParams(offset int) string {
 }
 
 func resourceGaussDBClientAuthConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
-		httpUrl = "v3/{project_id}/instances/{instance_id}/hba-info"
-		product = "opengauss"
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/hba-info"
+		product    = "opengauss"
+		instanceId = d.Get("instance_id").(string)
 	)
 	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
-	instanceID := d.Get("instance_id").(string)
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceID)
+	if d.HasChange("method") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-	}
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		}
 
-	oldMethodRaw, newMethodRaw := d.GetChange("method")
+		oldMethodRaw, newMethodRaw := d.GetChange("method")
 
-	updateOpt.JSONBody = utils.RemoveNil(buildUpdateGaussDBClientAuthConfigBodyParams(
-		oldMethodRaw.(string),
-		newMethodRaw.(string),
-		d,
-	))
+		updateOpt.JSONBody = utils.RemoveNil(buildUpdateGaussDBClientAuthConfigBodyParams(
+			oldMethodRaw.(string),
+			newMethodRaw.(string),
+			d,
+		))
 
-	retryFunc := func() (interface{}, bool, error) {
-		res, err := client.Request("PUT", updatePath, &updateOpt)
-		retry, err := handleMultiOperationsError(err)
-		return res, retry, err
-	}
-	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
-		Ctx:          ctx,
-		RetryFunc:    retryFunc,
-		WaitFunc:     instanceStateRefreshFunc(client, instanceID),
-		WaitTarget:   []string{"ACTIVE"},
-		Timeout:      d.Timeout(schema.TimeoutUpdate),
-		DelayTimeout: 10 * time.Second,
-		PollInterval: 10 * time.Second,
-	})
-	if err != nil {
-		return diag.Errorf("error updating GaussDB client auth config: %s", err)
+		retryFunc := func() (interface{}, bool, error) {
+			res, err := client.Request("PUT", updatePath, &updateOpt)
+			retry, err := handleMultiOperationsError(err)
+			return res, retry, err
+		}
+		_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     instanceStateRefreshFunc(client, instanceId),
+			WaitTarget:   []string{"ACTIVE"},
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			DelayTimeout: 10 * time.Second,
+			PollInterval: 10 * time.Second,
+		})
+		if err != nil {
+			return diag.Errorf("error updating GaussDB client auth config: %s", err)
+		}
 	}
 
 	return resourceGaussDBClientAuthConfigRead(ctx, d, meta)

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_account_permission.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_account_permission.go
@@ -131,12 +131,11 @@ func resourceGaussdbInstanceAccountPermissionRead(_ context.Context, _ *schema.R
 }
 
 func resourceGaussdbInstanceAccountPermissionUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
 		httpUrl = "v3/{project_id}/instances/{instance_id}/db-privilege"
 		product = "opengauss"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
 	)
 
 	client, err := cfg.NewServiceClient(product, region)
@@ -144,31 +143,33 @@ func resourceGaussdbInstanceAccountPermissionUpdate(_ context.Context, d *schema
 		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
 
-	usersSet := d.Get("users").(*schema.Set)
-	usersList := usersSet.List()
+		usersSet := d.Get("users").(*schema.Set)
+		usersList := usersSet.List()
 
-	start := 0
-	end := int(math.Min(50, float64(len(usersList))))
+		start := 0
+		end := int(math.Min(50, float64(len(usersList))))
 
-	for start < end {
-		updateOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			MoreHeaders: map[string]string{
-				"Content-Type": "application/json",
-			},
+		for start < end {
+			updateOpt := golangsdk.RequestOpts{
+				KeepResponseBody: true,
+				MoreHeaders: map[string]string{
+					"Content-Type": "application/json",
+				},
+			}
+			updateOpt.JSONBody = utils.RemoveNil(buildCreateGaussdbInstanceAccountPermissionBodyParams(d, usersList[start:end]))
+
+			_, err = client.Request("POST", updatePath, &updateOpt)
+			if err != nil {
+				return diag.Errorf("error updating GaussDB instance account permission: %s", err)
+			}
+			start += 50
+			end = int(math.Min(float64(end+50), float64(len(usersList))))
 		}
-		updateOpt.JSONBody = utils.RemoveNil(buildCreateGaussdbInstanceAccountPermissionBodyParams(d, usersList[start:end]))
-
-		_, err = client.Request("POST", updatePath, &updateOpt)
-		if err != nil {
-			return diag.Errorf("error updating GaussDB instance account permission: %s", err)
-		}
-		start += 50
-		end = int(math.Min(float64(end+50), float64(len(usersList))))
 	}
 
 	return nil

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_full_sqls_config.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_full_sqls_config.go
@@ -207,10 +207,9 @@ func resourceFullSqlConfigRead(_ context.Context, _ *schema.ResourceData, _ inte
 }
 
 func resourceFullSqlConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
 		httpUrl = "v3/{project_id}/instances/{instance_id}/full-sqls/start"
 		product = "opengauss"
 	)
@@ -220,33 +219,35 @@ func resourceFullSqlConfigUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Id())
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Id())
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-		JSONBody:         utils.RemoveNil(buildFullSqlConfigBodyParams(d)),
-	}
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+			JSONBody:         utils.RemoveNil(buildFullSqlConfigBodyParams(d)),
+		}
 
-	resp, err := client.Request("POST", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating GaussDB full SQL configuration: %s", err)
-	}
+		resp, err := client.Request("POST", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating GaussDB full SQL configuration: %s", err)
+		}
 
-	respBody, err := utils.FlattenResponse(resp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
-	jobId := utils.PathSearch("job_id", respBody, nil)
-	if jobId == nil {
-		return diag.Errorf("error updating GaussDB full SQL collection: unable to find job ID")
-	}
-	err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId.(string), 5, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return diag.FromErr(err)
+		jobId := utils.PathSearch("job_id", respBody, nil)
+		if jobId == nil {
+			return diag.Errorf("error updating GaussDB full SQL collection: unable to find job ID")
+		}
+		err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId.(string), 5, d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_lts_log_associate.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_lts_log_associate.go
@@ -211,12 +211,12 @@ func resourceGaussdbInstanceLtsLogAssociateRead(_ context.Context, d *schema.Res
 }
 
 func resourceGaussdbInstanceLtsLogAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
-		httpUrl = "v3/{project_id}/instances/logs/lts-config"
-		product = "opengauss"
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/logs/lts-config"
+		product    = "opengauss"
+		instanceId = d.Get("instance_id").(string)
 	)
 
 	client, err := cfg.NewServiceClient(product, region)
@@ -224,49 +224,50 @@ func resourceGaussdbInstanceLtsLogAssociateUpdate(ctx context.Context, d *schema
 		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
-	instanceID := d.Get("instance_id").(string)
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-	}
-	updateOpt.JSONBody = utils.RemoveNil(buildCreateGaussdbInstanceLtsLogAssociateBodyParams(d))
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildCreateGaussdbInstanceLtsLogAssociateBodyParams(d)),
+		}
 
-	retryFunc := func() (interface{}, bool, error) {
-		res, err := client.Request("POST", updatePath, &updateOpt)
-		retry, err := handleMultiOperationsError(err)
-		return res, retry, err
-	}
-	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
-		Ctx:          ctx,
-		RetryFunc:    retryFunc,
-		WaitFunc:     instanceStateRefreshFunc(client, instanceID),
-		WaitTarget:   []string{"ACTIVE"},
-		Timeout:      d.Timeout(schema.TimeoutUpdate),
-		DelayTimeout: 10 * time.Second,
-		PollInterval: 10 * time.Second,
-	})
-	if err != nil {
-		return diag.Errorf("error updating GaussDB instance LTS log associate: %s", err)
-	}
+		retryFunc := func() (interface{}, bool, error) {
+			res, err := client.Request("POST", updatePath, &updateOpt)
+			retry, err := handleMultiOperationsError(err)
+			return res, retry, err
+		}
+		r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     instanceStateRefreshFunc(client, instanceId),
+			WaitTarget:   []string{"ACTIVE"},
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			DelayTimeout: 10 * time.Second,
+			PollInterval: 10 * time.Second,
+		})
+		if err != nil {
+			return diag.Errorf("error updating GaussDB instance LTS log associate: %s", err)
+		}
 
-	updateRespBody, err := utils.FlattenResponse(r.(*http.Response))
-	if err != nil {
-		return diag.FromErr(err)
-	}
+		updateRespBody, err := utils.FlattenResponse(r.(*http.Response))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
-	jobId := utils.PathSearch("job_id", updateRespBody, "").(string)
-	if jobId == "" {
-		return diag.Errorf("error updating GaussDB instance LTS log associate, job_id is not found in the response")
-	}
+		jobId := utils.PathSearch("job_id", updateRespBody, "").(string)
+		if jobId == "" {
+			return diag.Errorf("error updating GaussDB instance LTS log associate, job_id is not found in the response")
+		}
 
-	err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId, 2, d.Timeout(schema.TimeoutUpdate))
-	if err != nil {
-		return diag.FromErr(err)
+		err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId, 2, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceGaussdbInstanceLtsLogAssociateRead(ctx, d, meta)

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_role_permission.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance_role_permission.go
@@ -156,10 +156,9 @@ func resourceGaussDBInstanceRolePermissionRead(_ context.Context, _ *schema.Reso
 }
 
 func resourceGaussDBInstanceRolePermissionUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
 		httpUrl = "v3.1/{project_id}/instances/{instance_id}/db-privilege"
 		product = "opengauss"
 	)
@@ -169,21 +168,23 @@ func resourceGaussDBInstanceRolePermissionUpdate(_ context.Context, d *schema.Re
 		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-	}
-	updateOpt.JSONBody = utils.RemoveNil(buildCreateGaussDBInstanceRolePermissionBodyParams(d))
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildCreateGaussDBInstanceRolePermissionBodyParams(d)),
+		}
 
-	_, err = client.Request("POST", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating GaussDB instance role permission: %s", err)
+		_, err = client.Request("POST", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating GaussDB instance role permission: %s", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Skip update API calls when only enable_force_new changes for these resources:
+ huaweicloud_gaussdb_client_auth_config
+ huaweicloud_gaussdb_instance_account_permission
+ huaweicloud_gaussdb_instance_full_sqls_config
+ huaweicloud_gaussdb_instance_lts_log_associate
+ huaweicloud_gaussdb_instance_role_permission

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. define the trigger boundaries of enable_force_new.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

1.huaweicloud_gaussdb_client_auth_config
<img width="1230" height="933" alt="111" src="https://github.com/user-attachments/assets/5b977289-5246-40ef-af67-f51380f06122" />
<img width="1242" height="937" alt="222" src="https://github.com/user-attachments/assets/2ee07b03-4910-4bcf-9c30-974277bbce22" />
<img width="1247" height="932" alt="333" src="https://github.com/user-attachments/assets/e796b713-38f4-4c2d-8491-fd0ca4d84df4" />
2.huaweicloud_gaussdb_instance_account_permission
<img width="1237" height="911" alt="111" src="https://github.com/user-attachments/assets/82771c59-0bf9-43f2-8b6d-146a0ca50634" />
<img width="1238" height="929" alt="222" src="https://github.com/user-attachments/assets/9fd4ebd6-3111-4812-b9b6-1eaff54d2232" />
<img width="1242" height="925" alt="333" src="https://github.com/user-attachments/assets/2bcf079e-47ef-474d-b0fe-ac3dc39ada2c" />
3.huaweicloud_gaussdb_instance_full_sqls_config
<img width="1243" height="898" alt="111" src="https://github.com/user-attachments/assets/12bba50f-b16c-4a9f-829a-db50e4eaa780" />
<img width="1239" height="925" alt="222" src="https://github.com/user-attachments/assets/b864b66c-fedc-4010-9214-b581fb047f1f" />
<img width="1236" height="936" alt="333" src="https://github.com/user-attachments/assets/14f209c6-d685-45cf-8817-ad815e468f74" />
4.huaweicloud_gaussdb_instance_lts_log_associate
<img width="1240" height="908" alt="111" src="https://github.com/user-attachments/assets/a7c4b5c1-feb2-4c80-a640-8286b70f1521" />
<img width="1237" height="942" alt="222" src="https://github.com/user-attachments/assets/ede545f5-25e4-4e55-ad1e-3dee260cfde0" />
<img width="1235" height="942" alt="333" src="https://github.com/user-attachments/assets/39a01b0c-f4ca-42af-b9cd-bfdb2d350eb0" />
5.huaweicloud_gaussdb_instance_role_permission
<img width="1231" height="925" alt="111" src="https://github.com/user-attachments/assets/3f4e3f13-f60f-4a75-be2f-439cf2dafd51" />
<img width="1238" height="867" alt="222" src="https://github.com/user-attachments/assets/8701b0a7-0deb-485c-b81f-4f199cb7afc9" />
<img width="1234" height="941" alt="333" src="https://github.com/user-attachments/assets/cb19d2aa-b389-44dd-961d-2c89e6adc59f" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
