### PR TITLE
feat(dsc): support dsc_metadata_tags resource

### DIFF
--- a/docs/resources/dsc_metadata_tags.md
+++ b/docs/resources/dsc_metadata_tags.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_metadata_tags"
+description: |-
+  Manages DSC metadata tags resource within HuaweiCloud.
+---
+
+# huaweicloud_dsc_metadata_tags
+
+Manages DSC metadata tags resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "tag_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_dsc_metadata_tags" "test" {
+  names = var.tag_names
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `names` - (Required, List) Specifies the list of tag names.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `msg` - The returned message describing the operation result or error information.
+
+* `status` - The returned status, such as '200' or '400'.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5057,6 +5057,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_mask_algorithm":                             dsc.ResourceMaskAlgorithm(),
 			"huaweicloud_dsc_mask_algorithm_debug":                       dsc.ResourceMaskAlgorithmDebug(),
 			"huaweicloud_dsc_measure_info":                               dsc.ResourceMeasureInfo(),
+			"huaweicloud_dsc_metadata_tags":                              dsc.ResourceMetadataTags(),
 			"huaweicloud_dsc_multi_enable_trusted_service":               dsc.ResourceMultiEnableTrustedService(),
 			"huaweicloud_dsc_operate_instance_metadata":                  dsc.ResourceOperateInstanceMetadata(),
 			"huaweicloud_dsc_operate_obs_audit":                          dsc.ResourceOperateObsAudit(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -467,6 +467,8 @@ var (
 	HW_DSC_ENABLE_FLAG              = os.Getenv("HW_DSC_ENABLE_FLAG")
 	HW_DSC_DEVICE_ID                = os.Getenv("HW_DSC_DEVICE_ID")
 	HW_DSC_LABEL_ID                 = os.Getenv("HW_DSC_LABEL_ID")
+	HW_DSC_METADATA_TAG_NAME        = os.Getenv("HW_DSC_METADATA_TAG_NAME")
+	HW_DSC_METADATA_TAG_NAME_UPDATE = os.Getenv("HW_DSC_METADATA_TAG_NAME_UPDATE")
 	HW_DSC_TYPE_ID                  = os.Getenv("HW_DSC_TYPE_ID")
 	HW_DSC_SCAN_TEMPLATE_ID         = os.Getenv("HW_DSC_SCAN_TEMPLATE_ID")
 	HW_DSC_SCAN_JOB_ID              = os.Getenv("HW_DSC_SCAN_JOB_ID")
@@ -5368,6 +5370,13 @@ func TestAccPreCheckDscDeviceId(t *testing.T) {
 func TestAccPreCheckDscLabelId(t *testing.T) {
 	if HW_DSC_LABEL_ID == "" {
 		t.Skip("HW_DSC_LABEL_ID must be set for DSC acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDscMetadataTagName(t *testing.T) {
+	if HW_DSC_METADATA_TAG_NAME == "" || HW_DSC_METADATA_TAG_NAME_UPDATE == "" {
+		t.Skip("HW_DSC_METADATA_TAG_NAME and HW_DSC_METADATA_TAG_NAME_UPDATE must be set for DSC acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_metadata_tags_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_metadata_tags_test.go
@@ -1,0 +1,53 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceMetadataTags_basic(t *testing.T) {
+	resourceName := "huaweicloud_dsc_metadata_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscMetadataTagName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceMetadataTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "names.0", acceptance.HW_DSC_METADATA_TAG_NAME),
+				),
+			},
+			{
+				Config: testAccResourceMetadataTags_update(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "names.0", acceptance.HW_DSC_METADATA_TAG_NAME_UPDATE),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceMetadataTags_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_metadata_tags" "test" {
+  names = ["%s"]
+}
+`, acceptance.HW_DSC_METADATA_TAG_NAME)
+}
+
+func testAccResourceMetadataTags_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_metadata_tags" "test" {
+  names = ["%s"]
+}
+`, acceptance.HW_DSC_METADATA_TAG_NAME_UPDATE)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_metadata_tags.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_metadata_tags.go
@@ -1,0 +1,177 @@
+package dsc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC POST /v1/{project_id}/metadata/tags
+// @API DSC DELETE /v1/{project_id}/metadata/tags
+func ResourceMetadataTags() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceMetadataTagsCreate,
+		ReadContext:   resourceMetadataTagsRead,
+		UpdateContext: resourceMetadataTagsUpdate,
+		DeleteContext: resourceMetadataTagsDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"names": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+			},
+			"msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildMetadataTagsBodyParams(names []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"names": utils.ExpandToStringList(names),
+	}
+}
+
+func createMetadataTags(client *golangsdk.ServiceClient, names []interface{}) (interface{}, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	requestPath := client.Endpoint + "v1/{project_id}/metadata/tags"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildMetadataTagsBodyParams(names)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func deleteMetadataTags(client *golangsdk.ServiceClient, names []interface{}) error {
+	if len(names) == 0 {
+		return nil
+	}
+
+	requestPath := client.Endpoint + "v1/{project_id}/metadata/tags"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildMetadataTagsBodyParams(names)),
+	}
+
+	_, err := client.Request("DELETE", requestPath, &requestOpt)
+	return err
+}
+
+func resourceMetadataTagsCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		names  = d.Get("names").(*schema.Set).List()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	respBody, err := createMetadataTags(client, names)
+	if err != nil {
+		return diag.Errorf("error creating DSC metadata tags: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("names", names),
+		d.Set("msg", utils.PathSearch("msg", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceMetadataTagsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because there is no query API to verify the tags.
+	return nil
+}
+
+func resourceMetadataTagsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	if d.HasChange("names") {
+		oldRaws, newRaws := d.GetChange("names")
+		deleteNameList := oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set)).List()
+		addNameList := newRaws.(*schema.Set).Difference(oldRaws.(*schema.Set)).List()
+
+		if err := deleteMetadataTags(client, deleteNameList); err != nil {
+			return diag.Errorf("error deleting DSC metadata tags in update operation: %s", err)
+		}
+
+		if _, err := createMetadataTags(client, addNameList); err != nil {
+			return diag.Errorf("error creating DSC metadata tags in update operation: %s", err)
+		}
+	}
+
+	return resourceMetadataTagsRead(ctx, d, meta)
+}
+
+func resourceMetadataTagsDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		names  = d.Get("names").(*schema.Set).List()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	if err := deleteMetadataTags(client, names); err != nil {
+		return diag.Errorf("error deleting DSC metadata tags: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support dsc_metadata_tags resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support dsc_metadata_tags resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccResourceMetadataTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccResourceMetadataTags_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceMetadataTags_basic
=== PAUSE TestAccResourceMetadataTags_basic
=== CONT  TestAccResourceMetadataTags_basic
--- PASS: TestAccResourceMetadataTags_basic (9.10s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       10.970s coverage: 6.1% of statements in ./huaweicloud/services/dsc
```
<img width="1031" height="29" alt="image" src="https://github.com/user-attachments/assets/7265ead6-a8c1-40b5-a5b8-c66d3b40c444" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
