### PR TITLE
fix(das): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/das/resource_huaweicloud_das_database_instance_connection.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_database_instance_connection.go
@@ -353,9 +353,11 @@ func resourceDatabaseInstanceConnectionUpdate(ctx context.Context, d *schema.Res
 		return diag.Errorf("error creating DAS Client: %s", err)
 	}
 
-	err = updateDatabaseInstanceConnection(client, d)
-	if err != nil {
-		return diag.FromErr(err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateDatabaseInstanceConnection(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceDatabaseInstanceConnectionRead(ctx, d, meta)

--- a/huaweicloud/services/das/resource_huaweicloud_das_database_user.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_database_user.go
@@ -230,9 +230,11 @@ func resourceDatabaseUserUpdate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error creating DAS Client: %s", err)
 	}
 
-	err = updateDatabaseUser(client, d)
-	if err != nil {
-		return diag.FromErr(err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateDatabaseUser(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceDatabaseUserRead(ctx, d, meta)

--- a/huaweicloud/services/das/resource_huaweicloud_das_email_template.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_email_template.go
@@ -342,24 +342,26 @@ func resourceEmailTemplateUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("error creating DAS client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updateBodyParams, err := buildEmailTemplateUpdateBodyParams(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updateBodyParams, err := buildEmailTemplateUpdateBodyParams(d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-		JSONBody: utils.RemoveNil(updateBodyParams),
-	}
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(updateBodyParams),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating DAS email template (%s): %s", d.Id(), err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating DAS email template (%s): %s", d.Id(), err)
+		}
 	}
 
 	return resourceEmailTemplateRead(ctx, d, meta)

--- a/huaweicloud/services/das/resource_huaweicloud_das_instance_group.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_instance_group.go
@@ -204,21 +204,23 @@ func resourceInstanceGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("error creating DAS client: %s", err)
 	}
 
-	httpUrl := "v3/{project_id}/batch-inspection/instance-group"
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	if d.HasChangeExcept("enable_force_new") {
+		httpUrl := "v3/{project_id}/batch-inspection/instance-group"
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-		JSONBody: utils.RemoveNil(buildInstanceGroupUpdateBodyParams(d)),
-	}
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildInstanceGroupUpdateBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating DAS instance group: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating DAS instance group: %s", err)
+		}
 	}
 
 	return resourceInstanceGroupRead(ctx, d, meta)

--- a/huaweicloud/services/das/resource_huaweicloud_das_search_path_switch.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_search_path_switch.go
@@ -228,14 +228,16 @@ func resourceSearchPathSwitchUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error creating DAS client: %s", err)
 	}
 
-	updatePath, updateOpt := buildSearchPathSwitchRequest(client, d)
-	_, err = client.Request("POST", updatePath, updateOpt)
-	if err != nil {
-		return diag.Errorf("error switching DAS search path switch: %s", err)
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath, updateOpt := buildSearchPathSwitchRequest(client, d)
+		_, err = client.Request("POST", updatePath, updateOpt)
+		if err != nil {
+			return diag.Errorf("error switching DAS search path switch: %s", err)
+		}
 
-	if err = waitForSearchPathSwitchComplete(ctx, client, d); err != nil {
-		return diag.Errorf("error waiting for the DAS search path switch to complete: %s", err)
+		if err = waitForSearchPathSwitchComplete(ctx, client, d); err != nil {
+			return diag.Errorf("error waiting for the DAS search path switch to complete: %s", err)
+		}
 	}
 
 	return resourceSearchPathSwitchRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Skip update API calls when only enable_force_new changes for these resources:
+ huaweicloud_das_database_instance_connection
+ huaweicloud_das_database_user
+ huaweicloud_das_email_template
+ huaweicloud_das_instance_group
+ huaweicloud_das_search_path_switch

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Skip update logic when only 'enable_force_new' changes.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

1. huaweicloud_das_database_instance_connection
```
./scripts/coverage.sh -o das -f TestAccDatabaseInstanceConnection_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/das" -v -coverprofile="./huaweicloud/services/acceptance/das/das_coverage.cov" -coverpkg="./huaweicloud/services/das" -run TestAccDatabaseInstanceConnection_basic -timeout 360m -parallel 10
=== RUN   TestAccDatabaseInstanceConnection_basic
=== PAUSE TestAccDatabaseInstanceConnection_basic
=== CONT  TestAccDatabaseInstanceConnection_basic
--- PASS: TestAccDatabaseInstanceConnection_basic (31.58s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/das
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/das       34.396s coverage: 5.4% of statements in ./huaweicloud/services/das
```
<img width="1622" height="942" alt="image" src="https://github.com/user-attachments/assets/660933b3-6c50-47f8-a38f-537542b29422" />
<img width="1546" height="910" alt="image" src="https://github.com/user-attachments/assets/49726b13-d900-457f-a1e1-6b83fac261d5" />

2. huaweicloud_das_database_user
```
./scripts/coverage.sh -o das -f TestAccDatabaseUser_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/das" -v -coverprofile="./huaweicloud/services/acceptance/das/das_coverage.cov" -coverpkg="./huaweicloud/services/das" -run TestAccDatabaseUser_basic -timeout 360m -parallel 10
=== RUN   TestAccDatabaseUser_basic
=== PAUSE TestAccDatabaseUser_basic
=== CONT  TestAccDatabaseUser_basic
--- PASS: TestAccDatabaseUser_basic (36.25s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/das
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/das       39.254s coverage: 5.9% of statements in ./huaweicloud/services/das
```
<img width="1840" height="916" alt="image" src="https://github.com/user-attachments/assets/d362072f-8455-409f-878f-29ef38b344e8" />
<img width="1863" height="928" alt="image" src="https://github.com/user-attachments/assets/bfbd469c-a007-436e-aac6-aba045bab1a6" />

3. huaweicloud_das_email_template
```
./scripts/coverage.sh -o das -f TestAccEmailTemplate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/das" -v -coverprofile="./huaweicloud/services/acceptance/das/das_coverage.cov" -coverpkg="./huaweicloud/services/das" -run TestAccEmailTemplate_basic -timeout 360m -parallel 10
=== RUN   TestAccEmailTemplate_basic
=== PAUSE TestAccEmailTemplate_basic
=== CONT  TestAccEmailTemplate_basic
--- PASS: TestAccEmailTemplate_basic (25.02s)
PASS
coverage: 9.1% of statements in ./huaweicloud/services/das
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/das       27.778s coverage: 9.1% of statements in ./huaweicloud/services/das
```
<img width="1555" height="920" alt="image" src="https://github.com/user-attachments/assets/22b12189-3ca3-4339-a9ca-15f0990d1bc9" />
<img width="1558" height="924" alt="image" src="https://github.com/user-attachments/assets/37c372ec-0314-47f7-ad6d-ec2c0eed20c0" />

4. huaweicloud_das_instance_group
```
./scripts/coverage.sh -o das -f TestAccInstanceGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/das" -v -coverprofile="./huaweicloud/services/acceptance/das/das_coverage.cov" -coverpkg="./huaweicloud/services/das" -run TestAccInstanceGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceGroup_basic
=== PAUSE TestAccInstanceGroup_basic
=== CONT  TestAccInstanceGroup_basic
--- PASS: TestAccInstanceGroup_basic (23.09s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/das
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/das       25.914s coverage: 6.2% of statements in ./huaweicloud/services/das
```
<img width="1578" height="900" alt="image" src="https://github.com/user-attachments/assets/d149dd50-926c-4d55-849a-9751553f7b70" />
<img width="1576" height="929" alt="image" src="https://github.com/user-attachments/assets/6bea1a48-e4ca-4c8d-b146-41e3c951c9de" />

5. huaweicloud_das_search_path_switch
```
./scripts/coverage.sh -o das -f TestAccSearchPathSwitch_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/das" -v -coverprofile="./huaweicloud/services/acceptance/das/das_coverage.cov" -coverpkg="./huaweicloud/services/das" -run TestAccSearchPathSwitch_basic -timeout 360m -parallel 10
=== RUN   TestAccSearchPathSwitch_basic
=== PAUSE TestAccSearchPathSwitch_basic
=== CONT  TestAccSearchPathSwitch_basic
--- PASS: TestAccSearchPathSwitch_basic (657.19s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/das
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/das       659.883s        coverage: 7.8% of statements in ./huaweicloud/services/das
```
<img width="1627" height="938" alt="image" src="https://github.com/user-attachments/assets/9bf83171-50e5-4d67-98a7-4496a6dd4a8d" />
<img width="1533" height="860" alt="image" src="https://github.com/user-attachments/assets/1049db31-8c17-4f6c-99ba-47a34b0e572b" />
