### PR TITLE
feat(coc): add a new resource to execute script on the multiple instances

### DIFF
--- a/docs/resources/coc_script_batch_execute.md
+++ b/docs/resources/coc_script_batch_execute.md
@@ -1,0 +1,139 @@
+---
+subcategory: "Cloud Operations Center (COC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_coc_script_batch_execute"
+description: |-
+  Manages a COC script execution on multiple ECS instances within HuaweiCloud.
+---
+
+# huaweicloud_coc_script_batch_execute
+
+Manages a COC script execution on multiple ECS instances within HuaweiCloud.
+
+-> Please make sure each ECS instance has installed the [UniAgent](https://support.huaweicloud.com/intl/en-us/usermanual-aom2/agent_01_0005.html).
+
+## Example Usage
+
+```hcl
+variable "script_id" {}
+variable "execute_user" {}
+variable "execute_batches" {
+  type = list(object({
+    batch_index  = number
+    instance_ids = list(string)
+  }))
+}
+variable "parameters" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+}
+
+resource "huaweicloud_coc_script_batch_execute" "test" {
+  script_id    = var.script_id
+  timeout      = 600
+  execute_user = var.execute_user
+
+  dynamic "execute_batches" {
+    for_each = var.execute_batches
+
+    content {
+      batch_index  = execute_batches.value.batch_index
+      instance_ids = execute_batches.value.instance_ids
+    }
+  }
+
+  dynamic "parameters" {
+    for_each = var.parameters
+
+    content {
+      name  = parameters.value.name
+      value = parameters.value.value
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `script_id` - (Required, String, NonUpdatable) Specifies the ID of the COC script.
+
+* `execute_batches` - (Required, List, NonUpdatable) Specifies the batch information of the target instances.  
+  The [execute_batches](#coc_script_batch_execute_execute_batches) structure is documented below.  
+  The maximum number of batches allowed is `20`.
+
+* `timeout` - (Required, Int, NonUpdatable) Specifies the maximum time to execute the script, in seconds.
+
+* `execute_user` - (Required, String, NonUpdatable) Specifies the user to execute the script.
+
+* `parameters` - (Optional, List, NonUpdatable) Specifies the input parameters of the script.  
+  The [parameters](#coc_script_batch_execute_parameters) structure is documented below.
+
+* `is_sync` - (Optional, Bool, NonUpdatable) Specifies whether to sync data before executing the script.  
+  Defaults to **true**.
+
+<a name="coc_script_batch_execute_execute_batches"></a>
+The `execute_batches` block supports:
+
+* `batch_index` - (Required, Int, NonUpdatable) Specifies the batch index.  
+  The minimum value is `1`.
+
+* `instance_ids` - (Required, List, NonUpdatable) Specifies the ID list of the ECS instances in this batch.  
+  A maximum of `10` instances can be operated in batches.
+
+<a name="coc_script_batch_execute_parameters"></a>
+The `parameters` block supports:
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the parameter.
+
+* `value` - (Required, String, NonUpdatable) Specifies the value of the parameter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `script_name` - The name of the script.
+
+* `status` - The status of the script execution.
+
+* `created_at` - The start time of the script execution, in RFC3339 format.
+
+* `finished_at` - The end time of the script execution, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_coc_script_batch_execute.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `execute_batches`, `parameters`, `is_sync`.
+
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_coc_script_batch_execute" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      execute_batches, parameters, is_sync,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3566,6 +3566,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_compute_scheduled_event_update":     ecs.ResourceComputeScheduledEventUpdate(),
 
 			"huaweicloud_coc_script":                           coc.ResourceScript(),
+			"huaweicloud_coc_script_batch_execute":             coc.ResourceScriptBatchExecute(),
 			"huaweicloud_coc_script_execute":                   coc.ResourceScriptExecute(),
 			"huaweicloud_coc_script_order_operation":           coc.ResourceScriptOrderOperation(),
 			"huaweicloud_coc_script_approval":                  coc.ResourceScriptApproval(),

--- a/huaweicloud/services/acceptance/coc/resource_huaweicloud_coc_script_batch_execute_test.go
+++ b/huaweicloud/services/acceptance/coc/resource_huaweicloud_coc_script_batch_execute_test.go
@@ -1,0 +1,234 @@
+package coc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/coc"
+)
+
+func getScriptBatchExecuteResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("coc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating COC client: %s", err)
+	}
+
+	return coc.GetExecutionTicketDetail(client, state.Primary.ID)
+}
+
+func TestAccScriptBatchExecute_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_coc_script_batch_execute.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getScriptBatchExecuteResourceFunc)
+
+		rNameWithNotSync = "huaweicloud_coc_script_batch_execute.with_not_sync"
+		rcWithNotSync    = acceptance.InitResourceCheck(rNameWithNotSync, &obj, getScriptBatchExecuteResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckProjectID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScriptBatchExecute_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "script_id", "huaweicloud_coc_script.test", "id"),
+					resource.TestCheckResourceAttr(rName, "execute_batches.#", "2"),
+					resource.TestCheckResourceAttr(rName, "execute_batches.0.batch_index", "1"),
+					resource.TestCheckResourceAttr(rName, "execute_batches.0.instance_ids.#", "1"),
+					resource.TestCheckResourceAttr(rName, "execute_batches.1.batch_index", "2"),
+					resource.TestCheckResourceAttr(rName, "execute_batches.1.instance_ids.#", "2"),
+					resource.TestCheckResourceAttr(rName, "timeout", "600"),
+					resource.TestCheckResourceAttr(rName, "execute_user", "root"),
+					resource.TestCheckResourceAttr(rName, "parameters.#", "2"),
+					resource.TestCheckResourceAttr(rName, "script_name", name),
+					resource.TestCheckResourceAttr(rName, "is_sync", "true"),
+					resource.TestCheckResourceAttr(rName, "status", "FINISHED"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "finished_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					rcWithNotSync.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithNotSync, "is_sync", "false"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"execute_batches", "parameters", "is_sync",
+				},
+			},
+			{
+				ResourceName:      rNameWithNotSync,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"execute_batches", "parameters", "is_sync",
+				},
+			},
+		},
+	})
+}
+
+func testAccScriptBatchExecute_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = try(data.huaweicloud_availability_zones.test.names[0], "")
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_images_images" "test" {
+  flavor_id  = try(data.huaweicloud_compute_flavors.test.ids[0], "")
+  os         = "Ubuntu"
+  visibility = "public"
+}
+
+# The default security group rules cannot be deleted, otherwise the UniAgent installation will fail.
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[2]s"
+}
+
+# Create two ECS instances and install UniAgent
+resource "huaweicloud_compute_instance" "test" {
+  count = 3
+
+  name                  = "%[2]s${count.index}"
+  availability_zone     = try(data.huaweicloud_availability_zones.test.names[0], "")
+  flavor_id             = try(data.huaweicloud_compute_flavors.test.flavors[0].id, "NOT_FOUND")
+  image_id              = try(data.huaweicloud_images_images.test.images[0].id, "NOT_FOUND")
+  security_group_ids    = [huaweicloud_networking_secgroup.test.id]
+  enterprise_project_id = "%[3]s"
+
+  user_data = <<EOF
+#! /bin/bash
+set +o history;
+curl -k -X GET -m 20 --retry 1 --retry-delay 10 -o /tmp/install_uniagent https://aom-uniagent-%[4]s.obs.%[4]s.myhuaweicloud.com/install_uniagent.sh; \
+bash /tmp/install_uniagent -p %[5]s -v 1.2.0 -e %[4]s;set -o history;
+EOF
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+# Wait for the ECS instances UniAgent to be install completed.
+resource "time_sleep" "test" {
+  create_duration = "1m"
+
+  depends_on = [huaweicloud_compute_instance.test]
+}
+
+resource "huaweicloud_coc_script" "test" {
+  name                  = "%[2]s"
+  risk_level            = "LOW"
+  version               = "1.0.1"
+  type                  = "SHELL"
+  enterprise_project_id = "%[3]s"
+  description           = "Created by Terraform script"
+
+  content = <<EOF
+#! /bin/bash
+echo "hello $${name}@$${organization}!"
+EOF
+
+  parameters {
+    name        = "name"
+    value       = "world"
+    description = "the first parameter"
+  }
+  parameters {
+    name        = "organization"
+    value       = "Huawei"
+    description = "the second parameter"
+    sensitive   = true
+  }
+}`, common.TestVpc(name, acceptance.HW_ENTERPRISE_PROJECT_ID), name,
+		acceptance.HW_ENTERPRISE_PROJECT_ID,
+		acceptance.HW_REGION_NAME,
+		acceptance.HW_PROJECT_ID,
+	)
+}
+
+func testAccScriptBatchExecute_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_coc_script_batch_execute" "test" {
+  script_id    = huaweicloud_coc_script.test.id
+  timeout      = 600
+  execute_user = "root"
+
+  execute_batches {
+    batch_index  = 1
+    instance_ids = slice(huaweicloud_compute_instance.test[*].id, 0, 1)
+  }
+  execute_batches {
+    batch_index  = 2
+    instance_ids = slice(huaweicloud_compute_instance.test[*].id, 1, 3)
+  }
+
+  parameters {
+    name  = "name"
+    value = "TF acceptance test"
+  }
+  parameters {
+    name  = "organization"
+    value = "HuaweiCloud"
+  }
+
+  depends_on = [time_sleep.test]
+}
+
+resource "huaweicloud_coc_script_batch_execute" "with_not_sync" {
+  script_id    = huaweicloud_coc_script.test.id
+  timeout      = 600
+  execute_user = "root"
+  is_sync      = false
+
+  execute_batches {
+    batch_index  = 1
+    instance_ids = huaweicloud_compute_instance.test[*].id
+  }
+
+  parameters {
+    name  = "name"
+    value = "TF"
+  }
+  parameters {
+    name  = "organization"
+    value = "HW TF"
+  }
+
+  depends_on = [time_sleep.test]
+}
+`, testAccScriptBatchExecute_base(name))
+}

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_public_script_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_public_script_execute.go
@@ -387,7 +387,7 @@ func resourcePublicScriptExecuteRead(_ context.Context, d *schema.ResourceData, 
 	}
 
 	ticketID := d.Id()
-	ticketDetail, err := getExecutionTicketDetail(client, ticketID)
+	ticketDetail, err := GetExecutionTicketDetail(client, ticketID)
 	if err != nil {
 		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code",
 			scriptOrderNotFoundErrCodes...), "COC public script execute")

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script_batch_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script_batch_execute.go
@@ -1,0 +1,444 @@
+package coc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var scriptBatchExecuteNonUpdatableParams = []string{
+	"script_id",
+	"execute_batches",
+	"execute_batches.*.batch_index",
+	"execute_batches.*.instance_ids",
+	"timeout",
+	"execute_user",
+	"parameters",
+	"parameters.*.name",
+	"parameters.*.value",
+	"is_sync",
+}
+
+// @API COC POST /v1/external/resources/sync
+// @API COC GET /v1/resources
+// @API COC POST /v1/job/scripts/{script_uuid}
+// @API COC GET /v1/job/script/orders/{execute_uuid}
+// @API COC PUT /v1/job/script/orders/{execute_uuid}/operation
+func ResourceScriptBatchExecute() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScriptBatchExecuteCreate,
+		ReadContext:   resourceScriptBatchExecuteRead,
+		UpdateContext: resourceScriptBatchExecuteUpdate,
+		DeleteContext: resourceScriptBatchExecuteDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(scriptBatchExecuteNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"script_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the COC script.`,
+			},
+			"execute_batches": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        scriptBatchExecuteBatchesSchema(),
+				Description: `The batch information of the target instances.`,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The maximum time to execute the script, in seconds.`,
+			},
+			"execute_user": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The user to execute the script.`,
+			},
+
+			// Optional parameters.
+			"parameters": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        scriptBatchExecuteParametersSchema(),
+				Description: `The input parameters of the script.`,
+			},
+			"is_sync": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to sync data before executing the script.`,
+			},
+
+			// Attributes.
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the script execution.`,
+			},
+			"script_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the script.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The start time of the script execution, in RFC3339 format.`,
+			},
+			"finished_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end time of the script execution, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func scriptBatchExecuteBatchesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"batch_index": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The batch index.`,
+			},
+			"instance_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The ID list of the ECS instances in this batch.`,
+			},
+		},
+	}
+}
+
+func scriptBatchExecuteParametersSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the parameter.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The value of the parameter.`,
+			},
+		},
+	}
+}
+
+func buildScriptBatchExecuteParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"success_rate":  100,
+		"timeout":       d.Get("timeout"),
+		"execute_user":  d.Get("execute_user"),
+		"script_params": buildScriptBatchExecuteScriptParams(d.Get("parameters").([]interface{})),
+	}
+}
+
+func buildScriptBatchExecuteScriptParams(scriptParams []interface{}) []map[string]interface{} {
+	if len(scriptParams) < 1 {
+		return nil
+	}
+
+	params := make([]map[string]interface{}, 0, len(scriptParams))
+	for _, v := range scriptParams {
+		params = append(params, map[string]interface{}{
+			"param_name":  utils.PathSearch("name", v, ""),
+			"param_value": utils.PathSearch("value", v, ""),
+		})
+	}
+
+	return params
+}
+
+func buildScriptBatchExecuteBodyParams(d *schema.ResourceData, instances []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"execute_param":   buildScriptBatchExecuteParam(d),
+		"execute_batches": buildScriptBatchExecuteBatches(d.Get("execute_batches").([]interface{}), instances),
+	}
+}
+
+func buildScriptBatchExecuteBatches(executeBatches, instances []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(executeBatches))
+	for _, v := range executeBatches {
+		instanceIds := utils.ExpandToStringList(utils.PathSearch("instance_ids", v, make([]interface{}, 0)).([]interface{}))
+		result = append(result, map[string]interface{}{
+			"batch_index":       utils.PathSearch("batch_index", v, nil),
+			"rotation_strategy": "CONTINUE",
+			"target_instances":  buildScriptBatchExecuteBatchesTargetInstances(instanceIds, instances),
+		})
+	}
+
+	return result
+}
+
+func buildScriptBatchExecuteBatchesTargetInstances(instanceIds []string, instances []interface{}) []map[string]interface{} {
+	results := make([]map[string]interface{}, 0, len(instanceIds))
+	for _, instanceId := range instanceIds {
+		targetInstance := utils.PathSearch(fmt.Sprintf("[?resource_id== '%s']|[0]", instanceId), instances, nil)
+		results = append(results, map[string]interface{}{
+			"resource_id": utils.PathSearch("resource_id", targetInstance, nil),
+			"region_id":   utils.PathSearch("region_id", targetInstance, nil),
+		})
+	}
+
+	return results
+}
+
+func listResources(client *golangsdk.ServiceClient, instanceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/resources"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + fmt.Sprintf("%s?provider=ecs&type=cloudservers&limit=%v&resource_id_list=%s", httpUrl, limit, instanceId)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%v", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		resources := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, resources...)
+		if len(resources) < limit {
+			break
+		}
+
+		offset += limit
+	}
+
+	return result, nil
+}
+
+func refreshResourcesAgentStatus(client *golangsdk.ServiceClient, instanceId string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resources, err := listResources(client, instanceId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		if len(resources) < 1 {
+			return nil, "ERROR", fmt.Errorf("unable to find any resources")
+		}
+
+		for _, v := range resources {
+			agentId := utils.PathSearch("agent_id", v, "").(string)
+			agentStatus := utils.PathSearch("agent_state", v, "").(string)
+			if agentId != "" && agentStatus == "ONLINE" {
+				continue
+			}
+
+			if agentId == "" && agentStatus == "" {
+				return nil, "ERROR", fmt.Errorf("UniAgent is not installed on the instance (%v)", utils.PathSearch("resource_id", v, ""))
+			}
+
+			if utils.StrSliceContains([]string{"FAILED", "OFFLINE", "UNINSTALLED"}, agentStatus) {
+				return nil, "ERROR", fmt.Errorf("unexpected UniAgent status (%s)", agentStatus)
+			}
+
+			return resources, "PENDING", nil
+		}
+
+		return resources, "COMPLETE", nil
+	}
+}
+
+func batchExecuteScript(client *golangsdk.ServiceClient, d *schema.ResourceData, instances []interface{}) (interface{}, error) {
+	httpUrl := "v1/job/scripts/{script_uuid}"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{script_uuid}", d.Get("script_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildScriptBatchExecuteBodyParams(d, instances)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(createResp)
+}
+
+func resourceScriptBatchExecuteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("coc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating COC client: %s", err)
+	}
+
+	// Synchronize the ECS instances to get information about UniAgent.
+	if d.Get("is_sync").(bool) {
+		if err = syncResourceInfo(client); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	instanceIds := utils.PathSearch("[*].instance_ids[]", d.Get("execute_batches").([]interface{}), make([]interface{}, 0))
+	stateConf := &retry.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETE"},
+		Refresh:      refreshResourcesAgentStatus(client, strings.Join(utils.ExpandToStringList(instanceIds.([]interface{})), ",")),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+
+	instances, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for ECS instance agent to be online: %s", err)
+	}
+
+	respBody, err := batchExecuteScript(client, d, instances.([]interface{}))
+	if err != nil {
+		return diag.Errorf("error executing script on instances: %s", err)
+	}
+
+	ticketId := utils.PathSearch("data", respBody, "").(string)
+	if ticketId == "" {
+		return diag.Errorf("unable to find the script execution ticket ID from the API response")
+	}
+
+	d.SetId(ticketId)
+
+	stateConf = &retry.StateChangeConf{
+		Pending:      []string{"pending"},
+		Target:       []string{"exited"},
+		Refresh:      refreshGetExecutionTicketDetail(client, ticketId),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        15 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for script execution to be completed: %s", err)
+	}
+
+	return resourceScriptBatchExecuteRead(ctx, d, meta)
+}
+
+func resourceScriptBatchExecuteRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		ticketId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("coc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating COC client: %s", err)
+	}
+
+	ticketDetail, err := GetExecutionTicketDetail(client, ticketId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code",
+			scriptOrderNotFoundErrCodes...), fmt.Sprintf("error retrieving COC script execute ticket (%s)", ticketId))
+	}
+
+	mErr := multierror.Append(nil,
+		// Required parameters.
+		d.Set("script_id", utils.PathSearch("data.properties.script_uuid", ticketDetail, nil)),
+		d.Set("timeout", utils.PathSearch("data.properties.execute_param.timeout", ticketDetail, nil)),
+		d.Set("execute_user", utils.PathSearch("data.properties.execute_param.execute_user", ticketDetail, nil)),
+		// Attributes.
+		d.Set("status", utils.PathSearch("data.status", ticketDetail, nil)),
+		d.Set("script_name", utils.PathSearch("data.properties.script_name", ticketDetail, nil)),
+		d.Set("created_at", flattenScriptTimeStamp(ticketDetail, "data.gmt_created")),
+		d.Set("finished_at", flattenScriptTimeStamp(ticketDetail, "data.gmt_finished")),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceScriptBatchExecuteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func cancelScriptExecute(client *golangsdk.ServiceClient, ticketId string, params map[string]interface{}) error {
+	httpUrl := "v1/job/script/orders/{execute_uuid}/operation"
+	operationPath := client.Endpoint + httpUrl
+	operationPath = strings.ReplaceAll(operationPath, "{execute_uuid}", ticketId)
+
+	operationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         params,
+	}
+
+	_, err := client.Request("PUT", operationPath, &operationOpt)
+	return err
+}
+
+func resourceScriptBatchExecuteDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("coc", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating COC client: %s", err)
+	}
+
+	if utils.StrSliceContains([]string{"FINISHED", "ROLLBACKED", "CANCELED", "ERROR", "ABNORMAL"}, d.Get("status").(string)) {
+		return nil
+	}
+
+	// Cancel the ticket when it is in PROCESSING or PAUSED status.
+	params := map[string]interface{}{
+		"operation_type": "CANCEL_ORDER",
+	}
+	err = cancelScriptExecute(client, d.Id(), params)
+	if err != nil {
+		return diag.Errorf("error canceling COC script batch execute (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
@@ -253,7 +253,7 @@ func resourceScriptExecuteCreate(ctx context.Context, d *schema.ResourceData, me
 
 func refreshGetExecutionTicketDetail(client *golangsdk.ServiceClient, ticketID string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		ticketDetail, err := getExecutionTicketDetail(client, ticketID)
+		ticketDetail, err := GetExecutionTicketDetail(client, ticketID)
 		if err != nil {
 			return nil, "error", err
 		}
@@ -270,7 +270,7 @@ func refreshGetExecutionTicketDetail(client *golangsdk.ServiceClient, ticketID s
 	}
 }
 
-func getExecutionTicketDetail(client *golangsdk.ServiceClient, id string) (interface{}, error) {
+func GetExecutionTicketDetail(client *golangsdk.ServiceClient, id string) (interface{}, error) {
 	getExecutionTicketHttpUrl := "v1/job/script/orders/{id}"
 	getExecutionTicketPath := client.Endpoint + getExecutionTicketHttpUrl
 	getExecutionTicketPath = strings.ReplaceAll(getExecutionTicketPath, "{id}", id)
@@ -298,7 +298,7 @@ func resourceScriptExecuteRead(_ context.Context, d *schema.ResourceData, meta i
 	}
 
 	ticketID := d.Id()
-	ticketDetail, err := getExecutionTicketDetail(client, ticketID)
+	ticketDetail, err := GetExecutionTicketDetail(client, ticketID)
 	if err != nil {
 		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code",
 			scriptOrderNotFoundErrCodes...), "COC script execute")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The existing `huaweicloud_coc_script_execute` resource only supports single-instance execution. If the script is deployed to multiple ECS instances via count/for_each, multiple script work orders will be generated. To address this, a new `huaweicloud_coc_script_batch_execute` resource is provided, which can deploy scripts to multiple instances in a single execution and generate only one work order record.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource for COC service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o coc -f TestAccScriptBatchExecute_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/coc" -v -coverprofile="./huaweicloud/services/acceptance/coc/coc_coverage.cov" -coverpkg="./huaweicloud/services/coc"-run TestAccScriptBatchExecute_basic -timeout 360m -parallel 10
=== RUN   TestAccScriptBatchExecute_basic
=== PAUSE TestAccScriptBatchExecute_basic
=== CONT  TestAccScriptBatchExecute_basic
--- PASS: TestAccScriptBatchExecute_basic (329.40s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/coc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/coc       332.692s        coverage: 7.6% of statements in ./huaweicloud/services/coc
```
<img width="999" height="49" alt="image" src="https://github.com/user-attachments/assets/3aa7b394-ed5e-4a47-aaf0-215046be6a09" />

```
./scripts/coverage.sh -o coc -f TestAccResourceCocPublicScriptExecute_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/coc" -v -coverprofile="./huaweicloud/services/acceptance/coc/coc_coverage.cov" -coverpkg="./huaweicloud/services/coc" -run TestAccResourceCocPublicScriptExecute_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceCocPublicScriptExecute_basic
=== PAUSE TestAccResourceCocPublicScriptExecute_basic
=== CONT  TestAccResourceCocPublicScriptExecute_basic
--- PASS: TestAccResourceCocPublicScriptExecute_basic (43.78s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/coc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/coc       46.577s coverage: 6.0% of statements in ./huaweicloud/services/coc
```

```
./scripts/coverage.sh -o coc -f TestAccScriptExecute_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/coc" -v -coverprofile="./huaweicloud/services/acceptance/coc/coc_coverage.cov" -coverpkg="./huaweicloud/services/coc" -run TestAccScriptExecute_ -timeout 360m -parallel 10
=== RUN   TestAccScriptExecute_basic
=== PAUSE TestAccScriptExecute_basic
=== RUN   TestAccScriptExecute_no_sync
=== PAUSE TestAccScriptExecute_no_sync
=== CONT  TestAccScriptExecute_basic
=== CONT  TestAccScriptExecute_no_sync
--- PASS: TestAccScriptExecute_no_sync (49.75s)
--- PASS: TestAccScriptExecute_basic (49.76s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/coc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/coc       52.487s coverage: 7.6% of statements in ./huaweicloud/services/coc
```
* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
