### PR TITLE
feat(dsc): add data source to dsc column details by level dim

### DIFF
--- a/docs/data-sources/dsc_column_details_by_level_dim.md
+++ b/docs/data-sources/dsc_column_details_by_level_dim.md
@@ -1,0 +1,108 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_column_details_by_level_dim"
+description: |-
+  Use this data source to get the column details of sensitive data by level dimension within HuaweiCloud.
+---
+
+# huaweicloud_dsc_column_details_by_level_dim
+
+Use this data source to get the column details of sensitive data by level dimension.
+
+## Example Usage
+
+```hcl
+variable "label_id" {}
+
+data "huaweicloud_dsc_column_details_by_level_dim" "test" {
+  label_id = var.label_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `label_id` - (Required, String) Specifies the group label ID for filtering.
+
+* `type_id` - (Optional, String) Specifies the type ID for filtering.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `results` - The column details list by level dimension.
+
+  The [results](#results_struct) structure is documented below.
+
+<a name="results_struct"></a>
+The `results` block supports:
+
+* `level_name` - The level name.
+
+* `columns` - The column information and match information list.
+
+  The [columns](#columns_struct) structure is documented below.
+
+<a name="columns_struct"></a>
+The `columns` block supports:
+
+* `asset_id` - The asset ID.
+
+* `asset_name` - The asset name.
+
+* `column_fqn` - The fully qualified name (FQN) of the column.
+
+* `db_type` - The database type.
+
+* `match_infos` - The match information list.
+
+  The [match_infos](#match_infos_struct) structure is documented below.
+
+<a name="match_infos_struct"></a>
+The `match_infos` block supports:
+
+* `classification_id` - The classification ID.
+
+* `classification_name` - The classification name.
+
+* `match_content_cnt` - The match content count.
+
+* `match_rate` - The match rate (percentage).
+
+* `matched_detail` - The matched detail.
+
+* `matched_examples` - The matched examples list.
+
+  The [matched_examples](#matched_examples_struct) structure is documented below.
+
+* `rule_id` - The rule ID.
+
+* `rule_name` - The rule name.
+
+* `security_level_color` - The security level color (RGB value).
+
+* `security_level_id` - The security level ID.
+
+* `security_level_name` - The security level name.
+
+* `template_id` - The template ID.
+
+* `template_name` - The template name.
+
+<a name="matched_examples_struct"></a>
+The `matched_examples` block supports:
+
+* `context` - The match context.
+
+* `line_number` - The line number of the match.
+
+* `matched_content` - The matched content.
+
+* `nlp_revised` - Whether the content has been NLP revised.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1465,6 +1465,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_template_rules":                   dsc.DataSourceDscTemplateRules(),
 			"huaweicloud_dsc_dbss_oem_info":                    dsc.DataSourceDbssOemInfo(),
 			"huaweicloud_dsc_catalog_statical_chart":           dsc.DataSourceCatalogStaticalChart(),
+			"huaweicloud_dsc_column_details_by_level_dim":      dsc.DataSourceDscColumnDetailsByLevelDim(),
 			"huaweicloud_dsc_multi_accounts":                   dsc.DataSourceMultiAccounts(),
 			"huaweicloud_dsc_multi_account_assets":             dsc.DataSourceMultiAccountAssets(),
 			"huaweicloud_dsc_multi_account_info":               dsc.DataSourceMultiAccountInfo(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -464,6 +464,7 @@ var (
 	HW_DSC_ALARM_TOPIC_ID           = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
 	HW_DSC_ASSET_ID                 = os.Getenv("HW_DSC_ASSET_ID")
 	HW_DSC_ENABLE_FLAG              = os.Getenv("HW_DSC_ENABLE_FLAG")
+	HW_DSC_LABEL_ID                 = os.Getenv("HW_DSC_LABEL_ID")
 	HW_DSC_TYPE_ID                  = os.Getenv("HW_DSC_TYPE_ID")
 	HW_DSC_SCAN_TEMPLATE_ID         = os.Getenv("HW_DSC_SCAN_TEMPLATE_ID")
 	HW_DSC_SCAN_JOB_ID              = os.Getenv("HW_DSC_SCAN_JOB_ID")
@@ -5343,6 +5344,13 @@ func TestAccPreCheckDscAssetId(t *testing.T) {
 func TestAccPreCheckDscEnableFlag(t *testing.T) {
 	if HW_DSC_ENABLE_FLAG == "" {
 		t.Skip("HW_DSC_ENABLE_FLAG must be set for DSC acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDscLabelId(t *testing.T) {
+	if HW_DSC_LABEL_ID == "" {
+		t.Skip("HW_DSC_LABEL_ID must be set for DSC acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_column_details_by_level_dim_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_column_details_by_level_dim_test.go
@@ -1,0 +1,43 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscColumnDetailsByLevelDim_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_column_details_by_level_dim.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscLabelId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscColumnDetailsByLevelDim_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "results.0.level_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDscColumnDetailsByLevelDim_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_column_details_by_level_dim" "test" {
+  label_id = "%[1]s"
+}
+`, acceptance.HW_DSC_LABEL_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_column_details_by_level_dim.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_column_details_by_level_dim.go
@@ -1,0 +1,338 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/metadata/catalog/column-details/level-dim
+func DataSourceDscColumnDetailsByLevelDim() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscColumnDetailsByLevelDimRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"label_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the group label ID for filtering.",
+			},
+			"type_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the type ID for filtering.",
+			},
+			"results": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The column details list by level dimension.",
+				Elem:        dscColumnDetailsLevelDimSchema(),
+			},
+		},
+	}
+}
+
+func dscColumnDetailsLevelDimSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"level_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The level name.",
+			},
+			"columns": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The column information and match information list.",
+				Elem:        dscColumnDetailsColumnInfoSchema(),
+			},
+		},
+	}
+}
+
+func dscColumnDetailsColumnInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"asset_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The asset ID.",
+			},
+			"asset_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The asset name.",
+			},
+			"column_fqn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The fully qualified name (FQN) of the column.",
+			},
+			"db_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The database type.",
+			},
+			"match_infos": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The match information list.",
+				Elem:        dscColumnDetailsMatchInfoSchema(),
+			},
+		},
+	}
+}
+
+func dscColumnDetailsMatchInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"classification_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The classification ID.",
+			},
+			"classification_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The classification name.",
+			},
+			"match_content_cnt": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The match content count.",
+			},
+			"match_rate": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "The match rate (percentage).",
+			},
+			"matched_detail": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The matched detail.",
+			},
+			"matched_examples": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The matched examples list.",
+				Elem:        dscColumnDetailsMatchedExamplesSchema(),
+			},
+			"rule_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The rule ID.",
+			},
+			"rule_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The rule name.",
+			},
+			"security_level_color": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The security level color (RGB value).",
+			},
+			"security_level_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The security level ID.",
+			},
+			"security_level_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The security level name.",
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template ID.",
+			},
+			"template_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template name.",
+			},
+		},
+	}
+}
+
+func dscColumnDetailsMatchedExamplesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"context": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The match context.",
+			},
+			"line_number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The line number of the match.",
+			},
+			"matched_content": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The matched content.",
+			},
+			"nlp_revised": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the content has been NLP revised.",
+			},
+		},
+	}
+}
+
+func buildDscColumnDetailsByLevelDimQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?label_id=%v", d.Get("label_id"))
+	if v, ok := d.GetOk("type_id"); ok {
+		queryParams = fmt.Sprintf("%s&type_id=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceDscColumnDetailsByLevelDimRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v1/{project_id}/metadata/catalog/column-details/level-dim"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	currentPath := requestPath + buildDscColumnDetailsByLevelDimQueryParams(d)
+
+	resp, err := client.Request("GET", currentPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC column details by level dimension: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("results", flattenDscColumnDetailsLevelDim(
+			utils.PathSearch("results", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDscColumnDetailsLevelDim(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(results))
+	for _, v := range results {
+		rst = append(rst, map[string]interface{}{
+			"level_name": utils.PathSearch("level_name", v, nil),
+			"columns": flattenDscColumnDetailsColumnInfo(
+				utils.PathSearch("columns", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenDscColumnDetailsColumnInfo(columns []interface{}) []interface{} {
+	if len(columns) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(columns))
+	for _, v := range columns {
+		rst = append(rst, map[string]interface{}{
+			"asset_id":   utils.PathSearch("asset_id", v, nil),
+			"asset_name": utils.PathSearch("asset_name", v, nil),
+			"column_fqn": utils.PathSearch("column_fqn", v, nil),
+			"db_type":    utils.PathSearch("db_type", v, nil),
+			"match_infos": flattenDscColumnDetailsMatchInfo(
+				utils.PathSearch("match_infos", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenDscColumnDetailsMatchInfo(matchInfos []interface{}) []interface{} {
+	if len(matchInfos) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(matchInfos))
+	for _, v := range matchInfos {
+		rst = append(rst, map[string]interface{}{
+			"classification_id":   utils.PathSearch("classification_id", v, nil),
+			"classification_name": utils.PathSearch("classification_name", v, nil),
+			"match_content_cnt":   utils.PathSearch("match_content_cnt", v, nil),
+			"match_rate":          utils.PathSearch("match_rate", v, nil),
+			"matched_detail":      utils.PathSearch("matched_detail", v, nil),
+			"matched_examples": flattenDscColumnDetailsMatchedExamples(
+				utils.PathSearch("matched_examples", v, make([]interface{}, 0)).([]interface{})),
+			"rule_id":              utils.PathSearch("rule_id", v, nil),
+			"rule_name":            utils.PathSearch("rule_name", v, nil),
+			"security_level_color": utils.PathSearch("security_level_color", v, nil),
+			"security_level_id":    utils.PathSearch("security_level_id", v, nil),
+			"security_level_name":  utils.PathSearch("security_level_name", v, nil),
+			"template_id":          utils.PathSearch("template_id", v, nil),
+			"template_name":        utils.PathSearch("template_name", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenDscColumnDetailsMatchedExamples(examples []interface{}) []interface{} {
+	if len(examples) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(examples))
+	for _, v := range examples {
+		rst = append(rst, map[string]interface{}{
+			"context":         utils.PathSearch("context", v, nil),
+			"line_number":     utils.PathSearch("line_number", v, nil),
+			"matched_content": utils.PathSearch("matched_content", v, nil),
+			"nlp_revised":     utils.PathSearch("nlp_revised", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to dsc column details by level dim
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to dsc column details by level dim
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscColumnDetailsByLevelDim_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscColumnDetailsByLevelDim_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscColumnDetailsByLevelDim_basic
=== PAUSE TestAccDataSourceDscColumnDetailsByLevelDim_basic
=== CONT  TestAccDataSourceDscColumnDetailsByLevelDim_basic
--- PASS: TestAccDataSourceDscColumnDetailsByLevelDim_basic (11.23s)
PASS
coverage: 6.4% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       13.097s coverage: 6.4% of statements in ./huaweicloud/services/dsc
```
<img width="1048" height="64" alt="image" src="https://github.com/user-attachments/assets/c403bfa6-4fde-41ae-9d6d-8062ad0ecb3f" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
