### PR TITLE
fix(var/naming): rename locals that shadow package or import names

### DIFF
--- a/huaweicloud/services/cceautopilot/data_source_huaweicloud_cce_autopilot_cluster_certificate.go
+++ b/huaweicloud/services/cceautopilot/data_source_huaweicloud_cce_autopilot_cluster_certificate.go
@@ -254,10 +254,10 @@ func (w *ClusterCertificateDSWrapper) createAutopilotKubernetesClusterCertToSche
 				return map[string]any{
 					"name": contexts.Get("name").Value(),
 					"context": schemas.SliceToList(contexts.Get("context"),
-						func(context gjson.Result) any {
+						func(ctx gjson.Result) any {
 							return map[string]any{
-								"cluster": context.Get("cluster").Value(),
-								"user":    context.Get("user").Value(),
+								"cluster": ctx.Get("cluster").Value(),
+								"user":    ctx.Get("user").Value(),
 							}
 						},
 					),

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
@@ -1627,9 +1627,9 @@ func resourceDdsInstanceV3Delete(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func flattenDdsInstanceV3Groups(dds instances.InstanceResponse) interface{} {
-	nodesList := make([]map[string]interface{}, len(dds.Groups))
-	for i, group := range dds.Groups {
+func flattenDdsInstanceV3Groups(instance instances.InstanceResponse) interface{} {
+	nodesList := make([]map[string]interface{}, len(instance.Groups))
+	for i, group := range instance.Groups {
 		node := map[string]interface{}{
 			"id":     group.Id,
 			"name":   group.Name,
@@ -1662,9 +1662,9 @@ func flattenDdsInstanceGroupNodes(nodes []instances.Nodes) interface{} {
 	return nodesList
 }
 
-func flattenDdsInstanceV3Nodes(dds instances.InstanceResponse) interface{} {
+func flattenDdsInstanceV3Nodes(instance instances.InstanceResponse) interface{} {
 	nodesList := make([]map[string]interface{}, 0)
-	for _, group := range dds.Groups {
+	for _, group := range instance.Groups {
 		groupType := group.Type
 		for _, Node := range group.Nodes {
 			node := map[string]interface{}{

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eips.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eips.go
@@ -198,7 +198,7 @@ func dataSourceVpcEipsRead(_ context.Context, d *schema.ResourceData, meta inter
 			}
 		}
 
-		eip := map[string]interface{}{
+		queriedEip := map[string]interface{}{
 			"id":                    item.ID,
 			"name":                  item.Alias,
 			"status":                NormalizeEipStatus(item.Status),
@@ -217,7 +217,7 @@ func dataSourceVpcEipsRead(_ context.Context, d *schema.ResourceData, meta inter
 			"created_at":            item.CreateTime,
 		}
 
-		eipList = append(eipList, eip)
+		eipList = append(eipList, queriedEip)
 		ids = append(ids, item.ID)
 	}
 	log.Printf("[DEBUG]Eips List after filter, count=%d :%+v", len(eipList), eipList)

--- a/huaweicloud/services/lb/data_source_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/data_source_huaweicloud_lb_loadbalancer.go
@@ -108,22 +108,22 @@ func dataSourceELBV2LoadbalancerRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("your query returned more than one result, please try a more specific search criteria")
 	}
 
-	lb := lbList[0]
-	d.SetId(lb.ID)
+	loadbalancer := lbList[0]
+	d.SetId(loadbalancer.ID)
 
 	var publicIp string
-	if len(lb.PublicIps) > 0 {
-		publicIp = lb.PublicIps[0].PublicIpAddress
+	if len(loadbalancer.PublicIps) > 0 {
+		publicIp = loadbalancer.PublicIps[0].PublicIpAddress
 	}
 	mErr := multierror.Append(
 		d.Set("region", cfg.GetRegion(d)),
-		d.Set("name", lb.Name),
-		d.Set("status", lb.OperatingStatus),
-		d.Set("description", lb.Description),
-		d.Set("vip_address", lb.VipAddress),
-		d.Set("vip_subnet_id", lb.VipSubnetID),
-		d.Set("enterprise_project_id", lb.EnterpriseProjectID),
-		d.Set("vip_port_id", lb.VipPortID),
+		d.Set("name", loadbalancer.Name),
+		d.Set("status", loadbalancer.OperatingStatus),
+		d.Set("description", loadbalancer.Description),
+		d.Set("vip_address", loadbalancer.VipAddress),
+		d.Set("vip_subnet_id", loadbalancer.VipSubnetID),
+		d.Set("enterprise_project_id", loadbalancer.EnterpriseProjectID),
+		d.Set("vip_port_id", loadbalancer.VipPortID),
 		d.Set("public_ip", publicIp),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
@@ -245,20 +245,20 @@ func resourceLoadBalancerV2Create(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	lb, err := loadbalancers.Create(elbClient, createOpts).Extract()
+	loadbalancer, err := loadbalancers.Create(elbClient, createOpts).Extract()
 	if err != nil {
 		return diag.Errorf("error creating LoadBalancer: %s", err)
 	}
 
 	// Wait for LoadBalancer to become active before continuing
 	timeout := d.Timeout(schema.TimeoutCreate)
-	err = waitForLBV2LoadBalancer(ctx, elbClient, lb.ID, "ACTIVE", nil, timeout)
+	err = waitForLBV2LoadBalancer(ctx, elbClient, loadbalancer.ID, "ACTIVE", nil, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	// set the ID on the resource
-	d.SetId(lb.ID)
+	d.SetId(loadbalancer.ID)
 
 	// change to pre-paid mode
 	if d.Get("charging_mode").(string) == "prePaid" {
@@ -288,13 +288,13 @@ func resourceLoadBalancerV2Create(ctx context.Context, d *schema.ResourceData, m
 
 	// Once the LoadBalancer has been created, apply any requested security groups
 	// to the port that was created behind the scenes.
-	if lb.VipPortID != "" {
+	if loadbalancer.VipPortID != "" {
 		networkingClient, err := cfg.NetworkingV2Client(region)
 		if err != nil {
 			return diag.Errorf("error creating VPC v2 Client: %s", err)
 		}
 
-		if err := resourceLoadBalancerV2SecurityGroups(networkingClient, lb.VipPortID, d); err != nil {
+		if err := resourceLoadBalancerV2SecurityGroups(networkingClient, loadbalancer.VipPortID, d); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -303,8 +303,8 @@ func resourceLoadBalancerV2Create(ctx context.Context, d *schema.ResourceData, m
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
 		tagList := utils.ExpandResourceTags(tagRaw)
-		if tagErr := tags.Create(elbV2Client, "loadbalancers", lb.ID, tagList).ExtractErr(); tagErr != nil {
-			return diag.Errorf("error setting tags of LoadBalancer %s: %s", lb.ID, tagErr)
+		if tagErr := tags.Create(elbV2Client, "loadbalancers", loadbalancer.ID, tagList).ExtractErr(); tagErr != nil {
+			return diag.Errorf("error setting tags of LoadBalancer %s: %s", loadbalancer.ID, tagErr)
 		}
 	}
 
@@ -325,53 +325,53 @@ func resourceLoadBalancerV2Read(_ context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error creating ELB v2.0 Client: %s", err)
 	}
 
-	lb, err := loadbalancers.Get(elbClient, d.Id()).Extract()
+	loadbalancer, err := loadbalancers.Get(elbClient, d.Id()).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error retrieving LoadBalancer")
 	}
 
-	log.Printf("[DEBUG] Retrieved LoadBalancer %s: %#v", d.Id(), lb)
+	log.Printf("[DEBUG] Retrieved LoadBalancer %s: %#v", d.Id(), loadbalancer)
 
 	var publicIp string
-	if len(lb.PublicIps) > 0 {
-		publicIp = lb.PublicIps[0].PublicIpAddress
+	if len(loadbalancer.PublicIps) > 0 {
+		publicIp = loadbalancer.PublicIps[0].PublicIpAddress
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("name", lb.Name),
-		d.Set("description", lb.Description),
-		d.Set("vip_subnet_id", lb.VipSubnetID),
-		d.Set("tenant_id", lb.TenantID),
-		d.Set("vip_address", lb.VipAddress),
-		d.Set("vip_port_id", lb.VipPortID),
-		d.Set("admin_state_up", lb.AdminStateUp),
-		d.Set("flavor", lb.Flavor),
-		d.Set("loadbalancer_provider", lb.Provider),
-		d.Set("enterprise_project_id", lb.EnterpriseProjectID),
-		d.Set("protection_status", lb.ProtectionStatus),
-		d.Set("protection_reason", lb.ProtectionReason),
+		d.Set("name", loadbalancer.Name),
+		d.Set("description", loadbalancer.Description),
+		d.Set("vip_subnet_id", loadbalancer.VipSubnetID),
+		d.Set("tenant_id", loadbalancer.TenantID),
+		d.Set("vip_address", loadbalancer.VipAddress),
+		d.Set("vip_port_id", loadbalancer.VipPortID),
+		d.Set("admin_state_up", loadbalancer.AdminStateUp),
+		d.Set("flavor", loadbalancer.Flavor),
+		d.Set("loadbalancer_provider", loadbalancer.Provider),
+		d.Set("enterprise_project_id", loadbalancer.EnterpriseProjectID),
+		d.Set("protection_status", loadbalancer.ProtectionStatus),
+		d.Set("protection_reason", loadbalancer.ProtectionReason),
 		d.Set("public_ip", publicIp),
-		d.Set("charge_mode", lb.ChargeMode),
-		d.Set("frozen_scene", lb.FrozenScene),
-		d.Set("created_at", lb.CreatedAt),
-		d.Set("updated_at", lb.UpdatedAt),
+		d.Set("charge_mode", loadbalancer.ChargeMode),
+		d.Set("frozen_scene", loadbalancer.FrozenScene),
+		d.Set("created_at", loadbalancer.CreatedAt),
+		d.Set("updated_at", loadbalancer.UpdatedAt),
 	)
 
-	if lb.BillingInfo != "" {
+	if loadbalancer.BillingInfo != "" {
 		mErr = multierror.Append(mErr, d.Set("charging_mode", "prePaid"))
 	} else {
 		mErr = multierror.Append(mErr, d.Set("charging_mode", "postPaid"))
 	}
 
 	// Get any security groups on the VIP Port
-	if lb.VipPortID != "" {
+	if loadbalancer.VipPortID != "" {
 		networkingClient, err := cfg.NetworkingV2Client(region)
 		if err != nil {
 			return diag.Errorf("error creating VPC v2 Client: %s", err)
 		}
 
-		port, err := ports.Get(networkingClient, lb.VipPortID).Extract()
+		port, err := ports.Get(networkingClient, loadbalancer.VipPortID).Extract()
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/huaweicloud/services/rms/data_source_huaweicloud_rms_advanced_query_schemas.go
+++ b/huaweicloud/services/rms/data_source_huaweicloud_rms_advanced_query_schemas.go
@@ -110,10 +110,10 @@ func (w *AdvancedQuerySchemasDSWrapper) listSchemasToSchema(body *gjson.Result) 
 	d := w.ResourceData
 	mErr := multierror.Append(nil,
 		d.Set("schemas", schemas.SliceToList(body.Get("value"),
-			func(schema gjson.Result) any {
+			func(schemaItem gjson.Result) any {
 				return map[string]any{
-					"type":   schema.Get("type").Value(),
-					"schema": w.setValueSchema(schema),
+					"type":   schemaItem.Get("type").Value(),
+					"schema": w.setValueSchema(schemaItem),
 				}
 			},
 		)),

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
@@ -51,8 +51,8 @@ func dataSourceVpcIdsV1Read(_ context.Context, d *schema.ResourceData, meta inte
 
 	listVpcs := make([]string, 0)
 
-	for _, vpc := range refinedVpcs {
-		listVpcs = append(listVpcs, vpc.ID)
+	for _, refinedVpc := range refinedVpcs {
+		listVpcs = append(listVpcs, refinedVpc.ID)
 	}
 	d.SetId(listVpcs[0])
 	d.Set("ids", listVpcs)

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
@@ -137,7 +137,7 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 	tagFilter := d.Get("tags").(map[string]interface{})
 	var ids []string
 	for _, vpcResource := range vpcList {
-		vpc := map[string]interface{}{
+		queriedVpc := map[string]interface{}{
 			"id":                    vpcResource.ID,
 			"name":                  vpcResource.Name,
 			"cidr":                  vpcResource.CIDR,
@@ -152,7 +152,7 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 			if !utils.HasMapContains(tagmap, tagFilter) {
 				continue
 			}
-			vpc["tags"] = tagmap
+			queriedVpc["tags"] = tagmap
 		} else {
 			// The tags api does not support eps authorization, so don't return 403 to avoid error
 			if _, ok := err.(golangsdk.ErrDefault403); ok {
@@ -167,9 +167,9 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 		if err != nil {
 			diag.Errorf("error retrieving VPC (%s) v3 detail: %s", vpcResource.ID, err)
 		}
-		vpc["secondary_cidrs"] = utils.PathSearch("vpc.extend_cidrs", res, nil)
+		queriedVpc["secondary_cidrs"] = utils.PathSearch("vpc.extend_cidrs", res, nil)
 
-		vpcInfos = append(vpcInfos, vpc)
+		vpcInfos = append(vpcInfos, queriedVpc)
 		ids = append(ids, vpcResource.ID)
 	}
 	log.Printf("[DEBUG] VPC List after filter, count: %d vpcs: %+v", len(vpcInfos), vpcInfos)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Here are some code issues in the provider resource and data source file:
- Local variable names are duplicates of the package name of the current package.
- Local variable names are duplicates of the package name of the imported package.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rename locals that shadow package or import names
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cceautopilot -f TestAccDataSourceCceAutopilotClusterCertificate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cceautopilot" -v -coverprofile="./huaweicloud/services/acceptance/cceautopilot/cceautopilot_coverage.cov" -coverpkg="./huaweicloud/services/cceautopilot" -run TestAccDataSourceCceAutopilotClusterCertificate_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCceAutopilotClusterCertificate_basic
=== PAUSE TestAccDataSourceCceAutopilotClusterCertificate_basic
=== CONT  TestAccDataSourceCceAutopilotClusterCertificate_basic
--- PASS: TestAccDataSourceCceAutopilotClusterCertificate_basic (586.88s)
PASS
coverage: 17.9% of statements in ./huaweicloud/services/cceautopilot
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cceautopilot      586.997s        coverage: 17.9% of statements in ./huaweicloud/services/cceautopilot
```
```
./scripts/coverage.sh -o dds -f TestAccDDSV3Instance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dds" -v -coverprofile="./huaweicloud/services/acceptance/dds/dds_coverage.cov" -coverpkg="./huaweicloud/services/dds" -run TestAccDDSV3Instance_basic -timeout 360m -parallel 10
=== RUN   TestAccDDSV3Instance_basic
=== PAUSE TestAccDDSV3Instance_basic
=== CONT  TestAccDDSV3Instance_basic
--- PASS: TestAccDDSV3Instance_basic (2944.62s)
PASS
coverage: 11.0% of statements in ./huaweicloud/services/dds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       2944.754s    coverage: 11.0% of statements in ./huaweicloud/services/dds
```
```
./scripts/coverage.sh -o eip -f TestAccVpcEipsDataSource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccVpcEipsDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccVpcEipsDataSource_basic
=== PAUSE TestAccVpcEipsDataSource_basic
=== CONT  TestAccVpcEipsDataSource_basic
--- PASS: TestAccVpcEipsDataSource_basic (23.54s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       23.691s      coverage: 6.1% of statements in ./huaweicloud/services/eip
```
```
./scripts/coverage.sh -o lb -f TestAccELBV2LoadbalancerDataSource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lb" -v -coverprofile="./huaweicloud/services/acceptance/lb/lb_coverage.cov" -coverpkg="./huaweicloud/services/lb" -run TestAccELBV2LoadbalancerDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccELBV2LoadbalancerDataSource_basic
=== PAUSE TestAccELBV2LoadbalancerDataSource_basic
=== CONT  TestAccELBV2LoadbalancerDataSource_basic
--- PASS: TestAccELBV2LoadbalancerDataSource_basic (26.73s)
PASS
coverage: 9.2% of statements in ./huaweicloud/services/lb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        26.865s      coverage: 9.2% of statements in ./huaweicloud/services/lb
```
```
./scripts/coverage.sh -o lb -f TestAccLBV2LoadBalancer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lb" -v -coverprofile="./huaweicloud/services/acceptance/lb/lb_coverage.cov" -coverpkg="./huaweicloud/services/lb" -run TestAccLBV2LoadBalancer_basic -timeout 360m -parallel 10
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (81.33s)
PASS
coverage: 10.3% of statements in ./huaweicloud/services/lb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        81.469s      coverage: 10.3% of statements in ./huaweicloud/services/lb
```
```
./scripts/coverage.sh -o rms -f TestAccDataSourceRmsAdvancedQuerySchemas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rms" -v -coverprofile="./huaweicloud/services/acceptance/rms/rms_coverage.cov" -coverpkg="./huaweicloud/services/rms" -run TestAccDataSourceRmsAdvancedQuerySchemas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceRmsAdvancedQuerySchemas_basic
=== PAUSE TestAccDataSourceRmsAdvancedQuerySchemas_basic
=== CONT  TestAccDataSourceRmsAdvancedQuerySchemas_basic
--- PASS: TestAccDataSourceRmsAdvancedQuerySchemas_basic (9.92s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/rms
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       10.046s      coverage: 4.3% of statements in ./huaweicloud/services/rms
```
```
./scripts/coverage.sh -o vpc -f TestAccVpcIdsDataSource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/vpc" -v -coverprofile="./huaweicloud/services/acceptance/vpc/vpc_coverage.cov" -coverpkg="./huaweicloud/services/vpc" -run TestAccVpcIdsDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccVpcIdsDataSource_basic
=== PAUSE TestAccVpcIdsDataSource_basic
=== CONT  TestAccVpcIdsDataSource_basic
--- PASS: TestAccVpcIdsDataSource_basic (25.82s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/vpc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       25.950s      coverage: 4.5% of statements in ./huaweicloud/services/vpc
```
```
./scripts/coverage.sh -o vpc -f TestAccVpcsDataSource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/vpc" -v -coverprofile="./huaweicloud/services/acceptance/vpc/vpc_coverage.cov" -coverpkg="./huaweicloud/services/vpc" -run TestAccVpcsDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccVpcsDataSource_basic
=== PAUSE TestAccVpcsDataSource_basic
=== CONT  TestAccVpcsDataSource_basic
--- PASS: TestAccVpcsDataSource_basic (26.48s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/vpc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       26.603s      coverage: 5.0% of statements in ./huaweicloud/services/vpc
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
