### PR TITLE
feat(geminidb): add a best practice for creating geminidb parameter template copy

### DIFF
--- a/examples/geminidb/geminidb-parameter-template-copy/README.md
+++ b/examples/geminidb/geminidb-parameter-template-copy/README.md
@@ -1,0 +1,95 @@
+# Copy a GeminiDB Parameter Template
+
+This example provides best practice code for using Terraform to create a GeminiDB parameter template and copy it
+with a new name, description, and parameter values in HuaweiCloud GeminiDB service.
+
+## Prerequisites
+
+* A HuaweiCloud account
+* Terraform installed
+* HuaweiCloud access key and secret key (AK/SK)
+
+## Variable Introduction
+
+The following variables need to be configured:
+
+### Authentication Variables
+
+* `region_name` - The region where resources will be created
+* `access_key` - The access key of the IAM user
+* `secret_key` - The secret key of the IAM user
+
+### Resource Variables
+
+#### Required Variables
+
+* `template_name` - The name of the source GeminiDB parameter template
+* `copy_name` - The name of the copied GeminiDB parameter template
+
+#### Optional Variables - Source Parameter Template
+
+* `template_description` - The description of the source parameter template (default: "test configuration")
+* `datastore_type` - The database type (default: "cassandra")
+* `datastore_version` - The database version (default: "3.11")
+* `datastore_mode` - The database instance mode (default: "CloudNativeCluster")
+* `parameter_values` - The parameter values map for the source template (default: {"request_timeout_in_ms" = "20000"})
+
+#### Optional Variables - Parameter Template Copy
+
+* `copy_description` - The description of the copied parameter template (default: "test parameter template update")
+* `copy_values` - The parameter values map for the copied template (default: {"request_timeout_in_ms" = "10000"})
+
+## Usage
+
+* Copy this example script to your `main.tf`.
+
+* Create a `terraform.tfvars` file and fill in the required variables:
+
+  ```hcl
+  template_name = "your_geminidb_parameter_template_name"
+  copy_name     = "your_geminidb_parameter_template_copy_name"
+  ```
+
+* Initialize Terraform:
+
+  ```bash
+  $ terraform init
+  ```
+
+* Review the Terraform plan:
+
+  ```bash
+  $ terraform plan
+  ```
+
+* Apply the configuration:
+
+  ```bash
+  $ terraform apply
+  ```
+
+* To clean up the resources:
+
+  ```bash
+  $ terraform destroy
+  ```
+
+## Note
+
+* Make sure to keep your credentials secure and never commit them to version control
+* The source parameter template is created for GeminiDB Cassandra with `version = "3.11"` and `mode = "CloudNativeCluster"`
+* The `huaweicloud_geminidb_parameter_template_copy` resource copies the source template with a new name, description,
+  and parameter values
+* The `config_id` of the copy resource references the source parameter template created above
+* The `lifecycle.ignore_changes` on the source template ignores `datastore` as it is not returned by the API after import
+* The `lifecycle.ignore_changes` on the copy resource ignores `config_id` and `values` as they are not returned by the
+  API after import
+* All resources will be created in the specified region
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.14.0 |
+| huaweicloud | >= 1.93.0 |
+| random | >= 3.0.0 |

--- a/examples/geminidb/geminidb-parameter-template-copy/main.tf
+++ b/examples/geminidb/geminidb-parameter-template-copy/main.tf
@@ -1,0 +1,35 @@
+# Create a source GeminiDB parameter template with custom parameter values
+resource "huaweicloud_geminidb_parameter_template" "test" {
+  name        = var.template_name
+  description = var.template_description
+
+  datastore {
+    type    = var.datastore_type
+    version = var.datastore_version
+    mode    = var.datastore_mode
+  }
+
+  values = var.parameter_values
+
+  lifecycle {
+    ignore_changes = [
+      datastore,
+    ]
+  }
+}
+
+# Copy the GeminiDB parameter template with updated name, description and values
+resource "huaweicloud_geminidb_parameter_template_copy" "test" {
+  config_id   = huaweicloud_geminidb_parameter_template.test.id
+  name        = var.copy_name
+  description = var.copy_description
+
+  values = var.copy_values
+
+  lifecycle {
+    ignore_changes = [
+      config_id,
+      values,
+    ]
+  }
+}

--- a/examples/geminidb/geminidb-parameter-template-copy/providers.tf
+++ b/examples/geminidb/geminidb-parameter-template-copy/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.93.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/geminidb/geminidb-parameter-template-copy/terraform.tfvars
+++ b/examples/geminidb/geminidb-parameter-template-copy/terraform.tfvars
@@ -1,0 +1,2 @@
+template_name = "your_geminidb_parameter_template"
+copy_name     = "your_geminidb_parameter_template_copy"

--- a/examples/geminidb/geminidb-parameter-template-copy/variables.tf
+++ b/examples/geminidb/geminidb-parameter-template-copy/variables.tf
@@ -1,0 +1,75 @@
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where resources will be created"
+  type        = string
+}
+
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+# Variable definitions for the source parameter template
+variable "template_name" {
+  description = "The name of the source GeminiDB parameter template"
+  type        = string
+}
+
+variable "template_description" {
+  description = "The description of the source GeminiDB parameter template"
+  type        = string
+  default     = "test configuration"
+}
+
+variable "datastore_type" {
+  description = "The database type. Valid values are cassandra, mongodb, influxdb, redis, dynamodb, hbase"
+  type        = string
+  default     = "cassandra"
+}
+
+variable "datastore_version" {
+  description = "The database version. Cassandra: 3.11, Mongo: 4.0, Influx: 1.8, Redis: 5.0"
+  type        = string
+  default     = "3.11"
+}
+
+variable "datastore_mode" {
+  description = "The database instance mode. Valid values are ReplicaSet, InfluxdbSingle, EnhancedCluster, CloudNativeCluster"
+  type        = string
+  default     = "CloudNativeCluster"
+}
+
+variable "parameter_values" {
+  description = "The parameter values map for the source GeminiDB parameter template"
+  type        = map(string)
+  default     = {
+    request_timeout_in_ms = "20000"
+  }
+}
+
+# Variable definitions for the parameter template copy
+variable "copy_name" {
+  description = "The name of the copied GeminiDB parameter template"
+  type        = string
+}
+
+variable "copy_description" {
+  description = "The description of the copied GeminiDB parameter template"
+  type        = string
+  default     = "test parameter template update"
+}
+
+variable "copy_values" {
+  description = "The parameter values map for the copied GeminiDB parameter template"
+  type        = map(string)
+  default     = {
+    request_timeout_in_ms = "10000"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a best practice for creating geminidb parameter template copy

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a best practice for creating geminidb parameter template copy
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

terraform apply：
<img width="1205" height="910" alt="image" src="https://github.com/user-attachments/assets/a6546e2f-f34d-467e-81e4-6f3a7bd96e84" />
<img width="991" height="594" alt="image" src="https://github.com/user-attachments/assets/b0e04fc1-bdc4-4172-96f6-af1106e614af" />
terraform destroy：
<img width="1513" height="897" alt="image" src="https://github.com/user-attachments/assets/af307d0e-edf1-47ad-b46e-71fea14ff871" />
<img width="1387" height="931" alt="image" src="https://github.com/user-attachments/assets/54acef47-face-49a7-8077-89745d29e7f6" />
<img width="1445" height="937" alt="image" src="https://github.com/user-attachments/assets/763fe4ee-7696-4e4b-ae9e-76940e13b3f3" />
<img width="1492" height="939" alt="image" src="https://github.com/user-attachments/assets/23786b4f-47fa-44e9-bcba-2b5865f526df" />
<img width="1476" height="935" alt="image" src="https://github.com/user-attachments/assets/130d1972-7504-4765-9cce-fc5f0feac33d" />
<img width="1161" height="889" alt="image" src="https://github.com/user-attachments/assets/9423c2ff-c7e6-405f-a4e4-00d58b741790" />
<img width="1510" height="932" alt="image" src="https://github.com/user-attachments/assets/0682c9de-7a9d-48a8-b552-d3c045f87216" />
<img width="1082" height="927" alt="image" src="https://github.com/user-attachments/assets/76fa5ee8-5488-4c53-bdd1-dca6df1d67f8" />
<img width="1423" height="951" alt="image" src="https://github.com/user-attachments/assets/19a57f98-9799-43ec-b6cc-5158fe815114" />
<img width="1478" height="946" alt="image" src="https://github.com/user-attachments/assets/1849bda6-35c5-4760-927e-284d4f6be822" />
<img width="1194" height="948" alt="image" src="https://github.com/user-attachments/assets/6f4e5cca-823a-4f0e-b7e5-714e61aa9849" />
<img width="1069" height="709" alt="image" src="https://github.com/user-attachments/assets/25232826-0a49-444b-a495-96265ca4a4cb" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
