### PR TITLE
docs(dew): encryption_type cannot be filled if import without private_key

### DIFF
--- a/docs/resources/kps_keypair.md
+++ b/docs/resources/kps_keypair.md
@@ -56,6 +56,8 @@ resource "huaweicloud_kps_keypair" "test" {
 
 ### Import an existing KPS keypair without private key
 
+-> parameter `encryption_type` cannot be filled in this scenario.
+
 ```hcl
 variable "public_key" {}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The parameter `encryption_type` cannot be filled in the resource script if we need to import a keypiar without using private key and only use public key.
If not, the following error will be reported:
<img width="1891" height="1221" alt="image" src="https://github.com/user-attachments/assets/f498addf-3d62-4b1f-88a3-390c6fb6bbdb" />

The corresponding script:
```hcl
resource "huaweicloud_kps_keypair" "test" {
  name            = var.random_resource_name
  scope           = "user"
  encryption_type = "kms"
  kms_key_id      = try(data.huaweicloud_kms_keys.test.keys[0].id, null)
  description     = "Imported by Terraform"
  public_key      = var.public_key
}
```

If we omit it, the create processing will be passed.
<img width="1000" height="797" alt="image" src="https://github.com/user-attachments/assets/7b3af3e4-01cc-46ac-8a3b-0399c3692fad" />

The corresponding script:
```hcl
resource "huaweicloud_kps_keypair" "test" {
  name        = var.random_resource_name
  scope       = "user"
  description = "Imported by Terraform"
  public_key  = var.public_key
}
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #7049 

**Special notes for your reviewer**:

There is no acceptance test to cover this error scenario.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a note to the exmaple and limit the parameter `encryption_type` input if import keypair without `private_key`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
