### PR TITLE
feat(dsc): add a new one-time resource to operate database watermark embed task

### DIFF
--- a/docs/resources/dsc_database_watermark_embed_task_action.md
+++ b/docs/resources/dsc_database_watermark_embed_task_action.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_database_watermark_embed_task_action"
+description: |-
+  Use this resource to operate a DSC database watermark embed task within HuaweiCloud.
+---
+
+# huaweicloud_dsc_database_watermark_embed_task_action
+
+Use this resource to operate a DSC database watermark embed task within HuaweiCloud.
+
+-> This resource is a one-time action resource used to operate a DSC database watermark embed task. Deleting this resource
+   will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "task_id" {}
+
+resource "huaweicloud_dsc_database_watermark_embed_task_action" "test" {
+  task_id = var.task_id
+  action  = "START"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the database watermark embed task is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `task_id` - (Required, String, NonUpdatable) Specifies the ID of the database watermark embed task.
+
+* `action` - (Required, String, NonUpdatable) Specifies the operation type of the database watermark embed task.  
+  The valid values are as follows:
+  + **ENABLE**
+  + **DISABLE**
+  + **START**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -5054,6 +5054,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dsc_bigdata_instance":                           dsc.ResourceBigdataInstance(),
 			"huaweicloud_dsc_data_map_score_update":                      dsc.ResourceDscDataMapScoreUpdate(),
 			"huaweicloud_dsc_database_watermark_embed_task":              dsc.ResourceDatabaseWatermarkEmbedTask(),
+			"huaweicloud_dsc_database_watermark_embed_task_action":       dsc.ResourceDatabaseWatermarkEmbedTaskAction(),
 			"huaweicloud_dsc_device":                                     dsc.ResourceDscDevice(),
 			"huaweicloud_dsc_instance":                                   dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_mask_algorithm":                             dsc.ResourceMaskAlgorithm(),

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_database_watermark_embed_task_action_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_database_watermark_embed_task_action_test.go
@@ -1,0 +1,145 @@
+package dsc
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatabaseWatermarkEmbedTaskAction_basic(t *testing.T) {
+	var (
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_dsc_database_watermark_embed_task_action.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDscDbInstanceId(t)
+			acceptance.TestAccPreCheckDscDbTableName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseWatermarkEmbedTaskAction_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "action", "DISABLE"),
+				),
+			},
+			{
+				Config: testAccDatabaseWatermarkEmbedTaskAction_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "action", "ENABLE"),
+				),
+			},
+			{
+				Config: testAccDatabaseWatermarkEmbedTaskAction_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "action", "START"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatabaseWatermarkEmbedTaskAction_base(name string) string {
+	startTime := time.Now().Add(4 * time.Hour).Format("2006-01-02T15:04:05+08:00")
+	return fmt.Sprintf(`
+data "huaweicloud_dsc_authorize_databases" "test" {
+  instance_type = "RDS"
+}
+
+locals {
+  instance_id   = "%[1]s"
+  instance      = try([for v in data.huaweicloud_dsc_authorize_databases.test.databases : v if v.ins_id == local.instance_id][0], {})
+  instance_name = try(local.instance.ins_name, "NOT_FOUND")
+  database_id   = try(local.instance.id, "NOT_FOUND")
+  database_name = try(local.instance.db_name, "NOT_FOUND")
+}
+
+resource "huaweicloud_dsc_database_watermark_embed_task" "test" {
+  task_name         = "%[2]s"
+  water_mark        = "TF"
+  watermark_version = "V2"
+
+  db_water_param {
+    embed_mode = "EMBED_FAKE_COLUMN"
+
+    params {
+      new_column_name = "test"
+      new_column_type = "varchar"
+      fake_strategy   = "name"
+    }
+  }
+
+  source_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[4]s"
+  }
+
+  target_db_info {
+    db_id      = local.database_id
+    db_name    = local.database_name
+    db_type    = "MySQL"
+    ins_id     = local.instance_id
+    ins_name   = local.instance_name
+    table_name = "%[2]s"
+  }
+
+  error_code    = 1
+  schedule_type = "MONTH"
+  start_time    = "%[3]s"
+
+  # Each time the task is restarted, 'start_time' will be changed to the time when the current task started execution.
+  lifecycle {
+    ignore_changes = [start_time]
+  }
+}
+`, acceptance.HW_DSC_DB_INSTANCE_ID, name, startTime, acceptance.HW_DSC_DB_TABLE_NAME)
+}
+
+func testAccDatabaseWatermarkEmbedTaskAction_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_database_watermark_embed_task_action" "test" {
+  task_id = huaweicloud_dsc_database_watermark_embed_task.test.id
+  action  = "DISABLE"
+}
+`, testAccDatabaseWatermarkEmbedTaskAction_base(name))
+}
+
+func testAccDatabaseWatermarkEmbedTaskAction_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_database_watermark_embed_task_action" "test" {
+  task_id = huaweicloud_dsc_database_watermark_embed_task.test.id
+  action  = "ENABLE"
+
+  enable_force_new = "true"
+}
+`, testAccDatabaseWatermarkEmbedTaskAction_base(name))
+}
+
+func testAccDatabaseWatermarkEmbedTaskAction_basic_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_database_watermark_embed_task_action" "test" {
+  task_id = huaweicloud_dsc_database_watermark_embed_task.test.id
+  action  = "START"
+
+  enable_force_new = "true"
+}
+`, testAccDatabaseWatermarkEmbedTaskAction_base(name))
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_database_watermark_embed_task_action.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_database_watermark_embed_task_action.go
@@ -1,0 +1,143 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var databaseWatermarkEmbedTaskActionNonUpdatableParams = []string{
+	"task_id",
+	"action",
+}
+
+// @API DSC PUT /v1/{project_id}/data-watermark-embed-tasks/{id}/status
+func ResourceDatabaseWatermarkEmbedTaskAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDatabaseWatermarkEmbedTaskActionCreate,
+		ReadContext:   resourceDatabaseWatermarkEmbedTaskActionRead,
+		UpdateContext: resourceDatabaseWatermarkEmbedTaskActionUpdate,
+		DeleteContext: resourceDatabaseWatermarkEmbedTaskActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(databaseWatermarkEmbedTaskActionNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the database watermark embed task is located.`,
+			},
+
+			// Required parameters.
+			"task_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the database watermark embed task.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The operation type of the database watermark embed task.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func actionDatabaseWatermarkEmbedTask(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/data-watermark-embed-tasks/{id}/status"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{id}", d.Get("task_id").(string))
+	createPath = fmt.Sprintf("%s?action=%v", createPath, d.Get("action"))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("PUT", createPath, &createOpt)
+	return err
+}
+
+func resourceDatabaseWatermarkEmbedTaskActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		taskId = d.Get("task_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dsc", region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	if err = actionDatabaseWatermarkEmbedTask(client, d); err != nil {
+		return diag.Errorf("error actioning the database watermark embed task (%s): %s", taskId, err)
+	}
+
+	if d.Get("action").(string) == "START" {
+		if _, err := waitForDatabaseWatermarkEmbedTaskCompleted(ctx, client, d.Timeout(schema.TimeoutCreate), taskId); err != nil {
+			return diag.Errorf("error waiting for executing the database watermark embed task to be completed: %s", err)
+		}
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	return nil
+}
+
+func resourceDatabaseWatermarkEmbedTaskActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDatabaseWatermarkEmbedTaskActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDatabaseWatermarkEmbedTaskActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to operate a DSC database watermark embed task. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time resource to operate database watermark embed task.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new one-time action resource for DSC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dsc -f TestAccDatabaseWatermarkEmbedTaskAction_basic             d_task_action)
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccDatabaseWatermarkEmbedTaskAction_basic -timeout 360m -parallel 10
=== RUN   TestAccDatabaseWatermarkEmbedTaskAction_basic
=== PAUSE TestAccDatabaseWatermarkEmbedTaskAction_basic
=== CONT  TestAccDatabaseWatermarkEmbedTaskAction_basic
--- PASS: TestAccDatabaseWatermarkEmbedTaskAction_basic (84.52s)
PASS
coverage: 8.5% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc   87.447s coverage: 8.5% of statements in ./huaweicloud/services/dsc
```
<img width="1168" height="59" alt="image" src="https://github.com/user-attachments/assets/5b9ec8ff-a6b7-4ccd-9b7f-deb3537b48bd" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
