### PR TITLE
feat(dsc): add a new resource to manage database watermark embed task

### DIFF
--- a/docs/resources/dsc_database_watermark_embed_task.md
+++ b/docs/resources/dsc_database_watermark_embed_task.md
@@ -1,0 +1,378 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_database_watermark_embed_task"
+description: |-
+  Manages a DSC database watermark embed task resource within HuaweiCloud.
+---
+
+# huaweicloud_dsc_database_watermark_embed_task
+
+Manages a DSC database watermark embed task resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a database fake-column watermark embed task and immediately execute it
+
+```hcl
+variable "task_name" {}
+variable "water_mark" {}
+variable "database_id" {}
+variable "database_name" {}
+variable "instance_id" {}
+variable "instance_name" {}
+variable "source_db_table_name" {}
+variable "target_db_table_name" {}
+variable "watermark_key" {}
+
+resource "huaweicloud_dsc_database_watermark_embed_task" "test" {
+  task_name         = var.task_name
+  water_mark        = var.water_mark
+  watermark_version = "V2"
+
+  db_water_param {
+    embed_mode    = "EMBED_FAKE_COLUMN"
+    watermark_key = var.watermark_key
+
+    params {
+      new_column_name = "field1"
+      new_column_type = "date"
+      fake_strategy   = "date"
+
+      fake_param {
+        date_begin = "2026-08-03T14:20:55+08:00"
+        date_end   = "2026-08-04T14:20:55+08:00"
+      }
+    }
+    params {
+      new_column_name = "field2"
+      new_column_type = "number"
+      fake_strategy   = "number_random"
+
+      fake_param {
+        random_begin    = "2"
+        random_end      = "3"
+        random_accuracy = 1
+      }
+    }
+  }
+
+  source_db_info {
+    db_id      = var.database_id
+    db_name    = var.database_name
+    db_type    = "MySQL"
+    ins_id     = var.instance_id
+    ins_name   = var.instance_name
+    table_name = var.source_db_table_name
+  }
+
+  target_db_info {
+    db_id      = var.database_id
+    db_name    = var.database_name
+    db_type    = "MySQL"
+    ins_id     = var.instance_id
+    ins_name   = var.instance_name
+    table_name = var.target_db_table_name
+  }
+
+  error_code    = 1
+  start_now     = true
+  schedule_type = "ONCE"
+}
+```
+
+### Create a database fake-row watermark embed task and execute it at a specific time
+
+```hcl
+variable "task_name" {}
+variable "water_mark" {}
+variable "row_spacing" {}
+variable "watermark_key" {}
+variable "instance_id" {}
+variable "instance_name" {}
+variable "database_id" {}
+variable "database_name" {}
+variable "source_db_table_name" {}
+variable "target_db_table_name" {}
+variable "start_time" {}
+
+resource "huaweicloud_dsc_database_watermark_embed_task" "test" {
+  task_name         = var.task_name
+  water_mark        = var.water_mark
+  watermark_version = "V2"
+
+  db_water_param {
+    embed_mode    = "EMBED_FAKE_ROW"
+    row_spacing   = var.row_spacing
+    watermark_key = var.watermark_key
+  }
+
+  source_db_info {
+    db_id      = var.database_id
+    db_name    = var.database_name
+    db_type    = "MySQL"
+    ins_id     = var.instance_id
+    ins_name   = var.instance_name
+    table_name = var.source_db_table_name
+  }
+
+  target_db_info {
+    db_id      = var.database_id
+    db_name    = var.database_name
+    db_type    = "MySQL"
+    ins_id     = var.instance_id
+    ins_name   = var.instance_name
+    table_name = var.target_db_table_name
+  }
+
+  error_code    = 1
+  schedule_type = "DAY"
+  start_time    = var.start_time
+}
+```
+
+### Create a database lossy column watermark embed task
+
+```hcl
+variable "task_name" {}
+variable "water_mark" {}
+variable "watermark_key" {}
+variable "instance_id" {}
+variable "instance_name" {}
+variable "database_id" {}
+variable "database_name" {}
+variable "schema_name" {}
+variable "source_db_table_name" {}
+variable "target_db_table_name" {}
+variable "start_time" {}
+variable "selected_fields" {
+  type = list(object({
+    column_name = string
+    column_type = string
+  }))
+}
+
+resource "huaweicloud_dsc_database_watermark_embed_task" "test" {
+  task_name         = var.task_name
+  water_mark        = var.water_mark
+  watermark_version = "V2"
+
+  db_water_param {
+    embed_mode    = "EMBED_COLUMN"
+    watermark_key = var.watermark_key
+  }
+
+  source_db_info {
+    db_id       = var.database_id
+    db_name     = var.database_name
+    db_type     = "DWS"
+    ins_id      = var.instance_id
+    ins_name    = var.instance_name
+    schema_name = var.schema_name
+    table_name  = var.source_db_table_name
+  }
+
+  target_db_info {
+    db_id       = var.database_id
+    db_name     = var.database_name
+    db_type     = "DWS"
+    ins_id      = var.instance_id
+    ins_name    = var.instance_name
+    schema_name = var.schema_name
+    table_name  = var.target_db_table_name
+  }
+
+  dynamic "selected_fields" {
+    for_each = var.selected_fields
+
+    content {
+      column_name = selected_fields.value.column_name
+      column_type = selected_fields.value.column_type
+    }
+  }
+
+  error_code    = 1
+  schedule_type = "DAY"
+  start_time    = var.start_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the database watermark embed task is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `task_name` - (Required, String) Specifies the name of the database watermark embed task.  
+  The maximum length is `255` characters and must be unique.  
+  Only Chinese characters, English letters, digits, underscores (_) and hyphens (-) are allowed.
+
+* `water_mark` - (Required, String) Specifies the watermark content to be embedded into the database.
+
+* `watermark_version` - (Required, String) Specifies the watermark algorithm version.  
+  The valid values are as follows:
+  + **V1**
+  + **V2**
+
+* `db_water_param` - (Required, List) Specifies the database watermark embedding configuration.  
+  The [db_water_param](#database_watermark_embed_task_db_water_param) structure is documented below.
+
+* `source_db_info` - (Required, List) Specifies the source database information from which data is read.  
+  The [source_db_info](#database_watermark_embed_task_db_info) structure is documented below.
+
+* `target_db_info` - (Required, List) Specifies the target database information to which watermarked data is written.  
+  The [target_db_info](#database_watermark_embed_task_db_info) structure is documented below.
+
+* `error_code` - (Required, Int) Specifies the watermark error correction level.  
+  The valid values are as follows:
+  + **1**
+  + **2**
+  + **3**
+  + **4**
+
+  The smaller the value, the higher the error correction ability.
+
+* `selected_fields` - (Optional, List) Specifies the selected field list used for watermark embedding.  
+  The [selected_fields](#database_watermark_embed_task_selected_fields) structure is documented below.  
+  This parameter is required when `db_water_param.embed_mode` is set to **EMBED_COLUMN**.
+
+* `watermark_describe` - (Optional, String) Specifies the description of the watermark.
+
+* `schedule_switch` - (Optional, Bool) Specifies whether to enable task scheduling.  
+  Defaults to **true**.
+
+* `schedule_type` - (Optional, String) Specifies the schedule type of the task.  
+  The valid values are as follows:
+  + **ONCE**
+  + **DAY**
+  + **WEEK**
+  + **MONTH**
+
+* `start_now` - (Optional, Bool) Specifies whether to start the watermark embed task immediately after creation.  
+  Defaults to **false**.  
+  This parameter is valid only when `schedule_type` is set to **ONCE**.
+
+* `start_time` - (Optional, String) Specifies the scheduled start time of the task, in RFC3339 format.  
+  `start_now` and `start_time` cannot be specified at the same time.  
+  When `start_now` is set to **true**, the value of this parameter is determined by the actual start time of the task.
+
+<a name="database_watermark_embed_task_db_water_param"></a>
+The `db_water_param` block supports:
+
+* `embed_mode` - (Required, String) Specifies the watermark embed mode.  
+  The valid values are as follows:
+  + **EMBED_FAKE_ROW**: Lossless fake-row watermark.
+  + **EMBED_FAKE_COLUMN**: Lossless fake-column watermark.
+  + **EMBED_COLUMN**: Lossy column watermark.
+
+* `watermark_key` - (Optional, String) Specifies the watermark key used to embed and extract the watermark.
+
+* `params` - (Optional, List) Specifies the fake-column embed parameter list.  
+  The [params](#database_watermark_embed_task_params) structure is documented below.  
+  This parameter is required when `embed_mode` is set to **EMBED_FAKE_COLUMN**.
+
+* `row_spacing` - (Optional, String) Specifies the row spacing used by fake-row watermark.  
+  This parameter is required when `embed_mode` is set to **EMBED_FAKE_ROW**.  
+  This value must be an integer greater than `1`.
+
+<a name="database_watermark_embed_task_params"></a>
+The `params` block supports:
+
+* `new_column_name` - (Required, String) Specifies the name of the new fake column to be created.
+
+* `new_column_type` - (Required, String) Specifies the data type of the new fake column.  
+  The valid values are as follows:
+  + **varchar**
+  + **date**
+  + **number**
+
+* `fake_strategy` - (Optional, String) Specifies the strategy used to generate fake data.
+
+* `fake_param` - (Optional, List) Specifies the configuration of fake data generation.  
+  The [fake_param](#database_watermark_embed_task_fake_param) structure is documented below.  
+  This parameter is used together with `fake_strategy`.
+
+<a name="database_watermark_embed_task_fake_param"></a>
+The `fake_param` block supports:
+
+* `address_accuracy` - (Optional, String) Specifies the accuracy of generated address data.
+
+* `date_begin` - (Optional, String) Specifies the start date of the generated date range, in RFC3339 format.
+
+* `date_end` - (Optional, String) Specifies the end date of the generated date range, in RFC3339 format.
+
+* `random_accuracy` - (Optional, Int) Specifies the precision of generated random numbers.
+
+* `random_begin` - (Optional, String) Specifies the lower bound of the generated random value range.
+
+* `random_distribute` - (Optional, String) Specifies the distribution mode of generated random values.
+
+* `random_end` - (Optional, String) Specifies the upper bound of the generated random value range.
+
+* `string_distribute` - (Optional, String) Specifies the distribution mode of generated string values.
+
+<a name="database_watermark_embed_task_selected_fields"></a>
+The `selected_fields` block supports:
+
+* `column_name` - (Optional, String) Specifies the name of the selected column.
+
+* `column_type` - (Optional, String) Specifies the data type of the selected column.
+
+<a name="database_watermark_embed_task_db_info"></a>
+The `source_db_info` and `target_db_info` blocks support:
+
+* `db_id` - (Required, String) Specifies the ID of the authorized database.
+
+* `db_name` - (Required, String) Specifies the name of the database.
+
+* `db_type` - (Required, String, NonUpdatable) Specifies the database type.  
+  When `db_water_param.embed_mode` is set to **EMBED_COLUMN**, the valid values are as follows:
+  + **DWS**
+  + **MRS_HIVE**
+
+  When `db_water_param.embed_mode` is set to **EMBED_FAKE_COLUMN** or **EMBED_FAKE_ROW**, the valid values are as follows:
+  + **DWS**
+  + **PostgreSQL**
+  + **MySQL**
+
+* `ins_id` - (Required, String, NonUpdatable) Specifies the ID of the database instance.
+
+* `ins_name` - (Required, String, NonUpdatable) Specifies the name of the database instance.
+
+* `table_name` - (Required, String) Specifies the name of the database table.
+
+* `schema_name` - (Optional, String) Specifies the schema name of the database.  
+  This parameter is valid only when `db_type` is **DWS** or **PostgreSQL**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `task_state` - The running state of the watermark embed task.  
+  + **WAIT**
+  + **FINISHED**
+  + **CLOSED**
+  + **ERROR**
+
+* `task_create_time` - The creation time of the task, in RFC3339 format.
+
+* `task_end_time` - The end time of the task, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dsc_database_watermark_embed_task.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5052,6 +5052,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_batch_update_template_rules_classification": dsc.ResourceDscBatchUpdateTemplateRulesClassification(),
 			"huaweicloud_dsc_bigdata_instance":                           dsc.ResourceBigdataInstance(),
 			"huaweicloud_dsc_data_map_score_update":                      dsc.ResourceDscDataMapScoreUpdate(),
+			"huaweicloud_dsc_database_watermark_embed_task":              dsc.ResourceDatabaseWatermarkEmbedTask(),
 			"huaweicloud_dsc_device":                                     dsc.ResourceDscDevice(),
 			"huaweicloud_dsc_instance":                                   dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_mask_algorithm":                             dsc.ResourceMaskAlgorithm(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -477,6 +477,7 @@ var (
 	HW_DSC_RULE_IDS                 = os.Getenv("HW_DSC_RULE_IDS")
 	HW_DSC_DB_INSTANCE_ID           = os.Getenv("HW_DSC_DB_INSTANCE_ID")
 	HW_DSC_DB_ID                    = os.Getenv("HW_DSC_DB_ID")
+	HW_DSC_DB_TABLE_NAME            = os.Getenv("HW_DSC_DB_TABLE_NAME")
 	HW_DSC_BUCKET_ID                = os.Getenv("HW_DSC_BUCKET_ID")
 	HW_DSC_CLASSIFICATION_ID        = os.Getenv("HW_DSC_CLASSIFICATION_ID")
 
@@ -5424,6 +5425,13 @@ func TestAccPreCheckDscObsId(t *testing.T) {
 func TestAccPreCheckDscDbId(t *testing.T) {
 	if HW_DSC_DB_ID == "" {
 		t.Skip("HW_DSC_DB_ID must be set for DSC acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDscDbTableName(t *testing.T) {
+	if HW_DSC_DB_TABLE_NAME == "" {
+		t.Skip("HW_DSC_DB_TABLE_NAME must be set for DSC acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_database_watermark_embed_task_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_database_watermark_embed_task_test.go
@@ -1,0 +1,306 @@
+package dsc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dsc"
+)
+
+func getDatabaseWatermarkEmbedTaskResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dsc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DSC client: %s", err)
+	}
+
+	return dsc.GetDatabaseWatermarkEmbedTaskById(client, state.Primary.ID)
+}
+
+// Before this test, please ensure that the DSC instance has been created and authorized RDS MySQL database assets.
+// HW_DSC_DB_TABLE_NAME must belong to the currently provided authorized database.
+func TestAccDatabaseWatermarkEmbedTask_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dsc_database_watermark_embed_task.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getDatabaseWatermarkEmbedTaskResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscDbInstanceId(t)
+			acceptance.TestAccPreCheckProjectID(t)
+			acceptance.TestAccPreCheckDscDbTableName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseWatermarkEmbedTask_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "task_name", name),
+					resource.TestCheckResourceAttr(rName, "water_mark", "TF"),
+					resource.TestCheckResourceAttr(rName, "watermark_version", "V1"),
+					resource.TestCheckResourceAttr(rName, "watermark_describe", "Created by Terraform"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.#", "1"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.embed_mode", "EMBED_FAKE_COLUMN"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.watermark_key", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.#", "2"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.0.new_column_name", "field1"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.0.new_column_type", "date"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.0.fake_strategy", "date"),
+					resource.TestCheckResourceAttrSet(rName, "db_water_param.0.params.0.fake_param.0.date_begin"),
+					resource.TestCheckResourceAttrSet(rName, "db_water_param.0.params.0.fake_param.0.date_end"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.1.new_column_name", "field2"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.1.new_column_type", "number"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.1.fake_strategy", "number_random"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.1.fake_param.0.random_begin", "2"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.1.fake_param.0.random_end", "3"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.1.fake_param.0.random_accuracy", "1"),
+					resource.TestCheckResourceAttr(rName, "source_db_info.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "source_db_info.0.db_id"),
+					resource.TestCheckResourceAttrSet(rName, "source_db_info.0.db_name"),
+					resource.TestCheckResourceAttr(rName, "source_db_info.0.db_type", "MySQL"),
+					resource.TestCheckResourceAttr(rName, "source_db_info.0.ins_id", acceptance.HW_DSC_DB_INSTANCE_ID),
+					resource.TestCheckResourceAttrSet(rName, "source_db_info.0.ins_name"),
+					resource.TestCheckResourceAttr(rName, "source_db_info.0.table_name", acceptance.HW_DSC_DB_TABLE_NAME),
+					resource.TestCheckResourceAttr(rName, "target_db_info.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "target_db_info.0.db_id"),
+					resource.TestCheckResourceAttrSet(rName, "target_db_info.0.db_name"),
+					resource.TestCheckResourceAttr(rName, "target_db_info.0.db_type", "MySQL"),
+					resource.TestCheckResourceAttr(rName, "target_db_info.0.ins_id", acceptance.HW_DSC_DB_INSTANCE_ID),
+					resource.TestCheckResourceAttrSet(rName, "target_db_info.0.ins_name"),
+					resource.TestCheckResourceAttr(rName, "target_db_info.0.table_name", name),
+					resource.TestCheckResourceAttr(rName, "error_code", "1"),
+					resource.TestCheckResourceAttr(rName, "start_now", "true"),
+					resource.TestCheckResourceAttr(rName, "schedule_type", "ONCE"),
+					resource.TestCheckResourceAttr(rName, "schedule_switch", "true"),
+					resource.TestMatchResourceAttr(rName, "start_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(rName, "task_state"),
+					resource.TestCheckResourceAttrSet(rName, "task_create_time"),
+					resource.TestMatchResourceAttr(rName, "task_create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "task_end_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccDatabaseWatermarkEmbedTask_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "task_name", updateName),
+					resource.TestCheckResourceAttr(rName, "water_mark", "TFUpdate"),
+					resource.TestCheckResourceAttr(rName, "watermark_version", "V2"),
+					resource.TestCheckResourceAttr(rName, "watermark_describe", "update description"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.#", "1"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.embed_mode", "EMBED_FAKE_COLUMN"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.#", "1"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.0.new_column_name", "test_update"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.0.new_column_type", "varchar"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.0.fake_strategy", "name"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.0.fake_param.#", "0"),
+					resource.TestCheckResourceAttr(rName, "target_db_info.0.table_name", updateName),
+					resource.TestCheckResourceAttr(rName, "error_code", "2"),
+					resource.TestCheckResourceAttr(rName, "schedule_switch", "true"),
+					resource.TestCheckResourceAttr(rName, "schedule_type", "MONTH"),
+				),
+			},
+			{
+				Config: testAccDatabaseWatermarkEmbedTask_basic_step3(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "watermark_describe", ""),
+					resource.TestCheckResourceAttr(rName, "db_water_param.#", "1"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.embed_mode", "EMBED_FAKE_ROW"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.row_spacing", "2"),
+					resource.TestCheckResourceAttr(rName, "db_water_param.0.params.#", "0"),
+					resource.TestCheckResourceAttr(rName, "schedule_switch", "false"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDatabaseWatermarkEmbedTask_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_authorize_databases" "test" {
+  instance_type = "RDS"
+}
+
+locals {
+  instance_id   = "%[1]s"
+  instance      = try([for v in data.huaweicloud_dsc_authorize_databases.test.databases : v if v.ins_id == local.instance_id][0], {})
+  instance_name = try(local.instance.ins_name, "NOT_FOUND")
+  database_id   = try(local.instance.id, "NOT_FOUND")
+  database_name = try(local.instance.db_name, "NOT_FOUND")
+}
+`, acceptance.HW_DSC_DB_INSTANCE_ID)
+}
+
+func testAccDatabaseWatermarkEmbedTask_basic(name string) string {
+	currentTime := time.Now()
+	beginTime := currentTime.Format("2006-01-02T15:04:05+08:00")
+	endTime := currentTime.Add(1 * time.Hour).Format("2006-01-02T15:04:05+08:00")
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_database_watermark_embed_task" "test" {
+  task_name          = "%[2]s"
+  water_mark         = "TF"
+  watermark_version  = "V1"
+  watermark_describe = "Created by Terraform"
+
+  db_water_param {
+    embed_mode    = "EMBED_FAKE_COLUMN"
+    watermark_key = "%[3]s"
+
+    params {
+      new_column_name = "field1"
+      new_column_type = "date"
+      fake_strategy   = "date"
+
+      fake_param {
+        date_begin = "%[4]s"
+        date_end   = "%[5]s"
+      }
+    }
+    params {
+      new_column_name = "field2"
+      new_column_type = "number"
+      fake_strategy   = "number_random"
+
+      fake_param {
+        random_begin    = "2"
+        random_end      = "3"
+        random_accuracy = 1
+      }
+    }
+  }
+
+  source_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[6]s"
+  }
+
+  target_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[2]s"
+  }
+
+  error_code    = 1
+  start_now     = true
+  schedule_type = "ONCE"
+}
+`, testAccDatabaseWatermarkEmbedTask_base(), name, acceptance.HW_PROJECT_ID, beginTime, endTime, acceptance.HW_DSC_DB_TABLE_NAME)
+}
+
+func testAccDatabaseWatermarkEmbedTask_basic_step2(updateName string) string {
+	startTime := time.Now().Add(1 * time.Hour).Format("2006-01-02T15:04:05+08:00")
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_database_watermark_embed_task" "test" {
+  task_name         = "%[2]s"
+  water_mark        = "TFUpdate"
+  watermark_version = "V2"
+
+  db_water_param {
+    embed_mode = "EMBED_FAKE_COLUMN"
+
+    params {
+      new_column_name = "test_update"
+      new_column_type = "varchar"
+      fake_strategy   = "name"
+    }
+  }
+
+  source_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[4]s"
+  }
+
+  target_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[2]s"
+  }
+
+  error_code         = 2
+  watermark_describe = "update description"
+  schedule_switch    = true
+  schedule_type      = "MONTH"
+  start_time         = "%[3]s"
+}
+`, testAccDatabaseWatermarkEmbedTask_base(), updateName, startTime, acceptance.HW_DSC_DB_TABLE_NAME)
+}
+
+func testAccDatabaseWatermarkEmbedTask_basic_step3(updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_database_watermark_embed_task" "test" {
+  task_name         = "%[2]s"
+  water_mark        = "TFUpdate"
+  watermark_version = "V2"
+
+  db_water_param {
+    embed_mode  = "EMBED_FAKE_ROW"
+    row_spacing = "2"
+  }
+
+  source_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[3]s"
+  }
+
+  target_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[2]s"
+  }
+
+  error_code      = 1
+  schedule_switch = false
+}
+`, testAccDatabaseWatermarkEmbedTask_base(), updateName, acceptance.HW_DSC_DB_TABLE_NAME)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_database_watermark_embed_task.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_database_watermark_embed_task.go
@@ -1,0 +1,890 @@
+package dsc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	databaseWatermarkEmbedTaskNonUpdatableParams = []string{
+		"source_db_info.*.ins_id",
+		"source_db_info.*.ins_name",
+		"source_db_info.*.db_type",
+		"target_db_info.*.ins_id",
+		"target_db_info.*.ins_name",
+		"target_db_info.*.db_type",
+	}
+
+	databaseWatermarkEmbedTaskNotFoundErrCodes = []string{
+		"dsc.10000009", // The DSC instance does not exist.
+	}
+)
+
+// @API DSC POST /v1/{project_id}/data-watermark-embed-tasks
+// @API DSC GET /v1/{project_id}/data-watermark-embed-tasks
+// @API DSC PUT /v1/{project_id}/data-watermark-embed-tasks/{id}
+// @API DSC DELETE /v1/{project_id}/data-watermark-embed-tasks/{id}
+func ResourceDatabaseWatermarkEmbedTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDatabaseWatermarkEmbedTaskCreate,
+		ReadContext:   resourceDatabaseWatermarkEmbedTaskRead,
+		UpdateContext: resourceDatabaseWatermarkEmbedTaskUpdate,
+		DeleteContext: resourceDatabaseWatermarkEmbedTaskDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(databaseWatermarkEmbedTaskNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the database watermark embed task is located.`,
+			},
+
+			// Required parameters.
+			"task_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the database watermark embed task.`,
+			},
+			"water_mark": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The watermark content to be embedded into the database.`,
+			},
+			"watermark_version": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The watermark algorithm version.`,
+			},
+			"db_water_param": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Elem:        databaseWatermarkEmbedTaskDbWaterParamSchema(),
+				Description: `The database watermark embedding configuration.`,
+			},
+			"source_db_info": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Elem:        databaseWatermarkEmbedTaskDbInfoSchema(),
+				Description: `The source database information from which data is read.`,
+			},
+			"target_db_info": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Elem:        databaseWatermarkEmbedTaskDbInfoSchema(),
+				Description: `The target database information to which watermarked data is written.`,
+			},
+			"error_code": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The watermark error correction level.`,
+			},
+
+			// Optional parameters.
+			"selected_fields": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        databaseWatermarkEmbedTaskColumnInfoSchema(),
+				Description: `The selected field list used for watermark embedding.`,
+			},
+			"watermark_describe": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the watermark.`,
+			},
+			"schedule_switch": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to enable task scheduling.`,
+			},
+			"schedule_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The schedule type of the task.`,
+			},
+			"start_now": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to start the watermark embed task immediately after creation.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The scheduled start time of the task, in RFC3339 format.`,
+			},
+
+			// Attributes.
+			"task_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The running state of the watermark embed task.`,
+			},
+			"task_create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the task, in RFC3339 format.`,
+			},
+			"task_end_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end time of the task, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTaskDbWaterParamSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"embed_mode": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The watermark embed mode.`,
+			},
+			"watermark_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The watermark key used to embed and extract the watermark.`,
+			},
+			"params": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        databaseWatermarkEmbedTaskEmbedParamSchema(),
+				Description: `The fake-column embed parameter list.`,
+			},
+			"row_spacing": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The row spacing used by fake-row watermark.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTaskEmbedParamSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"new_column_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the new fake column to be created.`,
+			},
+			"new_column_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The data type of the new fake column.`,
+			},
+			"fake_strategy": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The strategy used to generate fake data.`,
+			},
+			"fake_param": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem:        databaseWatermarkEmbedTaskFakeParamSchema(),
+				Description: `The configuration of fake data generation.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTaskFakeParamSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"address_accuracy": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The accuracy of generated address data.`,
+			},
+			"date_begin": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The start date of the generated date range, in RFC3339 format.`,
+			},
+			"date_end": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The end date of the generated date range, in RFC3339 format.`,
+			},
+			"random_accuracy": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The precision of generated random numbers.`,
+			},
+			"random_begin": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The lower bound of the generated random value range.`,
+			},
+			"random_distribute": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The distribution mode of generated random values.`,
+			},
+			"random_end": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The upper bound of the generated random value range.`,
+			},
+			"string_distribute": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The distribution mode of generated string values.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTaskColumnInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"column_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the selected column.`,
+			},
+			"column_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The data type of the selected column.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTaskDbInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"db_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the authorized database.`,
+			},
+			"db_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the database.`,
+			},
+			"db_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The database type.`,
+			},
+			"ins_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the database instance.`,
+			},
+			"ins_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the database instance.`,
+			},
+			"table_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the database table.`,
+			},
+			"schema_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The schema name of the database.`,
+			},
+		},
+	}
+}
+
+func buildDatabaseWatermarkEmbedTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := utils.RemoveNil(map[string]interface{}{
+		// Required parameters.
+		"task_name":         d.Get("task_name"),
+		"water_mark":        d.Get("water_mark"),
+		"watermark_version": d.Get("watermark_version"),
+		"db_water_param":    buildDatabaseWatermarkEmbedTaskDbWaterParamBodyParams(d.Get("db_water_param").([]interface{})),
+		"source_db_info":    buildDatabaseWatermarkEmbedTaskDbInfoBodyParams(d.Get("source_db_info").([]interface{})),
+		"target_db_info":    buildDatabaseWatermarkEmbedTaskDbInfoBodyParams(d.Get("target_db_info").([]interface{})),
+		"error_code":        d.Get("error_code"),
+		// Optional parameters.
+		"start_now":          utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "start_now"),
+		"watermark_describe": utils.ValueIgnoreEmpty(d.Get("watermark_describe")),
+		"schedule_switch":    utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "schedule_switch"),
+		"schedule_type":      utils.ValueIgnoreEmpty(d.Get("schedule_type")),
+		"start_time":         utils.ValueIgnoreEmpty(utils.ConvertTimeStrToNanoTimestamp(d.Get("start_time").(string))),
+		"selected_fields":    buildDatabaseWatermarkEmbedTaskColumnInfoBodyParams(d.Get("selected_fields").([]interface{})),
+	})
+
+	// For API, the `selected_fields` is required.
+	if params["selected_fields"] == nil {
+		params["selected_fields"] = make([]interface{}, 0)
+	}
+
+	return params
+}
+
+func buildDatabaseWatermarkEmbedTaskDbWaterParamBodyParams(dbWaterParams []interface{}) map[string]interface{} {
+	if len(dbWaterParams) == 0 {
+		return nil
+	}
+
+	dbWaterParam := dbWaterParams[0]
+	return map[string]interface{}{
+		"embed_mode":    utils.PathSearch("embed_mode", dbWaterParam, nil),
+		"watermark_key": utils.ValueIgnoreEmpty(utils.PathSearch("watermark_key", dbWaterParam, nil)),
+		"params": buildDatabaseWatermarkEmbedTaskEmbedParamBodyParams(utils.PathSearch("params", dbWaterParam,
+			make([]interface{}, 0)).([]interface{})),
+		"row_spacing": utils.ValueIgnoreEmpty(utils.PathSearch("row_spacing", dbWaterParam, nil)),
+	}
+}
+
+func buildDatabaseWatermarkEmbedTaskEmbedParamBodyParams(params []interface{}) []map[string]interface{} {
+	if len(params) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(params))
+	for _, v := range params {
+		rst = append(rst, map[string]interface{}{
+			"new_column_name": utils.PathSearch("new_column_name", v, nil),
+			"new_column_type": utils.PathSearch("new_column_type", v, nil),
+			"fake_strategy":   utils.PathSearch("fake_strategy", v, nil),
+			"fake_param": buildDatabaseWatermarkEmbedTaskFakeParamBodyParams(utils.PathSearch("fake_param", v,
+				make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func buildDatabaseWatermarkEmbedTaskFakeParamBodyParams(fakeParams []interface{}) map[string]interface{} {
+	if len(fakeParams) == 0 || fakeParams[0] == nil {
+		return nil
+	}
+
+	fakeParam := fakeParams[0]
+	return map[string]interface{}{
+		"address_accuracy": utils.ValueIgnoreEmpty(utils.PathSearch("address_accuracy", fakeParam, nil)),
+		"date_begin": utils.ValueIgnoreEmpty(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("date_begin",
+			fakeParam, "").(string))),
+		"date_end": utils.ValueIgnoreEmpty(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("date_end",
+			fakeParam, "").(string))),
+		"random_accuracy":   utils.ValueIgnoreEmpty(utils.PathSearch("random_accuracy", fakeParam, nil)),
+		"random_begin":      utils.ValueIgnoreEmpty(utils.PathSearch("random_begin", fakeParam, nil)),
+		"random_distribute": utils.ValueIgnoreEmpty(utils.PathSearch("random_distribute", fakeParam, nil)),
+		"random_end":        utils.ValueIgnoreEmpty(utils.PathSearch("random_end", fakeParam, nil)),
+		"string_distribute": utils.ValueIgnoreEmpty(utils.PathSearch("string_distribute", fakeParam, nil)),
+	}
+}
+
+func buildDatabaseWatermarkEmbedTaskDbInfoBodyParams(dbInfos []interface{}) map[string]interface{} {
+	if len(dbInfos) == 0 {
+		return nil
+	}
+
+	dbInfo := dbInfos[0]
+	return map[string]interface{}{
+		"db_id":       utils.PathSearch("db_id", dbInfo, nil),
+		"db_name":     utils.PathSearch("db_name", dbInfo, nil),
+		"db_type":     utils.PathSearch("db_type", dbInfo, nil),
+		"ins_id":      utils.PathSearch("ins_id", dbInfo, nil),
+		"ins_name":    utils.PathSearch("ins_name", dbInfo, nil),
+		"table_name":  utils.PathSearch("table_name", dbInfo, nil),
+		"schema_name": utils.ValueIgnoreEmpty(utils.PathSearch("schema_name", dbInfo, nil)),
+	}
+}
+
+func buildDatabaseWatermarkEmbedTaskColumnInfoBodyParams(selectedFields []interface{}) []map[string]interface{} {
+	if len(selectedFields) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(selectedFields))
+	for _, v := range selectedFields {
+		rst = append(rst, map[string]interface{}{
+			"column_name": utils.ValueIgnoreEmpty(utils.PathSearch("column_name", v, nil)),
+			"column_type": utils.ValueIgnoreEmpty(utils.PathSearch("column_type", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func createDatabaseWatermarkEmbedTask(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/data-watermark-embed-tasks"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDatabaseWatermarkEmbedTaskBodyParams(d),
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func resourceDatabaseWatermarkEmbedTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = createDatabaseWatermarkEmbedTask(client, d)
+	if err != nil {
+		return diag.Errorf("error creating database watermark embed task: %s", err)
+	}
+
+	tasks, err := listDatabaseWatermarkEmbedTasks(client)
+	if err != nil {
+		return diag.Errorf("error retrieving database watermark embed tasks: %s", err)
+	}
+
+	taskId, ok := utils.PathSearch(fmt.Sprintf("[?task_name=='%s']|[0].id", d.Get("task_name").(string)), tasks, float64(0)).(float64)
+	if !ok || taskId == 0 {
+		return diag.Errorf("unable to find the database watermark embed task ID from API response")
+	}
+
+	taskIdStr := strconv.Itoa(int(taskId))
+	d.SetId(taskIdStr)
+
+	if isImmediateStart, ok := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "start_now").(bool); ok && isImmediateStart {
+		if _, err := waitForDatabaseWatermarkEmbedTaskCompleted(ctx, client, d.Timeout(schema.TimeoutCreate), taskIdStr); err != nil {
+			return diag.Errorf("error waiting for database watermark embed task to be completed: %s", err)
+		}
+	}
+
+	return resourceDatabaseWatermarkEmbedTaskRead(ctx, d, meta)
+}
+
+func waitForDatabaseWatermarkEmbedTaskCompleted(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration,
+	taskId string) (interface{}, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshDatabaseWatermarkEmbedTaskStatusFunc(client, taskId, []string{"FINISHED", "CLOSED"}),
+		Timeout:      timeout,
+		Delay:        15 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+
+	serverResp, err := stateConf.WaitForStateContext(ctx)
+	return serverResp, err
+}
+
+func refreshDatabaseWatermarkEmbedTaskStatusFunc(client *golangsdk.ServiceClient, taskId string, targets []string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		tasks, err := listDatabaseWatermarkEmbedTasks(client, fmt.Sprintf("&id=%v", taskId))
+		if err != nil {
+			return tasks, "ERROR", err
+		}
+
+		// The status enumeration values are as follows: `WAIT`, `READY`, `RUNNING`, `ERROR`, `FINISHED` and `CLOSED`.
+		// RUNNING: The task is executing.
+		// READY: The task is ready to execute.
+		status := utils.PathSearch("[0].task_state", tasks, "").(string)
+		if status == "ERROR" {
+			return nil, "FAILED", fmt.Errorf("unexpected status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return tasks, "COMPLETED", nil
+		}
+
+		return tasks, "PENDING", nil
+	}
+}
+
+func listDatabaseWatermarkEmbedTasks(client *golangsdk.ServiceClient, queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/data-watermark-embed-tasks"
+		limit   = 100
+		// `offset` means the page number, start from 1.
+		offset  = 1
+		results = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	if len(queryParams) > 0 && queryParams[0] != "" {
+		listPath += queryParams[0]
+	}
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		tasks := utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{})
+		results = append(results, tasks...)
+		if len(tasks) < limit {
+			break
+		}
+
+		offset++
+	}
+
+	return results, nil
+}
+
+// GetDatabaseWatermarkEmbedTaskById is a method used to query the database watermark embed task by ID.
+func GetDatabaseWatermarkEmbedTaskById(client *golangsdk.ServiceClient, taskId string) (interface{}, error) {
+	tasks, err := listDatabaseWatermarkEmbedTasks(client, fmt.Sprintf("&id=%v", taskId))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(tasks) == 0 {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/data-watermark-embed-tasks",
+				RequestId: "NONE",
+				Body:      fmt.Appendf(nil, "the database watermark embed task (%s) does not exist", taskId),
+			},
+		}
+	}
+
+	return tasks[0], nil
+}
+
+func resourceDatabaseWatermarkEmbedTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		taskId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	task, err := GetDatabaseWatermarkEmbedTaskById(client, taskId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", databaseWatermarkEmbedTaskNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving database watermark embed task (%s)", taskId),
+		)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Required parameters.
+		d.Set("task_name", utils.PathSearch("task_name", task, nil)),
+		d.Set("water_mark", utils.PathSearch("water_mark", task, nil)),
+		d.Set("watermark_version", utils.PathSearch("watermark_version", task, nil)),
+		d.Set("db_water_param", flattenDatabaseWatermarkEmbedTaskDbWaterParam(utils.PathSearch("db_water_param", task, nil))),
+		d.Set("source_db_info", flattenDatabaseWatermarkEmbedTaskDbInfo(utils.PathSearch("source_db_info", task, nil))),
+		d.Set("target_db_info", flattenDatabaseWatermarkEmbedTaskDbInfo(utils.PathSearch("target_db_info", task, nil))),
+		d.Set("error_code", utils.PathSearch("error_code", task, nil)),
+		// Optional parameters.
+		d.Set("start_now", utils.PathSearch("start_now", task, nil)),
+		d.Set("watermark_describe", utils.PathSearch("watermark_describe", task, nil)),
+		d.Set("schedule_switch", utils.PathSearch("schedule_switch", task, nil)),
+		d.Set("schedule_type", utils.PathSearch("schedule_type", task, nil)),
+		d.Set("start_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("start_time", task, float64(0)).(float64))/1000, false)),
+		d.Set("selected_fields", flattenDatabaseWatermarkEmbedTaskColumnInfos(utils.PathSearch("selected_fields", task,
+			make([]interface{}, 0)).([]interface{}))),
+		// Attributes.
+		d.Set("task_state", utils.PathSearch("task_state", task, nil)),
+		d.Set("task_create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("task_create_time",
+			task, float64(0)).(float64))/1000, false)),
+		d.Set("task_end_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("task_end_time",
+			task, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDatabaseWatermarkEmbedTaskDbWaterParam(dbWaterParam interface{}) []map[string]interface{} {
+	if dbWaterParam == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"embed_mode":    utils.PathSearch("embed_mode", dbWaterParam, nil),
+			"watermark_key": utils.PathSearch("watermark_key", dbWaterParam, nil),
+			"params": flattenDatabaseWatermarkEmbedTaskEmbedParams(utils.PathSearch("params", dbWaterParam,
+				make([]interface{}, 0)).([]interface{})),
+			"row_spacing": utils.PathSearch("row_spacing", dbWaterParam, nil),
+		},
+	}
+}
+
+func flattenDatabaseWatermarkEmbedTaskEmbedParams(params []interface{}) []map[string]interface{} {
+	if len(params) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(params))
+	for _, v := range params {
+		rst = append(rst, map[string]interface{}{
+			"new_column_name": utils.PathSearch("new_column_name", v, nil),
+			"new_column_type": utils.PathSearch("new_column_type", v, nil),
+			"fake_strategy":   utils.PathSearch("fake_strategy", v, nil),
+			"fake_param":      flattenDatabaseWatermarkEmbedTaskFakeParam(utils.PathSearch("fake_param", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenDatabaseWatermarkEmbedTaskFakeParam(fakeParam interface{}) []map[string]interface{} {
+	if fakeParam == nil {
+		return nil
+	}
+
+	beginTime, err := strconv.ParseInt(utils.PathSearch("date_begin", fakeParam, "").(string), 10, 64)
+	if err != nil {
+		log.Printf("[ERROR] error parsing 'date_begin' field to Integer: %s", err)
+	}
+
+	endTime, err := strconv.ParseInt(utils.PathSearch("date_end", fakeParam, "").(string), 10, 64)
+	if err != nil {
+		log.Printf("[ERROR] error parsing 'date_end' field to Integer: %s", err)
+	}
+
+	return []map[string]interface{}{
+		{
+			"address_accuracy":  utils.PathSearch("address_accuracy", fakeParam, nil),
+			"date_begin":        utils.FormatTimeStampRFC3339(beginTime/1000, false),
+			"date_end":          utils.FormatTimeStampRFC3339(endTime/1000, false),
+			"random_accuracy":   utils.PathSearch("random_accuracy", fakeParam, nil),
+			"random_begin":      utils.PathSearch("random_begin", fakeParam, nil),
+			"random_distribute": utils.PathSearch("random_distribute", fakeParam, nil),
+			"random_end":        utils.PathSearch("random_end", fakeParam, nil),
+			"string_distribute": utils.PathSearch("string_distribute", fakeParam, nil),
+		},
+	}
+}
+
+func flattenDatabaseWatermarkEmbedTaskDbInfo(dbInfo interface{}) []map[string]interface{} {
+	if dbInfo == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"db_id":       utils.PathSearch("db_id", dbInfo, nil),
+			"db_name":     utils.PathSearch("db_name", dbInfo, nil),
+			"db_type":     utils.PathSearch("db_type", dbInfo, nil),
+			"ins_id":      utils.PathSearch("ins_id", dbInfo, nil),
+			"ins_name":    utils.PathSearch("ins_name", dbInfo, nil),
+			"table_name":  utils.PathSearch("table_name", dbInfo, nil),
+			"schema_name": utils.PathSearch("schema_name", dbInfo, nil),
+		},
+	}
+}
+
+func flattenDatabaseWatermarkEmbedTaskColumnInfos(fields []interface{}) []map[string]interface{} {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(fields))
+	for _, v := range fields {
+		rst = append(rst, map[string]interface{}{
+			"column_name": utils.PathSearch("column_name", v, nil),
+			"column_type": utils.PathSearch("column_type", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func updateDatabaseWatermarkEmbedTask(ctx context.Context, client *golangsdk.ServiceClient, taskId string, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/data-watermark-embed-tasks/{id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{id}", taskId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildDatabaseWatermarkEmbedTaskBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		_, err := client.Request("PUT", updatePath, &updateOpt)
+		isRetry, err := handleOperationDatabaseWatermarkEmbedTaskError(err)
+		return nil, isRetry, err
+	}
+	_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		DelayTimeout: 15 * time.Second,
+		PollInterval: 15 * time.Second,
+	})
+
+	return err
+}
+
+func resourceDatabaseWatermarkEmbedTaskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		taskId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	if d.HasChangesExcept("enable_force_new") {
+		err = updateDatabaseWatermarkEmbedTask(ctx, client, taskId, d)
+		if err != nil {
+			return diag.Errorf("error updating database watermark embed task (%v): %s", taskId, err)
+		}
+
+		if isImmediateStart, ok := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "start_now").(bool); ok && isImmediateStart {
+			if _, err := waitForDatabaseWatermarkEmbedTaskCompleted(ctx, client, d.Timeout(schema.TimeoutUpdate), taskId); err != nil {
+				return diag.Errorf("error waiting for database watermark embed task to be completed: %s", err)
+			}
+		}
+	}
+
+	return resourceDatabaseWatermarkEmbedTaskRead(ctx, d, meta)
+}
+
+func handleOperationDatabaseWatermarkEmbedTaskError(err error) (bool, error) {
+	if err == nil {
+		// The operation was executed successfully and does not need to be executed again.
+		return false, nil
+	}
+
+	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return false, jsonErr
+		}
+
+		// dsc.40000028: The task is running and cannot be dispatched.
+		if utils.PathSearch("error_code", apiError, "").(string) == "dsc.40000028" {
+			return true, err
+		}
+	}
+
+	return false, err
+}
+
+func deleteDatabaseWatermarkEmbedTask(ctx context.Context, client *golangsdk.ServiceClient, taskId string, timeout time.Duration) error {
+	httpUrl := "v1/{project_id}/data-watermark-embed-tasks/{id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", taskId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("DELETE", deletePath, &deleteOpt)
+		isRetry, err := handleOperationDatabaseWatermarkEmbedTaskError(err)
+		return res, isRetry, err
+	}
+	_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		Timeout:      timeout,
+		DelayTimeout: 15 * time.Second,
+		PollInterval: 15 * time.Second,
+	})
+
+	return err
+}
+
+func resourceDatabaseWatermarkEmbedTaskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		taskId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("dsc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	err = deleteDatabaseWatermarkEmbedTask(ctx, client, taskId, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", databaseWatermarkEmbedTaskNotFoundErrCodes...),
+			fmt.Sprintf("error deleting database watermark embed task (%v)", taskId),
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage database watermark embed task.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDatabaseWatermarkEmbedTask_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDatabaseWatermarkEmbedTask_basic -timeout 360m -parallel 10
=== RUN   TestAccDatabaseWatermarkEmbedTask_basic
=== PAUSE TestAccDatabaseWatermarkEmbedTask_basic
=== CONT  TestAccDatabaseWatermarkEmbedTask_basic
--- PASS: TestAccDatabaseWatermarkEmbedTask_basic (86.63s)
PASS
coverage: 9.3% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       88.570s coverage: 9.3% of statements in ./huaweicloud/services/dsc
```
<img width="1353" height="70" alt="image" src="https://github.com/user-attachments/assets/076ceeff-a03c-4a2d-ac86-7814876d2338" />

<img width="1530" height="834" alt="image" src="https://github.com/user-attachments/assets/d6577e8b-659e-42ad-a4dc-a25d76580cf9" />
<img width="1564" height="927" alt="image" src="https://github.com/user-attachments/assets/5c2debd5-45ad-4b64-9684-017fba09ecd5" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1603" height="741" alt="image" src="https://github.com/user-attachments/assets/8789015d-158a-4a57-9022-03a85057cb9a" />
 
    ab. Related resources (parent resources) not found
    The DSC instance does not exist.
    <img width="1632" height="724" alt="image" src="https://github.com/user-attachments/assets/7c14e6cc-853e-4c89-bc66-2624ae437247" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    The delete interface always returns a status code of 200 when the resource does not exist.
    <img width="1562" height="801" alt="image" src="https://github.com/user-attachments/assets/0e987d38-b238-4271-bcd7-5d2675b2b940" />

    bb. Related resources (parent resources) not found
    The DSC instance does not exist.
    <img width="1557" height="770" alt="image" src="https://github.com/user-attachments/assets/c57c7c36-a47a-4c1a-bf15-3e406122dbd5" />
