### PR TITLE
fix(var/naming): rename snake case locals to camel case in acceptance tests

### DIFF
--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_lts_log_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_lts_log_test.go
@@ -44,8 +44,8 @@ func getLtsLogFunc(cfg *config.Config, state *terraform.ResourceState) (interfac
 		return nil, err
 	}
 
-	lts_enable := utils.PathSearch("data.lts_enable", respBody, float64(0)).(float64)
-	if lts_enable == 0 {
+	ltsLogEnable := utils.PathSearch("data.lts_enable", respBody, float64(0)).(float64)
+	if ltsLogEnable == 0 {
 		return nil, golangsdk.ErrDefault404{}
 	}
 

--- a/huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go
+++ b/huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go
@@ -74,7 +74,7 @@ func TestAccEnterpriseProject_delete(t *testing.T) {
 	deleteName := acceptance.RandomAccResourceName() + "delete"
 	resourceDeleteName := "huaweicloud_enterprise_project.test_delete"
 
-	rc_delete := acceptance.InitResourceCheck(
+	rc := acceptance.InitResourceCheck(
 		resourceDeleteName,
 		&project,
 		getResourceEnterpriseProject,
@@ -90,7 +90,7 @@ func TestAccEnterpriseProject_delete(t *testing.T) {
 			{
 				Config: testAccEnterpriseProject_delete(deleteName),
 				Check: resource.ComposeTestCheckFunc(
-					rc_delete.CheckResourceExists(),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceDeleteName, "name", deleteName),
 					resource.TestCheckResourceAttr(resourceDeleteName, "type", "prod"),
 					resource.TestCheckResourceAttr(resourceDeleteName, "description", "terraform test delete"),
@@ -101,7 +101,7 @@ func TestAccEnterpriseProject_delete(t *testing.T) {
 			{
 				Config: testAccEnterpriseProject_delete_update(deleteName),
 				Check: resource.ComposeTestCheckFunc(
-					rc_delete.CheckResourceExists(),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceDeleteName, "name", fmt.Sprintf("%s_update", deleteName)),
 					resource.TestCheckResourceAttr(resourceDeleteName, "type", "prod"),
 					resource.TestCheckResourceAttr(resourceDeleteName, "description", "terraform test delete update"),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_smart_connect_task_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_smart_connect_task_test.go
@@ -151,7 +151,7 @@ func testKafkaSmartConnectTaskResourceImportState(name string) resource.ImportSt
 		if !ok {
 			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
 		}
-		connector_id := rs.Primary.Attributes["connector_id"]
-		return fmt.Sprintf("%s/%s", connector_id, rs.Primary.ID), nil
+		connectorId := rs.Primary.Attributes["connector_id"]
+		return fmt.Sprintf("%s/%s", connectorId, rs.Primary.ID), nil
 	}
 }

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_smart_connect_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_smart_connect_test.go
@@ -106,7 +106,7 @@ func testKafkaSmartConnectResourceImportState(name string) resource.ImportStateI
 		if !ok {
 			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
 		}
-		instance_id := rs.Primary.Attributes["instance_id"]
-		return fmt.Sprintf("%s/%s", instance_id, rs.Primary.ID), nil
+		instanceId := rs.Primary.Attributes["instance_id"]
+		return fmt.Sprintf("%s/%s", instanceId, rs.Primary.ID), nil
 	}
 }

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_member_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_member_test.go
@@ -26,8 +26,8 @@ func getMemberResourceFunc(conf *config.Config, state *terraform.ResourceState) 
 }
 
 func TestAccLBV2Member_basic(t *testing.T) {
-	var member_1 pools.Member
-	var member_2 pools.Member
+	var member1 pools.Member
+	var member2 pools.Member
 	resourceName1 := "huaweicloud_lb_member.member_1"
 	resourceName2 := "huaweicloud_lb_member.member_2"
 	rName := acceptance.RandomAccResourceNameWithDash()
@@ -35,12 +35,12 @@ func TestAccLBV2Member_basic(t *testing.T) {
 
 	rc1 := acceptance.InitResourceCheck(
 		resourceName1,
-		&member_1,
+		&member1,
 		getMemberResourceFunc,
 	)
 	rc2 := acceptance.InitResourceCheck(
 		resourceName2,
-		&member_2,
+		&member2,
 		getMemberResourceFunc,
 	)
 

--- a/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_test.go
+++ b/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_test.go
@@ -27,7 +27,7 @@ func TestAccSMNV2Topic_basic(t *testing.T) {
 	resourceName := "huaweicloud_smn_topic.topic_1"
 	rName := acceptance.RandomAccResourceNameWithDash()
 	displayName := fmt.Sprintf("The display name of %s", rName)
-	update_displayName := fmt.Sprintf("The update display name of %s", rName)
+	updateDisplayName := fmt.Sprintf("The update display name of %s", rName)
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -54,7 +54,7 @@ func TestAccSMNV2Topic_basic(t *testing.T) {
 				Config: testAccSMNV2TopicConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "display_name", update_displayName),
+					resource.TestCheckResourceAttr(resourceName, "display_name", updateDisplayName),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value"),
 				),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Some local variables are named incorrectly:
- It is recommended to use camel case naming convention instead of snake case.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rename snake_case locals to camelCase in acceptance tests
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccLtsLog_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccLtsLog_basic -timeout 360m -parallel 10
=== RUN   TestAccLtsLog_basic
=== PAUSE TestAccLtsLog_basic
=== CONT  TestAccLtsLog_basic
--- PASS: TestAccLtsLog_basic (29.46s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       29.598s coverage: 4.7% of statements in ./huaweicloud/services/cfw
```
```
./scripts/coverage.sh -o eps -f TestAccEnterpriseProject_delete
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eps" -v -coverprofile="./huaweicloud/services/acceptance/eps/eps_coverage.cov" -coverpkg="./huaweicloud/services/eps" -run TestAccEnterpriseProject_delete -timeout 360m -parallel 10
=== RUN   TestAccEnterpriseProject_delete
=== PAUSE TestAccEnterpriseProject_delete
=== CONT  TestAccEnterpriseProject_delete
--- PASS: TestAccEnterpriseProject_delete (27.43s)
PASS
coverage: 18.3% of statements in ./huaweicloud/services/eps
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       27.546s coverage: 18.3% of statements in ./huaweicloud/services/eps
```
```
./scripts/coverage.sh -o kafka -f TestAccDmsKafkaSmartConnectTask_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDmsKafkaSmartConnectTask_basic -timeout 360m -parallel 10
=== RUN   TestAccDmsKafkaSmartConnectTask_basic
=== PAUSE TestAccDmsKafkaSmartConnectTask_basic
=== CONT  TestAccDmsKafkaSmartConnectTask_basic
--- PASS: TestAccDmsKafkaSmartConnectTask_basic (1121.24s)
PASS
coverage: 17.5% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka       1121.390s       coverage: 17.5% of statements in ./huaweicloud/services/kafka
```
```
./scripts/coverage.sh -o kafka -f TestAccDmsKafkaSmartConnect_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDmsKafkaSmartConnect_basic -timeout 360m -parallel 10
=== RUN   TestAccDmsKafkaSmartConnect_basic
=== PAUSE TestAccDmsKafkaSmartConnect_basic
=== CONT  TestAccDmsKafkaSmartConnect_basic
--- PASS: TestAccDmsKafkaSmartConnect_basic (1084.11s)
PASS
coverage: 13.2% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     1084.231s       coverage: 13.2% of statements in ./huaweicloud/services/kafka
```
```
./scripts/coverage.sh -o lb -f TestAccLBV2Member_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lb" -v -coverprofile="./huaweicloud/services/acceptance/lb/lb_coverage.cov" -coverpkg="./huaweicloud/services/lb" -run TestAccLBV2Member_basic -timeout 360m -parallel 10
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (92.73s)
PASS
coverage: 21.5% of statements in ./huaweicloud/services/lb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb92.852s coverage: 21.5% of statements in ./huaweicloud/services/lb
```
```
./scripts/coverage.sh -o smn -f TestAccSMNV2Topic_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/smn" -v -coverprofile="./huaweicloud/services/acceptance/smn/smn_coverage.cov" -coverpkg="./huaweicloud/services/smn" -run TestAccSMNV2Topic_basic -timeout 360m -parallel 10
=== RUN   TestAccSMNV2Topic_basic
=== PAUSE TestAccSMNV2Topic_basic
=== CONT  TestAccSMNV2Topic_basic
--- PASS: TestAccSMNV2Topic_basic (27.72s)
PASS
coverage: 9.2% of statements in ./huaweicloud/services/smn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn       27.839s coverage: 9.2% of statements in ./huaweicloud/services/smn
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.
