### PR TITLE
feat(geminidb): add a best practice for creating geminidb instance with account

### DIFF
--- a/examples/geminidb/geminidb-instance-with-account/README.md
+++ b/examples/geminidb/geminidb-instance-with-account/README.md
@@ -1,0 +1,115 @@
+# Create a GeminiDB Instance with Account
+
+This example provides best practice code for using Terraform to create a GeminiDB Redis instance with a database
+account in HuaweiCloud GeminiDB service.
+
+## Prerequisites
+
+* A HuaweiCloud account
+* Terraform installed
+* HuaweiCloud access key and secret key (AK/SK)
+
+## Variable Introduction
+
+The following variables need to be configured:
+
+### Authentication Variables
+
+* `region_name` - The region where resources will be created
+* `access_key` - The access key of the IAM user
+* `secret_key` - The secret key of the IAM user
+
+### Resource Variables
+
+#### Required Variables
+
+* `vpc_name` - The VPC name
+* `subnet_name` - The subnet name
+* `security_group_name` - The security group name
+* `instance_name` - The GeminiDB Redis instance name
+* `account_name` - The username of the GeminiDB account
+* `instance_backup_time_window` - The backup time window in HH:MM-HH:MM format
+* `instance_backup_keep_days` - The number of days to retain backups
+
+#### Optional Variables - GeminiDB Instance
+
+* `vpc_cidr` - The CIDR block of the VPC (default: "192.168.0.0/16")
+* `subnet_cidr` - The CIDR block of the subnet (default: "")
+* `gateway_ip` - The gateway IP address of the subnet (default: "")
+* `instance_password` - The password for the GeminiDB Redis instance (default: "")
+* `availability_zone` - The availability zone (default: "")
+* `instance_mode` - The instance mode (default: "Cluster")
+* `instance_db_port` - The database port (default: 8888)
+* `instance_ssl_option` - Whether to enable SSL (default: "on")
+* `vcpus` - The number of vCPUs of the flavor to query (default: 2)
+* `instance_flavor_num` - The node quantity (default: 3)
+* `instance_flavor_size` - The disk size in GB (default: 16)
+* `instance_flavor_storage` - The disk type (default: "ULTRAHIGH")
+* `instance_flavor_spec_code` - The resource specification code (default: "")
+* `enterprise_project_id` - The enterprise project ID (default: "0")
+* `tags` - The tags of the GeminiDB Redis instance (default: {"foo" = "bar", "key" = "value"})
+
+#### Optional Variables - GeminiDB Account
+
+* `account_password` - The password of the GeminiDB account (default: "")
+* `account_privilege` - The privilege of the GeminiDB account (default: "ReadWrite")
+* `account_databases` - The list of databases for the account (default: ["1", "2"])
+
+## Usage
+
+* Copy this example script to your `main.tf`.
+
+* Create a `terraform.tfvars` file and fill in the required variables:
+
+  ```hcl
+  vpc_name                    = "your_vpc_name"
+  subnet_name                 = "your_subnet_name"
+  security_group_name         = "your_security_group_name"
+  instance_name               = "your_geminidb_redis_instance_name"
+  account_name                = "your_account_name"
+  instance_backup_time_window = "03:00-04:00"
+  instance_backup_keep_days   = 14
+  ```
+
+* Initialize Terraform:
+
+  ```bash
+  $ terraform init
+  ```
+
+* Review the Terraform plan:
+
+  ```bash
+  $ terraform plan
+  ```
+
+* Apply the configuration:
+
+  ```bash
+  $ terraform apply
+  ```
+
+* To clean up the resources:
+
+  ```bash
+  $ terraform destroy
+  ```
+
+## Note
+
+* Make sure to keep your credentials secure and never commit them to version control
+* The GeminiDB Redis instance uses `datastore.type = "redis"` with `version = "5.0"` and `storage_engine = "rocksDB"`
+* The `mode` for a GeminiDB Redis instance is `Cluster`
+* The GeminiDB account is created on the Redis instance with `ReadWrite` privilege and a list of databases
+* The instance flavor is automatically queried from `huaweicloud_gaussdb_nosql_flavors` data source
+* The `lifecycle.ignore_changes` on the instance ignores `password`, `flavor.0.storage`, and `ssl_option`
+* The `lifecycle.ignore_changes` on the account ignores `password` as it is not returned by the API
+* All resources will be created in the specified region
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.14.0 |
+| huaweicloud | >= 1.96.0 |
+| random | >= 3.0.0 |

--- a/examples/geminidb/geminidb-instance-with-account/main.tf
+++ b/examples/geminidb/geminidb-instance-with-account/main.tf
@@ -1,0 +1,97 @@
+# Create VPC and subnet for the GeminiDB Redis instance
+resource "huaweicloud_vpc" "test" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = var.subnet_name
+  cidr       = var.subnet_cidr == "" ? cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0) : var.subnet_cidr
+  gateway_ip = var.gateway_ip == "" ? cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0), 1) : var.gateway_ip
+}
+
+# Query availability zones and GeminiDB NoSQL flavors
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = var.vcpus
+  engine            = "redis"
+  availability_zone = var.availability_zone == "" ? try(data.huaweicloud_availability_zones.test.names[0], null) : var.availability_zone
+}
+
+# Create security group for the GeminiDB Redis instance
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = var.security_group_name
+  delete_default_rules = true
+}
+
+# Generate random password for the instance if not provided
+resource "random_password" "test" {
+  count = var.instance_password == "" ? 2 : 0
+
+  length           = 12
+  special          = true
+  override_special = "!@%^*-_=+"
+  min_upper        = 1
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+}
+
+# Create GeminiDB Redis instance
+resource "huaweicloud_geminidb_instance" "test" {
+  name                  = var.instance_name
+  availability_zone     = var.availability_zone == "" ? try(data.huaweicloud_availability_zones.test.names[0], null) : var.availability_zone
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  password              = var.instance_password != "" ? var.instance_password : try(random_password.test[0].result, null)
+  mode                  = var.instance_mode
+  enterprise_project_id = var.enterprise_project_id
+  port                  = var.instance_db_port
+  ssl_option            = var.instance_ssl_option
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = var.instance_flavor_num
+    size      = var.instance_flavor_size
+    storage   = var.instance_flavor_storage
+    spec_code = var.instance_flavor_spec_code != "" ? var.instance_flavor_spec_code : try(data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name, null)
+  }
+
+  backup_strategy {
+    start_time = var.instance_backup_time_window
+    keep_days  = var.instance_backup_keep_days
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      password,
+      flavor.0.storage,
+      ssl_option,
+    ]
+  }
+}
+
+# Create GeminiDB account on the Redis instance
+resource "huaweicloud_geminidb_account" "test" {
+  instance_id = huaweicloud_geminidb_instance.test.id
+  name        = var.account_name
+  password    = var.account_password != "" ? var.account_password : try(random_password.test[1].result, null)
+  privilege   = var.account_privilege
+  databases   = var.account_databases
+
+  lifecycle {
+    ignore_changes = [
+      password,
+    ]
+  }
+}

--- a/examples/geminidb/geminidb-instance-with-account/providers.tf
+++ b/examples/geminidb/geminidb-instance-with-account/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.96.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/geminidb/geminidb-instance-with-account/terraform.tfvars
+++ b/examples/geminidb/geminidb-instance-with-account/terraform.tfvars
@@ -1,0 +1,11 @@
+vpc_name                    = "your_vpc"
+subnet_name                 = "your_subnet"
+security_group_name         = "your_security_group"
+instance_name               = "your_geminidb_redis_instance"
+account_name                = "your_account"
+instance_backup_time_window = "03:00-04:00"
+instance_backup_keep_days   = 14
+tags                        = {
+  foo = "bar"
+  key = "value"
+}

--- a/examples/geminidb/geminidb-instance-with-account/variables.tf
+++ b/examples/geminidb/geminidb-instance-with-account/variables.tf
@@ -1,0 +1,167 @@
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where resources will be created"
+  type        = string
+}
+
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+# Variable definitions for resources/data sources
+variable "vpc_name" {
+  description = "The VPC name"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block of the VPC"
+  type        = string
+  default     = "192.168.0.0/16"
+}
+
+variable "subnet_name" {
+  description = "The subnet name"
+  type        = string
+}
+
+variable "subnet_cidr" {
+  description = "The CIDR block of the subnet"
+  type        = string
+  default     = ""
+}
+
+variable "gateway_ip" {
+  description = "The gateway IP address of the subnet"
+  type        = string
+  default     = ""
+}
+
+variable "vcpus" {
+  description = "The number of vCPUs of the flavor to query"
+  type        = number
+  default     = 2
+}
+
+variable "availability_zone" {
+  description = "The availability zone of the GeminiDB Redis instance. If not specified, the first AZ from data source will be used"
+  type        = string
+  default     = ""
+}
+
+variable "security_group_name" {
+  description = "The security group name"
+  type        = string
+}
+
+variable "instance_password" {
+  description = "The password for the GeminiDB Redis instance"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "instance_name" {
+  description = "The GeminiDB Redis instance name"
+  type        = string
+}
+
+variable "instance_mode" {
+  description = "The instance mode. Valid value is Cluster"
+  type        = string
+  default     = "Cluster"
+}
+
+variable "enterprise_project_id" {
+  description = "The enterprise project ID"
+  type        = string
+  default     = "0"
+}
+
+variable "instance_db_port" {
+  description = "The database port of the GeminiDB Redis instance"
+  type        = number
+  default     = 8888
+}
+
+variable "instance_ssl_option" {
+  description = "Whether to enable SSL. Valid values are on, off"
+  type        = string
+  default     = "on"
+}
+
+variable "instance_flavor_num" {
+  description = "The node quantity of the GeminiDB Redis instance"
+  type        = number
+  default     = 3
+}
+
+variable "instance_flavor_size" {
+  description = "The disk size in GB of the GeminiDB Redis instance"
+  type        = number
+  default     = 16
+}
+
+variable "instance_flavor_storage" {
+  description = "The disk type of the GeminiDB Redis instance"
+  type        = string
+  default     = "ULTRAHIGH"
+}
+
+variable "instance_flavor_spec_code" {
+  description = "The resource specification code. If not specified, the first available flavor will be used"
+  type        = string
+  default     = ""
+}
+
+variable "instance_backup_time_window" {
+  description = "The backup time window in HH:MM-HH:MM format"
+  type        = string
+}
+
+variable "instance_backup_keep_days" {
+  description = "The number of days to retain backups"
+  type        = number
+}
+
+variable "tags" {
+  description = "The tags of the GeminiDB Redis instance"
+  type        = map(string)
+  default     = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+# Account variables
+variable "account_name" {
+  description = "The username of the GeminiDB account"
+  type        = string
+}
+
+variable "account_password" {
+  description = "The password of the GeminiDB account. If not specified, a random password will be generated"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "account_privilege" {
+  description = "The privilege of the GeminiDB account. Valid values are ReadWrite, ReadOnly"
+  type        = string
+  default     = "ReadWrite"
+}
+
+variable "account_databases" {
+  description = "The list of databases for the GeminiDB account"
+  type        = list(string)
+  default     = ["1", "2"]
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a best practice for creating geminidb instance with account
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a best practice for creating geminidb instance with account
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

terraform apply：
<img width="1115" height="895" alt="image" src="https://github.com/user-attachments/assets/0f105a59-ba7c-4c37-81d9-6c9330faf8b8" />
<img width="618" height="912" alt="image" src="https://github.com/user-attachments/assets/570ac528-fc89-4879-87fb-9958209202e8" />
<img width="505" height="906" alt="image" src="https://github.com/user-attachments/assets/03f738ce-28d6-475f-bf6a-5b65850e3518" />
<img width="473" height="906" alt="image" src="https://github.com/user-attachments/assets/e2004a8f-c52b-4deb-927b-3a886ed9c867" />
<img width="883" height="899" alt="image" src="https://github.com/user-attachments/assets/31fc9cad-1565-46f1-b89c-7cdf7667bfc6" />
<img width="968" height="908" alt="image" src="https://github.com/user-attachments/assets/d5e8f322-744e-4004-9035-4f1984c996bd" />
terraform destroy：
<img width="1146" height="905" alt="image" src="https://github.com/user-attachments/assets/987f9845-eb12-46df-98a5-c6ac73a51989" />
<img width="789" height="905" alt="image" src="https://github.com/user-attachments/assets/a1fd71cc-9b37-4966-9be1-527c8a9367eb" />
<img width="796" height="917" alt="image" src="https://github.com/user-attachments/assets/2dd2ea37-c9fa-4cff-9003-f3ecec1be0a0" />
<img width="699" height="904" alt="image" src="https://github.com/user-attachments/assets/ee399fbb-9a79-498f-a7f7-49184e2797ca" />
<img width="652" height="918" alt="image" src="https://github.com/user-attachments/assets/35ee062c-a46b-4954-b2a0-8a97fbc38153" />
<img width="926" height="916" alt="image" src="https://github.com/user-attachments/assets/fa8d43d0-7989-44ad-a926-531da323d96a" />
<img width="926" height="898" alt="image" src="https://github.com/user-attachments/assets/b0494b33-ac3d-499b-a393-2495d3446740" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
