### PR TITLE
feat(dsc): support dsc_operate_instance_metadata resource

### DIFF
--- a/docs/resources/dsc_operate_instance_metadata.md
+++ b/docs/resources/dsc_operate_instance_metadata.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_operate_instance_metadata"
+description: |-
+  Manages a resource to operate the metadata of a DSC data instance asset within HuaweiCloud.
+---
+
+# huaweicloud_dsc_operate_instance_metadata
+
+Manages a resource to operate the metadata of a DSC data instance asset within HuaweiCloud.
+
+-> This resource is a one-time action resource used to operate the metadata of a DSC data instance asset.
+  Deleting this resource will not restore the metadata or undo the operation, but will only remove the resource
+  information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dsc_operate_instance_metadata" "test" {
+  instance_id = var.instance_id
+  action      = "REFRESH"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the data instance asset.
+
+* `action` - (Required, String, NonUpdatable) Specifies the operation type.
+  The valid values are as follows:
+  + **REFRESH**: Refresh the metadata.
+  + **DELETE**: Delete the metadata.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `msg` - The returned message describing the operation result or error information.
+
+* `status` - The returned status.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5055,6 +5055,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_mask_algorithm_debug":                       dsc.ResourceMaskAlgorithmDebug(),
 			"huaweicloud_dsc_measure_info":                               dsc.ResourceMeasureInfo(),
 			"huaweicloud_dsc_multi_enable_trusted_service":               dsc.ResourceMultiEnableTrustedService(),
+			"huaweicloud_dsc_operate_instance_metadata":                  dsc.ResourceOperateInstanceMetadata(),
 			"huaweicloud_dsc_operate_obs_audit":                          dsc.ResourceOperateObsAudit(),
 			"huaweicloud_dsc_scan_rule":                                  dsc.ResourceScanRule(),
 			"huaweicloud_dsc_scan_template":                              dsc.ResourceScanTemplate(),

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_operate_instance_metadata_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_operate_instance_metadata_test.go
@@ -1,0 +1,35 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceOperateInstanceMetadata_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDscInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceOperateInstanceMetadata_basic(),
+			},
+		},
+	})
+}
+
+func testAccResourceOperateInstanceMetadata_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_operate_instance_metadata" "test" {
+  instance_id = "%s"
+  action      = "REFRESH"
+}
+`, acceptance.HW_DSC_INSTANCE_ID)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_operate_instance_metadata.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_operate_instance_metadata.go
@@ -1,0 +1,131 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var operateInstanceMetadataNonUpdatableParams = []string{"instance_id", "action"}
+
+// @API DSC PUT /v1/{project_id}/asset-center/instances/{instance_id}/metadata
+func ResourceOperateInstanceMetadata() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOperateInstanceMetadataCreate,
+		ReadContext:   resourceOperateInstanceMetadataRead,
+		UpdateContext: resourceOperateInstanceMetadataUpdate,
+		DeleteContext: resourceOperateInstanceMetadataDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(operateInstanceMetadataNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceOperateInstanceMetadataCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/asset-center/instances/{instance_id}/metadata"
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", d.Get("instance_id").(string))
+	requestPath += fmt.Sprintf("?action=%v", d.Get("action").(string))
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error operating metadata of the DSC data instance asset: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("msg", utils.PathSearch("msg", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceOperateInstanceMetadataRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceOperateInstanceMetadataUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceOperateInstanceMetadataDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to operate the metadata of a DSC data instance asset.
+Deleting this resource will not restore the metadata or undo the operation, but will only remove the resource
+information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support dsc_operate_instance_metadata resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support dsc_operate_instance_metadata resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o dsc -f TestAccResourceOperateInstanceMetadata_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccResourceOperateInstanceMetadata_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceOperateInstanceMetadata_basic
=== PAUSE TestAccResourceOperateInstanceMetadata_basic
=== CONT  TestAccResourceOperateInstanceMetadata_basic
--- PASS: TestAccResourceOperateInstanceMetadata_basic (8.25s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc  9.855s   coverage: 5.9% of statements in ./huaweicloud/services/dsc

```
<img width="1029" height="74" alt="Snipaste_2026-07-28_15-16-03" src="https://github.com/user-attachments/assets/7955ca78-490a-4177-b037-494c986412a8" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
