### PR TITLE
feat(dsc): add data source to dsc device mask algorithms

### DIFF
--- a/docs/data-sources/dsc_device_mask_algorithms.md
+++ b/docs/data-sources/dsc_device_mask_algorithms.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_device_mask_algorithms"
+description: |-
+  Use this data source to get the list of DSC mask algorithms for a specific device.
+---
+
+# huaweicloud_dsc_device_mask_algorithms
+
+Use this data source to get the list of DSC mask algorithms for a specific device.
+
+## Example Usage
+
+```hcl
+variable "device_id" {}
+
+data "huaweicloud_dsc_device_mask_algorithms" "test" {
+  device_id = var.device_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `device_id` - (Required, String) Specifies the device ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `mask_algorithms` - The mask algorithm list.
+
+  The [mask_algorithms](#mask_algorithms_struct) structure is documented below.
+
+<a name="mask_algorithms_struct"></a>
+The `mask_algorithms` block supports:
+
+* `id` - The algorithm ID.
+
+* `name` - The algorithm name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1440,6 +1440,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_db_mask_tasks":                    dsc.DataSourceDscDbMaskTasks(),
 			"huaweicloud_dsc_dbss_ins_info":                    dsc.DataSourceDscDbssInsInfo(),
 			"huaweicloud_dsc_devices":                          dsc.DataSourceDscDevices(),
+			"huaweicloud_dsc_device_mask_algorithms":           dsc.DataSourceDscDeviceMaskAlgorithms(),
 			"huaweicloud_dsc_device_monitor_infos":             dsc.DataSourceDscDeviceMonitorInfos(),
 			"huaweicloud_dsc_device_security_policies":         dsc.DataSourceDscDeviceSecurityPolicies(),
 			"huaweicloud_dsc_event_overview":                   dsc.DataSourceDscEventOverview(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -464,6 +464,7 @@ var (
 	HW_DSC_ALARM_TOPIC_ID           = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
 	HW_DSC_ASSET_ID                 = os.Getenv("HW_DSC_ASSET_ID")
 	HW_DSC_ENABLE_FLAG              = os.Getenv("HW_DSC_ENABLE_FLAG")
+	HW_DSC_DEVICE_ID                = os.Getenv("HW_DSC_DEVICE_ID")
 	HW_DSC_LABEL_ID                 = os.Getenv("HW_DSC_LABEL_ID")
 	HW_DSC_TYPE_ID                  = os.Getenv("HW_DSC_TYPE_ID")
 	HW_DSC_SCAN_TEMPLATE_ID         = os.Getenv("HW_DSC_SCAN_TEMPLATE_ID")
@@ -5345,6 +5346,13 @@ func TestAccPreCheckDscAssetId(t *testing.T) {
 func TestAccPreCheckDscEnableFlag(t *testing.T) {
 	if HW_DSC_ENABLE_FLAG == "" {
 		t.Skip("HW_DSC_ENABLE_FLAG must be set for DSC acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDscDeviceId(t *testing.T) {
+	if HW_DSC_DEVICE_ID == "" {
+		t.Skip("HW_DSC_DEVICE_ID must be set for DSC acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_device_mask_algorithms_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_device_mask_algorithms_test.go
@@ -1,0 +1,42 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDscDeviceMaskAlgorithms_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dsc_device_mask_algorithms.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscDeviceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDscDeviceMaskAlgorithms_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "mask_algorithms.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDscDeviceMaskAlgorithms_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_device_mask_algorithms" "test" {
+  device_id = "%[1]s"
+}
+`, acceptance.HW_DSC_DEVICE_ID)
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_device_mask_algorithms.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_device_mask_algorithms.go
@@ -1,0 +1,134 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/devices/{device_id}/mask-algorithms
+func DataSourceDscDeviceMaskAlgorithms() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDscDeviceMaskAlgorithmsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"device_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mask_algorithms": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dscDeviceMaskAlgorithmSchema(),
+			},
+		},
+	}
+}
+
+func dscDeviceMaskAlgorithmSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDscDeviceMaskAlgorithmsQueryParams(limit, offset int) string {
+	return fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+}
+
+func dataSourceDscDeviceMaskAlgorithmsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+		httpUrl = "v1/{project_id}/devices/{device_id}/mask-algorithms"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{device_id}", d.Get("device_id").(string))
+
+	for {
+		currentPath := requestPath + buildDscDeviceMaskAlgorithmsQueryParams(limit, offset)
+		requestOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		requestResp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DSC device mask algorithms: %s", err)
+		}
+
+		requestRespBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		maskAlgorithmsList := utils.PathSearch("mask_algorithms", requestRespBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, maskAlgorithmsList...)
+		if len(maskAlgorithmsList) < limit {
+			break
+		}
+		offset += len(maskAlgorithmsList)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("mask_algorithms", flattenDscDeviceMaskAlgorithms(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDscDeviceMaskAlgorithms(maskAlgorithmsList []interface{}) []interface{} {
+	if len(maskAlgorithmsList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(maskAlgorithmsList))
+	for _, v := range maskAlgorithmsList {
+		rst = append(rst, map[string]interface{}{
+			"id":   utils.PathSearch("id", v, nil),
+			"name": utils.PathSearch("name", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to dsc device mask algorithms
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to dsc device mask algorithms
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDscDeviceMaskAlgorithms_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDscDeviceMaskAlgorithms_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDscDeviceMaskAlgorithms_basic
=== PAUSE TestAccDataSourceDscDeviceMaskAlgorithms_basic
=== CONT  TestAccDataSourceDscDeviceMaskAlgorithms_basic
--- PASS: TestAccDataSourceDscDeviceMaskAlgorithms_basic (8.83s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       10.754s coverage: 6.3% of statements in ./huaweicloud/services/dsc
```
<img width="1007" height="22" alt="image" src="https://github.com/user-attachments/assets/529647f4-a701-4200-a410-c444c0f9d5a7" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
