### PR TITLE
fix(gaussdb): fix client_auth_config import failure due to method not read from API response

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_client_auth_config_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_client_auth_config_test.go
@@ -100,8 +100,6 @@ func TestAccGaussDBClientAuthConfig_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
-			acceptance.TestAccPreCheckHighCostAllow(t)
 			acceptance.TestAccPreCheckGaussDBInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_client_auth_config.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_client_auth_config.go
@@ -185,7 +185,6 @@ func resourceGaussDBClientAuthConfigRead(_ context.Context, d *schema.ResourceDa
 	databaseRaw := d.Get("database").(string)
 	userRaw := d.Get("user").(string)
 	addressRaw := d.Get("address").(string)
-	methodRaw := d.Get("method").(string)
 
 	var hbaConf interface{}
 
@@ -231,7 +230,7 @@ func resourceGaussDBClientAuthConfigRead(_ context.Context, d *schema.ResourceDa
 		d.Set("database", databaseRaw),
 		d.Set("user", userRaw),
 		d.Set("address", addressRaw),
-		d.Set("method", methodRaw),
+		d.Set("method", utils.PathSearch("method", hbaConf, "").(string)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix client_auth_config import failure due to method not read from API response
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix client_auth_config import failure due to method not read from API response
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
$  ./scripts/coverage.sh -o gaussdb -f TestAccGaussDBClientAuthConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/gaussdb" -v -coverprofile="./huaweicloud/services/acceptance/gaussdb/gaussdb_coverage.cov" -coverpkg="./huaweicloud/services/gaussdb" -run TestAccGaussDBClientAuthConfig_basic -timeout 360m -parallel 10
=== RUN   TestAccGaussDBClientAuthConfig_basic
=== PAUSE TestAccGaussDBClientAuthConfig_basic
=== CONT  TestAccGaussDBClientAuthConfig_basic
--- PASS: TestAccGaussDBClientAuthConfig_basic (41.79s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/gaussdb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   43.662s coverage: 4.6% of statements in ./huaweicloud/services/gaussdb
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
