### PR TITLE
feat(ecs): instance primary security groups support reorder

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -214,6 +214,8 @@ The following arguments are supported:
 * `security_group_ids` - (Optional, List) Specifies an array of one or more security group IDs to associate with the
   instance.
 
+  -> Security groups that appear higher in the list have higher priority.
+
 * `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone in which to create the instance.
   Please following [reference](https://developer.huaweicloud.com/intl/en-us/endpoint/?ECS)
   for the values. Changing this creates a new instance.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.13
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
 	github.com/ProtonMail/go-crypto v1.3.0
-	github.com/chnsz/golangsdk v0.0.0-20260730075059-cd900f65ccb8
+	github.com/chnsz/golangsdk v0.0.0-20260731020229-e00f572ee8f7
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20260730075059-cd900f65ccb8 h1:1AqWKugnxd1YEYPu74yDplyzZV37owhr8vShHcSERVM=
-github.com/chnsz/golangsdk v0.0.0-20260730075059-cd900f65ccb8/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20260731020229-e00f572ee8f7 h1:c3/4ATjDM+OzJz415HRDqez5EVIdq3rLuBwcPwY4m/s=
+github.com/chnsz/golangsdk v0.0.0-20260731020229-e00f572ee8f7/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -1084,3 +1084,160 @@ resource "huaweicloud_compute_instance" "test" {
 }
 `, testAccCompute_data, rName)
 }
+
+func TestAccComputeInstance_reorderSecurityGroups(t *testing.T) {
+	var instance cloudservers.CloudServer
+
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_compute_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_reorderSecurityGroups_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "3"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.0",
+						"huaweicloud_networking_secgroup.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.1",
+						"huaweicloud_networking_secgroup.test.1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.2",
+						"huaweicloud_networking_secgroup.test.2", "id"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_reorderSecurityGroups_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "3"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.0",
+						"huaweicloud_networking_secgroup.test.2", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.1",
+						"huaweicloud_networking_secgroup.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.2",
+						"huaweicloud_networking_secgroup.test.1", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_eip_on_termination",
+					"stop_before_destroy",
+				},
+			},
+		},
+	})
+}
+
+func testAccComputeInstance_reorderSecurityGroups_base(name string) string {
+	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {}
+
+locals {
+  flavors_matched_vcpus_and_types = [for o in data.huaweicloud_compute_flavors.test.flavors: o if 
+    contains(["4", "8"], tostring(o.cpu_core_count)) && length(regexall("^(c5|c6|c7)\\.", o.id)) > 0
+  ]
+}
+
+data "huaweicloud_images_images" "test" {
+  flavor_id  = local.flavors_matched_vcpus_and_types[0].id
+  name_regex = "Ubuntu"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name                  = "%[2]s"
+  cidr                  = "192.168.0.0/24"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  count = 3
+
+  vpc_id = huaweicloud_vpc.test.id
+
+  name       = format("%[2]s_%%d", count.index)
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, count.index)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, count.index), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  count = 3
+
+  name                 = format("%[2]s_%%d", count.index)
+  delete_default_rules = true
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}
+
+func testAccComputeInstance_reorderSecurityGroups_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_compute_instance" "test" {
+  name                  = "%[2]s"
+  image_id              = try(data.huaweicloud_images_images.test.images[0].id, null)
+  flavor_id             = try(local.flavors_matched_vcpus_and_types[0].id, null)
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+  security_group_ids    = [
+    huaweicloud_networking_secgroup.test[0].id,
+    huaweicloud_networking_secgroup.test[1].id,
+    huaweicloud_networking_secgroup.test[2].id,
+  ]
+
+  system_disk_type = "SSD"
+  system_disk_size = 40
+
+  dynamic "network" {
+    for_each = huaweicloud_vpc_subnet.test
+
+    content {
+      uuid = network.value.id
+    }
+  }
+}
+`, testAccComputeInstance_reorderSecurityGroups_base(name), name)
+}
+
+func testAccComputeInstance_reorderSecurityGroups_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_compute_instance" "test" {
+  name                  = "%[2]s"
+  image_id              = try(data.huaweicloud_images_images.test.images[0].id, null)
+  flavor_id             = try(local.flavors_matched_vcpus_and_types[0].id, null)
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+  security_group_ids    = [
+    huaweicloud_networking_secgroup.test[2].id,
+    huaweicloud_networking_secgroup.test[0].id,
+    huaweicloud_networking_secgroup.test[1].id,
+  ]
+
+  system_disk_type = "SSD"
+  system_disk_size = 40
+
+  dynamic "network" {
+    for_each = huaweicloud_vpc_subnet.test
+
+    content {
+      uuid = network.value.id
+    }
+  }
+}
+`, testAccComputeInstance_reorderSecurityGroups_base(name), name)
+}

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -63,6 +63,7 @@ var (
 // @API IMS GET /v2/cloudimages
 // @API EVS POST /v2.1/{project_id}/cloudvolumes/{volume_id}/action
 // @API EVS GET /v2/{project_id}/cloudvolumes/{volume_id}
+// @API VPC GET /v1/{project_id}/ports
 // @API VPC PUT /v1/{project_id}/ports/{port_id}
 // @API VPC GET /v1/{project_id}/security-groups
 // @API VPC GET /v1/{project_id}/subnets/{subnet_id}
@@ -157,11 +158,10 @@ func ResourceComputeInstance() *schema.Resource {
 				Set:           schema.HashString,
 			},
 			"security_group_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 			"network": {
 				Type:     schema.TypeList,
@@ -878,6 +878,81 @@ func resourceComputeInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 	return resourceComputeInstanceRead(ctx, d, meta)
 }
 
+func listInstancePorts(vpcClient *golangsdk.ServiceClient, instanceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/ports?device_id={instance_id}&limit={limit}"
+		limit   = 100
+		marker  = ""
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := vpcClient.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", vpcClient.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker += fmt.Sprintf("&marker=%s", marker)
+		}
+		listResp, err := vpcClient.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return nil, err
+		}
+		associatedPorts := utils.PathSearch("ports", listRespBody, []interface{}{}).([]interface{})
+		result = append(result, associatedPorts...)
+		if len(associatedPorts) < limit {
+			break
+		}
+		marker = utils.PathSearch("[-1].id", associatedPorts, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func getInstancePrimaryNicAssociatedSecurityGroups(cfg *config.Config, region, serverId, primaryPortId string) ([]interface{}, error) {
+	vpcClient, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPC client: %s", err)
+	}
+	associatedPorts, err := listInstancePorts(vpcClient, serverId)
+	if err != nil {
+		return nil, fmt.Errorf("error listing instance ports: %s", err)
+	}
+
+	result := utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0].security_groups", primaryPortId), associatedPorts,
+		make([]interface{}, 0)).([]interface{})
+	if len(result) < 1 {
+		return nil, fmt.Errorf("no security groups found for instance (%s), the ports are: %+v", serverId, associatedPorts)
+	}
+	return result, nil
+}
+
+func getInstancePrimaryPortId(vpcId string, allAddresses map[string][]cloudservers.Address) string {
+	addresses, ok := allAddresses[vpcId]
+	if ok {
+		for _, address := range addresses {
+			if address.Primary {
+				return address.PortID
+			}
+		}
+	}
+	return ""
+}
+
 // nolint:gocyclo
 func resourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
@@ -973,17 +1048,24 @@ func resourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, meta
 		})
 	}
 
-	secGrpNames := []string{}
+	primaryPortId := getInstancePrimaryPortId(server.Metadata.VpcID, server.Addresses)
+	primaryNicSecGroupIds, err := getInstancePrimaryNicAssociatedSecurityGroups(cfg, region, serverID, primaryPortId)
+	secGrpIDs := make([]interface{}, 0)
+	if err != nil {
+		log.Printf("[WARN] failed to get primary nic associated security groups using '/v1/{project_id}/ports': %s", err)
+		for _, sg := range server.SecurityGroups {
+			secGrpIDs = append(secGrpIDs, sg.ID)
+		}
+	} else {
+		secGrpIDs = primaryNicSecGroupIds
+	}
+	d.Set("security_group_ids", secGrpIDs)
+
+	secGrpNames := make([]interface{}, 0)
 	for _, sg := range server.SecurityGroups {
 		secGrpNames = append(secGrpNames, sg.Name)
 	}
 	d.Set("security_groups", secGrpNames)
-
-	secGrpIDs := make([]string, len(server.SecurityGroups))
-	for i, sg := range server.SecurityGroups {
-		secGrpIDs[i] = sg.ID
-	}
-	d.Set("security_group_ids", secGrpIDs)
 
 	// Set volume attached
 	if len(server.VolumeAttached) > 0 {
@@ -1117,6 +1199,41 @@ func flattenEnclaveOptions(enclaveOptions *cloudservers.EnclaveOptions) []map[st
 	return res
 }
 
+func updatePortSecurityGroups(client *golangsdk.ServiceClient, portId string, newSecGroupIds []interface{}) error {
+	httpUrl := "v1/{project_id}/ports/{port_id}"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{port_id}", portId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"port": map[string]interface{}{
+				"security_groups": newSecGroupIds,
+			},
+		},
+	}
+
+	_, err := client.Request("PUT", path, &updateOpt)
+	return err
+}
+
+func updateInstancePrimaryNicSecurityGroups(vpcClient, ecsClient *golangsdk.ServiceClient, serverID string,
+	newSecGroupIds []interface{}) error {
+	instance, err := cloudservers.Get(ecsClient, serverID).Extract()
+	if err != nil {
+		return err
+	}
+	primaryPortId := getInstancePrimaryPortId(instance.Metadata.VpcID, instance.Addresses)
+	if primaryPortId == "" {
+		return fmt.Errorf("unable to find primary port ID for instance (%s), the addresses are: %+v",
+			serverID, instance.Addresses)
+	}
+
+	return updatePortSecurityGroups(vpcClient, primaryPortId, newSecGroupIds)
+}
+
 // nolint:gocyclo
 func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
@@ -1140,6 +1257,10 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 	bssClient, err := cfg.BssV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating BSS v2 client: %s", err)
+	}
+	vpcClient, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	serverID := d.Id()
@@ -1225,14 +1346,16 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	if d.HasChanges("security_group_ids", "security_groups") {
-		var oldSGRaw interface{}
-		var newSGRaw interface{}
-		if d.HasChange("security_group_ids") {
-			oldSGRaw, newSGRaw = d.GetChange("security_group_ids")
-		} else {
-			oldSGRaw, newSGRaw = d.GetChange("security_groups")
+	if d.HasChanges("security_group_ids") {
+		if err := updateInstancePrimaryNicSecurityGroups(vpcClient, ecsClient, serverID,
+			d.Get("security_group_ids").([]interface{})); err != nil {
+			return diag.FromErr(err)
 		}
+	}
+
+	// Deprecated
+	if d.HasChanges("security_groups") {
+		oldSGRaw, newSGRaw := d.GetChange("security_groups")
 		oldSGSet := oldSGRaw.(*schema.Set)
 		newSGSet := newSGRaw.(*schema.Set)
 		secgroupsToAdd := newSGSet.Difference(oldSGSet)
@@ -1618,7 +1741,7 @@ func buildUpdateInstanceNetworkOpts(d *schema.ResourceData, vpcID string) map[st
 }
 
 func buildUpdateInstanceNetworkSecgroupOpts(d *schema.ResourceData) []map[string]interface{} {
-	secgroupIDs := d.Get("security_group_ids").(*schema.Set).List()
+	secgroupIDs := d.Get("security_group_ids").([]interface{})
 	bodyParams := make([]map[string]interface{}, len(secgroupIDs))
 
 	for i, v := range secgroupIDs {
@@ -1862,7 +1985,7 @@ func ServerV1StateRefreshFunc(client *golangsdk.ServiceClient, instanceID string
 
 func buildInstanceSecGroupIds(d *schema.ResourceData, client *golangsdk.ServiceClient) ([]cloudservers.SecurityGroup, error) {
 	if v, ok := d.GetOk("security_group_ids"); ok {
-		rawSecGroups := v.(*schema.Set).List()
+		rawSecGroups := v.([]interface{})
 		secGroups := make([]cloudservers.SecurityGroup, len(rawSecGroups))
 		for i, raw := range rawSecGroups {
 			secGroups[i] = cloudservers.SecurityGroup{

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/results.go
@@ -72,6 +72,7 @@ type Address struct {
 	MacAddr string `json:"OS-EXT-IPS-MAC:mac_addr"`
 	PortID  string `json:"OS-EXT-IPS:port_id"`
 	Type    string `json:"OS-EXT-IPS:type"`
+	Primary bool   `json:"primary"`
 }
 
 type VolumeAttached struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/agext/levenshtein
 # github.com/apparentlymart/go-textseg/v15 v15.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v15/textseg
-# github.com/chnsz/golangsdk v0.0.0-20260730075059-cd900f65ccb8
+# github.com/chnsz/golangsdk v0.0.0-20260731020229-e00f572ee8f7
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The order of security groups for each network interface card (NIC) in the list has practical significance; the earlier a group appears, the higher its priority for rule execution.
The VPC service interface has both the ability to query the list of ordered security groups and the ability to overwrite and update (maintain the new ordered security group settings).

The following API behaviors regarding the security group list:

- **GET /v1/{project_id}/cloudservers/{server_id}**: Based on the security group API implementation, the returned security groups are unordered and have no priority markers.
- **PUT /v1/{project_id}/ports/{port_id}**: The security group list managed by this API is ordered, consistent with the API used in the console.
- **GET /v1/{project_id}/ports**: The security group list returned by this API is ordered, consistent with the API used in the console.

The relevant user guide documentation:
<img width="1443" height="646" alt="image" src="https://github.com/user-attachments/assets/19b5c78b-2066-4076-9dc5-eb5d900d6456" />
[>>>Link<<<](https://support.huaweicloud.com/intl/en-us/usermanual-ecs/en-us_topic_0140323157.html)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #6262 

**Special notes for your reviewer**:

The coverage of the relevant codes:

<img width="558" height="113" alt="image" src="https://github.com/user-attachments/assets/736532c0-2e49-43e5-8ec9-24ab0d762ebd" />
<img width="1002" height="802" alt="image" src="https://github.com/user-attachments/assets/20ec0493-7823-479b-bf10-1d117f21610a" />
<img width="1216" height="530" alt="image" src="https://github.com/user-attachments/assets/5d9b4139-c7ab-431c-92d7-7c4c63350acc" />
<img width="1144" height="340" alt="image" src="https://github.com/user-attachments/assets/04114cb1-07fd-4449-8d35-37934d777a49" />
<img width="852" height="129" alt="image" src="https://github.com/user-attachments/assets/f0bff61b-b714-41ee-a7c4-78736fda7a44" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. instance primary security groups support reorder
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o ecs -f TestAccComputeInstance_reorderSecurityGroups
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ecs" -v -coverprofile="./huaweicloud/services/acceptance/ecs/ecs_coverage.cov" -coverpkg="./huaweicloud/services/ecs" -run TestAccComputeInstance_reorderSecurityGroups -timeout 360m -parallel 10
=== RUN   TestAccComputeInstance_reorderSecurityGroups
=== PAUSE TestAccComputeInstance_reorderSecurityGroups
=== CONT  TestAccComputeInstance_reorderSecurityGroups
--- PASS: TestAccComputeInstance_reorderSecurityGroups (193.61s)
PASS
coverage: 15.8% of statements in ./huaweicloud/services/ecs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       193.734s        coverage: 15.8% of statements in ./huaweicloud/services/ecs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
