### PR TITLE
feat(dsc): add a new data source to query database watermark embed tasks

### DIFF
--- a/docs/data-sources/dsc_database_watermark_embed_tasks.md
+++ b/docs/data-sources/dsc_database_watermark_embed_tasks.md
@@ -1,0 +1,167 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_database_watermark_embed_tasks"
+description: |-
+  Use this data source to get the list of DSC database watermark embed tasks within HuaweiCloud.
+---
+
+# huaweicloud_dsc_database_watermark_embed_tasks
+
+Use this data source to get the list of DSC database watermark embed tasks within HuaweiCloud.
+
+## Example Usage
+
+### Query all database watermark embed tasks
+
+```hcl
+data "huaweicloud_dsc_database_watermark_embed_tasks" "test" {}
+```
+
+### Query database watermark embed tasks by task ID
+
+```hcl
+variable "task_id" {}
+
+data "huaweicloud_dsc_database_watermark_embed_tasks" "test" {
+  task_id = var.task_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the database watermark embed tasks are located.  
+  If omitted, the provider-level region will be used.
+
+* `task_id` - (Optional, String) Specifies the ID of the database watermark embed task.
+
+* `start` - (Optional, String) Specifies the start time of the task running time interval, in RFC3339 format.  
+
+* `end` - (Optional, String) Specifies the end time of the task running time interval, in RFC3339 format.  
+
+* `status` - (Optional, String) Specifies the status of the database watermark embed task.  
+  The valid values are as follows:
+  + **RUNNING**: The task is executing.
+  + **ERROR**: The task execution has failed.
+  + **FINISHED**: The task has completed.
+  + **WAIT**: The task is waiting to be executed.
+  + **CLOSED**: The task is closed.
+  
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - The list of the database watermark embed tasks.  
+  The [tasks](#database_watermark_embed_tasks_tasks) structure is documented below.
+
+<a name="database_watermark_embed_tasks_tasks"></a>
+The `tasks` block supports:
+
+* `id` - The ID of the database watermark embed task.
+
+* `task_name` - The name of the database watermark embed task.
+
+* `water_mark` - The watermark content.
+
+* `db_water_param` - The database watermark embedding configuration.  
+  The [db_water_param](#database_watermark_embed_tasks_db_water_param) structure is documented below.
+
+* `selected_fields` - The selected field list used for watermark embedding.  
+  The [selected_fields](#database_watermark_embed_tasks_selected_fields) structure is documented below.
+
+* `source_db_info` - The source database information.  
+  The [source_db_info](#database_watermark_embed_tasks_db_info) structure is documented below.
+
+* `target_db_info` - The target database information.  
+  The [target_db_info](#database_watermark_embed_tasks_db_info) structure is documented below.
+
+* `watermark_describe` - The watermark description.
+
+* `watermark_version` - The watermark algorithm version.
+
+* `start_now` - Whether the task starts immediately.
+
+* `start_time` - The scheduled start time of the task, in RFC3339 format.
+
+* `schedule_switch` - Whether task scheduling is enabled.
+
+* `schedule_type` - The schedule type of the task.
+
+* `task_state` - The running state of the watermark embed task.
+
+* `task_create_time` - The creation time of the task, in RFC3339 format.
+
+* `task_end_time` - The end time of the task, in RFC3339 format.
+
+* `water_extract_result` - The watermark extract result.
+
+<a name="database_watermark_embed_tasks_db_water_param"></a>
+The `db_water_param` block supports:
+
+* `embed_mode` - The watermark embed mode.
+
+* `row_spacing` - The row spacing used by fake-row watermark.
+
+* `watermark_key` - The watermark key used to embed and extract the watermark.
+
+* `params` - The fake-column embed parameter list.  
+  The [params](#database_watermark_embed_tasks_params) structure is documented below.
+
+<a name="database_watermark_embed_tasks_params"></a>
+The `params` block supports:
+
+* `new_column_name` - The name of the new fake column.
+
+* `new_column_type` - The data type of the new fake column.
+
+* `fake_strategy` - The strategy used to generate fake data.
+
+* `fake_param` - The configuration of fake data generation.  
+  The [fake_param](#database_watermark_embed_tasks_fake_param) structure is documented below.
+
+<a name="database_watermark_embed_tasks_fake_param"></a>
+The `fake_param` block supports:
+
+* `address_accuracy` - The accuracy of generated address data.
+
+* `date_begin` - The start date of the generated date range, in RFC3339 format.
+
+* `date_end` - The end date of the generated date range, in RFC3339 format.
+
+* `random_accuracy` - The precision of generated random numbers.
+
+* `random_begin` - The lower bound of the generated random value range.
+
+* `random_distribute` - The distribution mode of generated random values.
+
+* `random_end` - The upper bound of the generated random value range.
+
+* `string_distribute` - The distribution mode of generated string values.
+
+<a name="database_watermark_embed_tasks_selected_fields"></a>
+The `selected_fields` block supports:
+
+* `column_name` - The name of the selected column.
+
+* `column_type` - The data type of the selected column.
+
+<a name="database_watermark_embed_tasks_db_info"></a>
+The `source_db_info` and `target_db_info` blocks support:
+
+* `db_id` - The ID of the authorized database.
+
+* `db_name` - The name of the database.
+
+* `db_type` - The database type.
+
+* `ins_id` - The ID of the database instance.
+
+* `ins_name` - The name of the database instance.
+
+* `schema_name` - The schema name of the database.
+
+* `table_name` - The name of the database table.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1437,6 +1437,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_data_map_score":                   dsc.DataSourceDscDataMapScore(),
 			"huaweicloud_dsc_data_map_security_level":          dsc.DataSourceDscDataMapSecurityLevel(),
 			"huaweicloud_dsc_data_map_risk_level_info":         dsc.DataSourceDataMapRiskLevelInfo(),
+			"huaweicloud_dsc_database_watermark_embed_tasks":   dsc.DataSourceDatabaseWatermarkEmbedTasks(),
 			"huaweicloud_dsc_db_mask_tasks":                    dsc.DataSourceDscDbMaskTasks(),
 			"huaweicloud_dsc_dbss_ins_info":                    dsc.DataSourceDscDbssInsInfo(),
 			"huaweicloud_dsc_devices":                          dsc.DataSourceDscDevices(),

--- a/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_database_watermark_embed_tasks_test.go
+++ b/huaweicloud/services/acceptance/dsc/data_source_huaweicloud_dsc_database_watermark_embed_tasks_test.go
@@ -1,0 +1,277 @@
+package dsc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this acceptance test, please ensure that the DSC instance has been created
+// and at least one database watermark embed task exists.
+func TestAccDataSourceDatabaseWatermarkEmbedTasks_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dsc_database_watermark_embed_tasks.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byTaskId   = "data.huaweicloud_dsc_database_watermark_embed_tasks.filter_by_task_id"
+		dcByTaskId = acceptance.InitDataSourceCheck(byTaskId)
+
+		byStatus   = "data.huaweicloud_dsc_database_watermark_embed_tasks.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byStartAndEnd   = "data.huaweicloud_dsc_database_watermark_embed_tasks.filter_by_start_and_end"
+		dcByStartAndEnd = acceptance.InitDataSourceCheck(byStartAndEnd)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscDbInstanceId(t)
+			acceptance.TestAccPreCheckDscDbTableName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDatabaseWatermarkEmbedTasks_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "tasks.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'task_id' parameter.
+					dcByTaskId.CheckResourceExists(),
+					resource.TestCheckOutput("is_task_id_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byTaskId, "tasks.#", "1"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.id", "huaweicloud_dsc_database_watermark_embed_task.test", "id"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.task_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "task_name"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.water_mark",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "water_mark"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.watermark_version",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "watermark_version"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.watermark_describe",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "watermark_describe"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.start_now",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "start_now"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.schedule_type",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "schedule_type"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.schedule_switch",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "schedule_switch"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.task_state",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "task_state"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.start_time",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "start_time"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.embed_mode",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.embed_mode"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.#",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.#"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.0.new_column_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.0.new_column_name"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.0.new_column_type",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.0.new_column_type"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.0.fake_strategy",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.0.fake_strategy"),
+					resource.TestCheckResourceAttrSet(byTaskId, "tasks.0.db_water_param.0.params.0.fake_param.0.date_begin"),
+					resource.TestCheckResourceAttrSet(byTaskId, "tasks.0.db_water_param.0.params.0.fake_param.0.date_end"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.1.new_column_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.1.new_column_name"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.1.new_column_type",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.1.new_column_type"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.1.fake_strategy",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.1.fake_strategy"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.1.fake_param.0.random_begin",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.1.fake_param.0.random_begin"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.1.fake_param.0.random_end",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.1.fake_param.0.random_end"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.db_water_param.0.params.1.fake_param.0.random_accuracy",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "db_water_param.0.params.1.fake_param.0.random_accuracy"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.source_db_info.0.db_id",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "source_db_info.0.db_id"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.source_db_info.0.db_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "source_db_info.0.db_name"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.source_db_info.0.db_type",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "source_db_info.0.db_type"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.source_db_info.0.ins_id",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "source_db_info.0.ins_id"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.source_db_info.0.ins_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "source_db_info.0.ins_name"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.source_db_info.0.table_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "source_db_info.0.table_name"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.target_db_info.0.db_id",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "target_db_info.0.db_id"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.target_db_info.0.db_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "target_db_info.0.db_name"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.target_db_info.0.db_type",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "target_db_info.0.db_type"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.target_db_info.0.ins_id",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "target_db_info.0.ins_id"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.target_db_info.0.ins_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "target_db_info.0.ins_name"),
+					resource.TestCheckResourceAttrPair(byTaskId, "tasks.0.target_db_info.0.table_name",
+						"huaweicloud_dsc_database_watermark_embed_task.test", "target_db_info.0.table_name"),
+					resource.TestMatchResourceAttr(byTaskId, "tasks.0.task_create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byTaskId, "tasks.0.task_end_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Filter by 'status' parameter.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					// Filter by 'start' and 'end' parameters.
+					dcByStartAndEnd.CheckResourceExists(),
+					resource.TestCheckOutput("is_start_and_end_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDatabaseWatermarkEmbedTasks_base(name string) string {
+	currentTime := time.Now()
+	beginTime := currentTime.Format("2006-01-02T15:04:05+08:00")
+	endTime := currentTime.Add(1 * time.Hour).Format("2006-01-02T15:04:05+08:00")
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_authorize_databases" "test" {
+  instance_type = "RDS"
+}
+
+locals {
+  instance_id   = "%[1]s"
+  instance      = try([for v in data.huaweicloud_dsc_authorize_databases.test.databases : v if v.ins_id == local.instance_id][0], {})
+  instance_name = try(local.instance.ins_name, "NOT_FOUND")
+  database_id   = try(local.instance.id, "NOT_FOUND")
+  database_name = try(local.instance.db_name, "NOT_FOUND")
+}
+
+resource "huaweicloud_dsc_database_watermark_embed_task" "test" {
+  task_name          = "%[2]s"
+  water_mark         = "TF"
+  watermark_version  = "V2"
+  watermark_describe = "Created by Terraform"
+
+  db_water_param {
+    embed_mode = "EMBED_FAKE_COLUMN"
+
+    params {
+      new_column_name = "field1"
+      new_column_type = "date"
+      fake_strategy   = "date"
+
+      fake_param {
+        date_begin = "%[3]s"
+        date_end   = "%[4]s"
+      }
+    }
+    params {
+      new_column_name = "field2"
+      new_column_type = "number"
+      fake_strategy   = "number_random"
+
+      fake_param {
+        random_begin    = "2"
+        random_end      = "3"
+        random_accuracy = 1
+      }
+    }
+  }
+
+  source_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[5]s"
+  }
+
+  target_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[2]s"
+  }
+
+  error_code    = 1
+  start_now     = true
+  schedule_type = "ONCE"
+}
+`, acceptance.HW_DSC_DB_INSTANCE_ID, name, beginTime, endTime, acceptance.HW_DSC_DB_TABLE_NAME)
+}
+
+func testAccDataSourceDatabaseWatermarkEmbedTasks_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_dsc_database_watermark_embed_tasks" "test" {
+  depends_on = [huaweicloud_dsc_database_watermark_embed_task.test]
+}
+
+# Filter by 'task_id' parameter.
+locals {
+  task_id = huaweicloud_dsc_database_watermark_embed_task.test.id
+}
+
+data "huaweicloud_dsc_database_watermark_embed_tasks" "filter_by_task_id" {
+  task_id = local.task_id
+}
+
+locals {
+  task_id_filter_result = [
+    for v in data.huaweicloud_dsc_database_watermark_embed_tasks.filter_by_task_id.tasks[*].id : v == local.task_id
+  ]
+}
+
+output "is_task_id_filter_useful" {
+  value = length(local.task_id_filter_result) == 1 && alltrue(local.task_id_filter_result)
+}
+
+# Filter by 'status' parameter.
+locals {
+  task_state = huaweicloud_dsc_database_watermark_embed_task.test.task_state
+}
+
+data "huaweicloud_dsc_database_watermark_embed_tasks" "filter_by_status" {
+  status = local.task_state
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_dsc_database_watermark_embed_tasks.filter_by_status.tasks[*].task_state : v == local.task_state
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by 'start' and 'end' parameters.
+locals {
+  start_time = huaweicloud_dsc_database_watermark_embed_task.test.start_time
+  end_time   = timeadd(local.start_time, "1h")
+}
+
+data "huaweicloud_dsc_database_watermark_embed_tasks" "filter_by_start_and_end" {
+  start = local.start_time
+  end   = local.end_time
+}
+
+locals {
+  start_and_end_filter_result = [
+    for v in data.huaweicloud_dsc_database_watermark_embed_tasks.filter_by_start_and_end.tasks[*].start_time :
+    timecmp(v, local.start_time) >= 0 && timecmp(v, local.end_time) <= 0
+  ]
+}
+
+output "is_start_and_end_filter_useful" {
+  value = length(local.start_and_end_filter_result) > 0 && alltrue(local.start_and_end_filter_result)
+}
+`, testAccDataSourceDatabaseWatermarkEmbedTasks_base(name))
+}

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_database_watermark_embed_tasks.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_database_watermark_embed_tasks.go
@@ -1,0 +1,507 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC GET /v1/{project_id}/data-watermark-embed-tasks
+func DataSourceDatabaseWatermarkEmbedTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDatabaseWatermarkEmbedTasksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the database watermark embed tasks are located.`,
+			},
+
+			// Optional parameters.
+			"task_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the database watermark embed task.`,
+			},
+			"start": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"end"},
+				Description:  `The start time of the task running time interval, in RFC3339 format.`,
+			},
+			"end": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"start"},
+				Description:  `The end time of the task running time interval, in RFC3339 format.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status of the database watermark embed task.`,
+			},
+
+			// Attributes.
+			"tasks": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        databaseWatermarkEmbedTasksSchema(),
+				Description: `The list of the database watermark embed tasks.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTasksSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the database watermark embed task.`,
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database watermark embed task.`,
+			},
+			"water_mark": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The watermark content.`,
+			},
+			"db_water_param": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        databaseWatermarkEmbedTasksDbWaterParamSchema(),
+				Description: `The database watermark embedding configuration.`,
+			},
+			"selected_fields": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"column_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the selected column.`,
+						},
+						"column_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The data type of the selected column.`,
+						},
+					},
+				},
+				Description: `The selected field list used for watermark embedding.`,
+			},
+			"source_db_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        databaseWatermarkEmbedTasksDbInfoSchema(),
+				Description: `The source database information.`,
+			},
+			"target_db_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        databaseWatermarkEmbedTasksDbInfoSchema(),
+				Description: `The target database information.`,
+			},
+			"watermark_describe": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The watermark description.`,
+			},
+			"watermark_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The watermark algorithm version.`,
+			},
+			"start_now": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the task starts immediately.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The scheduled start time of the task, in RFC3339 format.`,
+			},
+			"schedule_switch": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether task scheduling is enabled.`,
+			},
+			"schedule_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The schedule type of the task.`,
+			},
+			"task_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The running state of the watermark embed task.`,
+			},
+			"task_create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the task, in RFC3339 format.`,
+			},
+			"task_end_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end time of the task, in RFC3339 format.`,
+			},
+			"water_extract_result": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The watermark extract result.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTasksDbWaterParamSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"embed_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The watermark embed mode.`,
+			},
+			"row_spacing": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The row spacing used by fake-row watermark.`,
+			},
+			"watermark_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The watermark key used to embed and extract the watermark.`,
+			},
+			"params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        databaseWatermarkEmbedTasksEmbedParamSchema(),
+				Description: `The fake-column embed parameter list.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTasksEmbedParamSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"new_column_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the new fake column.`,
+			},
+			"new_column_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data type of the new fake column.`,
+			},
+			"fake_strategy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The strategy used to generate fake data.`,
+			},
+			"fake_param": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        databaseWatermarkEmbedTasksFakeParamSchema(),
+				Description: `The configuration of fake data generation.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTasksFakeParamSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"address_accuracy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The accuracy of generated address data.`,
+			},
+			"date_begin": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The start date of the generated date range.`,
+			},
+			"date_end": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end date of the generated date range.`,
+			},
+			"random_accuracy": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The precision of generated random numbers.`,
+			},
+			"random_begin": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The lower bound of the generated random value range.`,
+			},
+			"random_distribute": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The distribution mode of generated random values.`,
+			},
+			"random_end": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The upper bound of the generated random value range.`,
+			},
+			"string_distribute": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The distribution mode of generated string values.`,
+			},
+		},
+	}
+}
+
+func databaseWatermarkEmbedTasksDbInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"db_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the authorized database.`,
+			},
+			"db_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database.`,
+			},
+			"db_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The database type.`,
+			},
+			"ins_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the database instance.`,
+			},
+			"ins_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database instance.`,
+			},
+			"schema_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The schema name of the database.`,
+			},
+			"table_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database table.`,
+			},
+		},
+	}
+}
+
+func buildDatabaseWatermarkEmbedTasksQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("task_id"); ok {
+		queryParams = fmt.Sprintf("%s&id=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("start"); ok {
+		queryParams = fmt.Sprintf("%s&start=%v", queryParams, utils.ConvertTimeStrToNanoTimestamp(v.(string)))
+	}
+
+	if v, ok := d.GetOk("end"); ok {
+		queryParams = fmt.Sprintf("%s&end=%v", queryParams, utils.ConvertTimeStrToNanoTimestamp(v.(string)))
+	}
+
+	if v, ok := d.GetOk("status"); ok {
+		queryParams = fmt.Sprintf("%s&status=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceDatabaseWatermarkEmbedTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	tasks, err := listDatabaseWatermarkEmbedTasks(client, buildDatabaseWatermarkEmbedTasksQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error retrieving database watermark embed tasks: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tasks", flattenDatabaseWatermarkEmbedTasks(tasks)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDatabaseWatermarkEmbedTasks(tasks []interface{}) []map[string]interface{} {
+	if len(tasks) < 1 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(tasks))
+	for _, v := range tasks {
+		rst = append(rst, map[string]interface{}{
+			"id":         strconv.Itoa(int(utils.PathSearch("id", v, float64(0)).(float64))),
+			"task_name":  utils.PathSearch("task_name", v, nil),
+			"water_mark": utils.PathSearch("water_mark", v, nil),
+			"db_water_param": flattenDatabaseWatermarkEmbedTasksDbWaterParam(utils.PathSearch("db_water_param",
+				v, make(map[string]interface{})).(map[string]interface{})),
+			"selected_fields": flattenDatabaseWatermarkEmbedTasksColumnInfos(utils.PathSearch("selected_fields",
+				v, make([]interface{}, 0)).([]interface{})),
+			"source_db_info": flattenDatabaseWatermarkEmbedTasksDbInfo(utils.PathSearch("source_db_info",
+				v, make(map[string]interface{})).(map[string]interface{})),
+			"target_db_info": flattenDatabaseWatermarkEmbedTasksDbInfo(utils.PathSearch("target_db_info",
+				v, make(map[string]interface{})).(map[string]interface{})),
+			"watermark_describe": utils.PathSearch("watermark_describe", v, nil),
+			"watermark_version":  utils.PathSearch("watermark_version", v, nil),
+			"start_now":          utils.PathSearch("start_now", v, nil),
+			"start_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("start_time",
+				v, float64(0)).(float64))/1000, false),
+			"schedule_switch": utils.PathSearch("schedule_switch", v, nil),
+			"schedule_type":   utils.PathSearch("schedule_type", v, nil),
+			"task_state":      utils.PathSearch("task_state", v, nil),
+			"task_create_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("task_create_time",
+				v, float64(0)).(float64))/1000, false),
+			"task_end_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("task_end_time",
+				v, float64(0)).(float64))/1000, false),
+			"water_extract_result": utils.PathSearch("water_extract_result", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenDatabaseWatermarkEmbedTasksDbWaterParam(dbWaterParam map[string]interface{}) []map[string]interface{} {
+	if len(dbWaterParam) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"embed_mode":    utils.PathSearch("embed_mode", dbWaterParam, nil),
+			"row_spacing":   utils.PathSearch("row_spacing", dbWaterParam, nil),
+			"watermark_key": utils.PathSearch("watermark_key", dbWaterParam, nil),
+			"params": flattenDatabaseWatermarkEmbedTasksEmbedParams(utils.PathSearch("params",
+				dbWaterParam, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenDatabaseWatermarkEmbedTasksEmbedParams(params []interface{}) []map[string]interface{} {
+	if len(params) < 1 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(params))
+	for _, v := range params {
+		rst = append(rst, map[string]interface{}{
+			"new_column_name": utils.PathSearch("new_column_name", v, nil),
+			"new_column_type": utils.PathSearch("new_column_type", v, nil),
+			"fake_strategy":   utils.PathSearch("fake_strategy", v, nil),
+			"fake_param": flattenDatabaseWatermarkEmbedTasksFakeParam(utils.PathSearch("fake_param",
+				v, make(map[string]interface{})).(map[string]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenDatabaseWatermarkEmbedTasksFakeParam(fakeParam map[string]interface{}) []map[string]interface{} {
+	if len(fakeParam) == 0 {
+		return nil
+	}
+
+	beginTime, err := strconv.ParseInt(utils.PathSearch("date_begin", fakeParam, "").(string), 10, 64)
+	if err != nil {
+		log.Printf("[ERROR] error parsing 'date_begin' field to Integer: %s", err)
+	}
+
+	endTime, err := strconv.ParseInt(utils.PathSearch("date_end", fakeParam, "").(string), 10, 64)
+	if err != nil {
+		log.Printf("[ERROR] error parsing 'date_end' field to Integer: %s", err)
+	}
+
+	return []map[string]interface{}{
+		{
+			"address_accuracy":  utils.PathSearch("address_accuracy", fakeParam, nil),
+			"date_begin":        utils.FormatTimeStampRFC3339(beginTime/1000, false),
+			"date_end":          utils.FormatTimeStampRFC3339(endTime/1000, false),
+			"random_accuracy":   utils.PathSearch("random_accuracy", fakeParam, nil),
+			"random_begin":      utils.PathSearch("random_begin", fakeParam, nil),
+			"random_distribute": utils.PathSearch("random_distribute", fakeParam, nil),
+			"random_end":        utils.PathSearch("random_end", fakeParam, nil),
+			"string_distribute": utils.PathSearch("string_distribute", fakeParam, nil),
+		},
+	}
+}
+
+func flattenDatabaseWatermarkEmbedTasksColumnInfos(fields []interface{}) []map[string]interface{} {
+	if len(fields) < 1 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(fields))
+	for _, v := range fields {
+		rst = append(rst, map[string]interface{}{
+			"column_name": utils.PathSearch("column_name", v, nil),
+			"column_type": utils.PathSearch("column_type", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenDatabaseWatermarkEmbedTasksDbInfo(dbInfo map[string]interface{}) []map[string]interface{} {
+	if len(dbInfo) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"db_id":       utils.PathSearch("db_id", dbInfo, nil),
+			"db_name":     utils.PathSearch("db_name", dbInfo, nil),
+			"db_type":     utils.PathSearch("db_type", dbInfo, nil),
+			"ins_id":      utils.PathSearch("ins_id", dbInfo, nil),
+			"ins_name":    utils.PathSearch("ins_name", dbInfo, nil),
+			"schema_name": utils.PathSearch("schema_name", dbInfo, nil),
+			"table_name":  utils.PathSearch("table_name", dbInfo, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source to query database watermark embed tasks.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
There's an issue with the API: when the name contains special characters, filtering by the name parameter will not return results. The name filter parameter is temporarily unavailable.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dsc -f TestAccDataSourceDatabaseWatermarkEmbedTasks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDataSourceDatabaseWatermarkEmbedTasks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDatabaseWatermarkEmbedTasks_basic
=== PAUSE TestAccDataSourceDatabaseWatermarkEmbedTasks_basic
=== CONT  TestAccDataSourceDatabaseWatermarkEmbedTasks_basic
--- PASS: TestAccDataSourceDatabaseWatermarkEmbedTasks_basic (60.09s)
PASS
coverage: 9.3% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       63.236s coverage: 9.3% of statements in ./huaweicloud/services/dsc
```
<img width="1131" height="57" alt="image" src="https://github.com/user-attachments/assets/147e320b-f3c6-4575-93f6-60271016ade7" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
