### PR TITLE
feat(dsc): support dsc_scan_security_level resource

### DIFF
--- a/docs/resources/dsc_scan_security_level.md
+++ b/docs/resources/dsc_scan_security_level.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_scan_security_level"
+description: |-
+  Manages a DSC scan security level resource within HuaweiCloud.
+---
+
+# huaweicloud_dsc_scan_security_level
+
+Manages a DSC scan security level resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "security_level_name" {}
+
+resource "huaweicloud_dsc_scan_security_level" "test" {
+  security_level_name = var.security_level_name
+  color_number        = 6
+  security_level_desc = "Created by terraform script"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the security level is located.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `security_level_name` - (Required, String) Specifies the name of the security level.
+
+* `color_number` - (Optional, Int) Specifies the color number of the security level displayed on the console.
+
+* `security_level_desc` - (Optional, String) Specifies the description of the security level.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also the security level ID.
+
+* `is_deleted` - Whether the security level is disabled.
+
+* `category` - The category of the security level.
+  The valid values are as follows:
+  + **BUILT_IN**: The built-in security level.
+  + **BUILT_IN_COPY**: The copy of the built-in security level.
+  + **BUILT_SELF**: The custom security level.
+
+* `used_count` - The number of the scan templates bound to the security level.
+
+* `sort_weight` - The sort weight of the security level.
+
+* `create_time` - The creation time of the security level.
+
+* `update_time` - The latest update time of the security level.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dsc_scan_security_level.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5061,6 +5061,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_operate_instance_metadata":                  dsc.ResourceOperateInstanceMetadata(),
 			"huaweicloud_dsc_operate_obs_audit":                          dsc.ResourceOperateObsAudit(),
 			"huaweicloud_dsc_scan_rule":                                  dsc.ResourceScanRule(),
+			"huaweicloud_dsc_scan_security_level":                        dsc.ResourceScanSecurityLevel(),
 			"huaweicloud_dsc_scan_template":                              dsc.ResourceScanTemplate(),
 			"huaweicloud_dsc_scan_template_classification":               dsc.ResourceScanTemplateClassification(),
 			"huaweicloud_dsc_stop_scan_job":                              dsc.ResourceStopScanJob(),

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_scan_security_level_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_scan_security_level_test.go
@@ -1,0 +1,89 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dsc"
+)
+
+func getScanSecurityLevelResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dsc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DSC client: %s", err)
+	}
+
+	return dsc.GetScanSecurityLevelById(client, state.Primary.ID)
+}
+
+// Before this test, please ensure that the DSC instance has been created.
+func TestAccResourceScanSecurityLevel_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dsc_scan_security_level.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getScanSecurityLevelResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceScanSecurityLevel_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "security_level_name", name),
+					resource.TestCheckResourceAttr(rName, "color_number", "6"),
+					resource.TestCheckResourceAttr(rName, "security_level_desc", "Created by terraform script"),
+					resource.TestCheckResourceAttrSet(rName, "category"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+				),
+			},
+			{
+				Config: testAccResourceScanSecurityLevel_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "security_level_name", updateName),
+					resource.TestCheckResourceAttr(rName, "color_number", "7"),
+					resource.TestCheckResourceAttr(rName, "security_level_desc", "Updated by terraform script"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResourceScanSecurityLevel_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_scan_security_level" "test" {
+  security_level_name = "%[1]s"
+  color_number        = 6
+  security_level_desc = "Created by terraform script"
+}
+`, name)
+}
+
+func testAccResourceScanSecurityLevel_basic_step2(updateName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dsc_scan_security_level" "test" {
+  security_level_name = "%[1]s"
+  color_number        = 7
+  security_level_desc = "Updated by terraform script"
+}
+`, updateName)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_security_level.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_security_level.go
@@ -1,0 +1,314 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var scanSecurityLevelNotFoundErrCodes = []string{
+	"dsc.10000009", // The DSC instance does not exist.
+}
+
+// @API DSC POST /v1/{project_id}/scan-security-levels
+// @API DSC GET /v1/{project_id}/scan-security-levels
+// @API DSC PUT /v1/{project_id}/scan-security-levels/{level_id}
+// @API DSC DELETE /v1/{project_id}/scan-security-levels/{level_id}
+func ResourceScanSecurityLevel() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScanSecurityLevelCreate,
+		ReadContext:   resourceScanSecurityLevelRead,
+		UpdateContext: resourceScanSecurityLevelUpdate,
+		DeleteContext: resourceScanSecurityLevelDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"security_level_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"color_number": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"security_level_desc": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_deleted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"used_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"sort_weight": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildScanSecurityLevelBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"security_level_name": d.Get("security_level_name"),
+		"color_number":        utils.ValueIgnoreEmpty(d.Get("color_number")),
+		"security_level_desc": utils.ValueIgnoreEmpty(d.Get("security_level_desc")),
+	}
+}
+
+func createScanSecurityLevel(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/scan-security-levels"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildScanSecurityLevelBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func resourceScanSecurityLevelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg  = meta.(*config.Config)
+		name = d.Get("security_level_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = createScanSecurityLevel(client, d)
+	if err != nil {
+		return diag.Errorf("error creating security level (%s): %s", name, err)
+	}
+
+	// The create API does not return the security level ID, query the list to get it.
+	securityLevels, err := listScanSecurityLevels(client)
+	if err != nil {
+		return diag.Errorf("error getting security level (%s): %s", name, err)
+	}
+
+	levelId := utils.PathSearch(fmt.Sprintf("[?security_level_name=='%s']|[0].level_id", name), securityLevels, "").(string)
+	if levelId == "" {
+		return diag.Errorf("unable to find the security level ID from API response")
+	}
+
+	d.SetId(levelId)
+
+	return resourceScanSecurityLevelRead(ctx, d, meta)
+}
+
+func listScanSecurityLevels(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl           = "v1/{project_id}/scan-security-levels"
+		limit             = 1000
+		offset            = 0
+		allSecurityLevels = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		// The 'is_deleted' parameter is set to true to query all security levels, including the disabled ones.
+		listPathWithOffset := fmt.Sprintf("%s?limit=%d&offset=%d&is_deleted=true", listPath, limit, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		securityLevels := utils.PathSearch("security_levels_list", respBody, make([]interface{}, 0)).([]interface{})
+		allSecurityLevels = append(allSecurityLevels, securityLevels...)
+		if len(securityLevels) < limit {
+			break
+		}
+
+		offset += len(securityLevels)
+	}
+
+	return allSecurityLevels, nil
+}
+
+func GetScanSecurityLevelById(client *golangsdk.ServiceClient, levelId string) (interface{}, error) {
+	securityLevels, err := listScanSecurityLevels(client)
+	if err != nil {
+		return nil, err
+	}
+
+	securityLevel := utils.PathSearch(fmt.Sprintf("[?level_id=='%s']|[0]", levelId), securityLevels, nil)
+	if securityLevel == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/scan-security-levels",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the security level (%s) does not exist", levelId)),
+			},
+		}
+	}
+
+	return securityLevel, nil
+}
+
+func resourceScanSecurityLevelRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		levelId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	securityLevel, err := GetScanSecurityLevelById(client, levelId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", scanSecurityLevelNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving security level (%s)", levelId),
+		)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("security_level_name", utils.PathSearch("security_level_name", securityLevel, nil)),
+		d.Set("color_number", utils.PathSearch("color_number", securityLevel, nil)),
+		d.Set("security_level_desc", utils.PathSearch("security_level_desc", securityLevel, nil)),
+		d.Set("is_deleted", utils.PathSearch("is_deleted", securityLevel, nil)),
+		d.Set("category", utils.PathSearch("category", securityLevel, nil)),
+		d.Set("used_count", utils.PathSearch("used_count", securityLevel, nil)),
+		d.Set("sort_weight", utils.PathSearch("sort_weight", securityLevel, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", securityLevel, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", securityLevel, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func updateScanSecurityLevel(client *golangsdk.ServiceClient, levelId string, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/scan-security-levels/{level_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{level_id}", levelId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildScanSecurityLevelBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceScanSecurityLevelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		levelId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	if d.HasChanges("security_level_name", "color_number", "security_level_desc") {
+		err = updateScanSecurityLevel(client, levelId, d)
+		if err != nil {
+			return diag.Errorf("error updating security level (%s): %s", levelId, err)
+		}
+	}
+
+	return resourceScanSecurityLevelRead(ctx, d, meta)
+}
+
+func deleteScanSecurityLevel(client *golangsdk.ServiceClient, levelId string) error {
+	httpUrl := "v1/{project_id}/scan-security-levels/{level_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{level_id}", levelId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceScanSecurityLevelDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = deleteScanSecurityLevel(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", scanSecurityLevelNotFoundErrCodes...),
+			fmt.Sprintf("error deleting security level (%v)", d.Get("security_level_name")),
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(dsc):support dsc_scan_security_level resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
feat(dsc):support dsc_scan_security_level resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o dsc -f TestAccResourceScanSecurityLevel_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccResourceScanSecurityLevel_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceScanSecurityLevel_basic
=== PAUSE TestAccResourceScanSecurityLevel_basic
=== CONT  TestAccResourceScanSecurityLevel_basic
--- PASS: TestAccResourceScanSecurityLevel_basic (19.00s)
PASS
coverage: 7.1% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc  20.587s  coverage: 7.1% of statements in ./huaweicloud/services/dsc

```
<img width="1034" height="59" alt="Snipaste_2026-07-30_16-03-52" src="https://github.com/user-attachments/assets/1cfb4c84-965f-4e4e-9541-b9daf7eb4ecc" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
