### PR TITLE
feat(dds): the parameter template resource supports new fields

### DIFF
--- a/docs/resources/dds_parameter_template.md
+++ b/docs/resources/dds_parameter_template.md
@@ -2,7 +2,8 @@
 subcategory: "Document Database Service (DDS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_dds_parameter_template"
-description: ""
+description: |-
+  Manages a DDS parameter template resource within HuaweiCloud.
 ---
 
 # huaweicloud_dds_parameter_template
@@ -11,9 +12,13 @@ Manages a DDS parameter template resource within HuaweiCloud.
 
 ## Example Usage
 
+### Basic Example
+
 ```hcl
 variable "name" {}
-variable "parameter_values" {}
+variable "parameter_values" {
+  type = map(string)
+}
 variable "node_type" {}
 variable "node_version" {}
 
@@ -25,6 +30,18 @@ resource "huaweicloud_dds_parameter_template" "test"{
 }
 ```
 
+### Create a parameter template with entity ID
+
+```hcl
+variable "name" {}
+variable "entity_id" {}
+
+resource "huaweicloud_dds_parameter_template" "test"{
+  name      = var.name
+  entity_id = var.entity_id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -33,28 +50,44 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
 * `name` - (Required, String) Specifies the parameter template name.
-  The value must be 1 to 64 characters, which can contain only letters, digits, hyphens (-),
+  The value must be `1` to `64` characters, which can contain only letters (case-sensitive), digits, hyphens (-),
   underscores (_), and periods (.).
 
-* `node_type` - (Required, String, ForceNew) Specifies the node type of parameter template. Valid value:
+* `node_type` - (Optional, String, ForceNew) Specifies the node type of parameter template.
+  Changing this parameter will create a new resource.
+  The valid values ara as follows:
   + **mongos**: the mongos node type.
   + **shard**: the shard node type.
   + **config**: the config node type.
   + **replica**: the replica node type.
+  + **readonly**: the read replica type of a replica set instance.
+  + **shard_readonly**: the read replica type of a cluster instance.
   + **single**: the single node type.
 
-  Changing this parameter will create a new resource.
+  -> This parameter is mandatory when `entity_id` is not specified.
 
-* `node_version` - (Required, String, ForceNew) Specifies the database version.
-  The value can be **4.4**, **4.2**, **4.0**, **3.4** or **3.2**.
-
+* `node_version` - (Optional, String, ForceNew) Specifies the database version.
   Changing this parameter will create a new resource.
+  The value can be **5.0**, **4.4**, **4.2**, **4.0**, **3.4**.
+
+  -> This parameter is mandatory when `entity_id` is not specified.
 
 * `parameter_values` - (Optional, Map) Specifies the mapping between parameter names and parameter values.
   You can customize parameter values based on the parameters in the default parameter template.
 
+  -> This parameter is mandatory when `entity_id` is not specified.
+
+* `entity_id` - (Optional, String, ForceNew) Specifies the instance ID, group ID, or node ID.
+
+  -> 1.If this parameter is specified, the parameter template is created based on the parameter information of
+    the instance, group, or node. The `parameter_values`, `node_type` and `node_version` parameters are ignored.
+    <br/>2.If the instance type is cluster, the value is the ID of the shard or config group, ID of the mongos node,
+    or ID of the read replica.
+    <br/>3.If the instance type is replica set, the value is the instance ID or ID of the read replica.
+    <br/>4.If the instance type is single node, the value is the instance ID.
+
 * `description` - (Optional, String) Specifies the parameter template description.
-  The description must consist of a maximum of 256 characters and cannot contain the carriage
+  The description must consist of a maximum of `256` characters and cannot contain the carriage
   return character or the following special characters: >!<"&'=.
 
 ## Attribute Reference
@@ -66,9 +99,11 @@ In addition to all arguments above, the following attributes are exported:
 * `parameters` - Indicates the parameters defined by users based on the default parameter templates.
   The [Parameter](#DdsParameterTemplate_Parameter) structure is documented below.
 
-* `created_at` - The create time of the parameter template.
+* `datastore_name` - Indicates database type.
 
-* `updated_at` - The update time of the parameter template.
+* `created_at` - Indicates the creation time of the parameter template.
+
+* `updated_at` - Indicates the update time of the parameter template.
 
 <a name="DdsParameterTemplate_Parameter"></a>
 The `Parameter` block supports:
@@ -79,7 +114,12 @@ The `Parameter` block supports:
 
 * `description` - Indicates the parameter description.
 
-* `type` - Indicates the parameter type. The value can be integer, string, boolean, float, or list.
+* `type` - Indicates the parameter type.
+  + **integer**
+  + **string**
+  + **boolean**
+  + **float**
+  + **list**
 
 * `value_range` - Indicates the value range.
 
@@ -96,5 +136,23 @@ The `Parameter` block supports:
 The DDS parameter template can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_dds_parameter_template.test <tempalate_id>
+$ terraform import huaweicloud_dds_parameter_template.test <id>
 ```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `node_type`, `parameter_values`, `entity_id`.
+It is generally recommended running `terraform plan` after importing an instance.
+You can then decide if changes should be applied to the instance, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dds_parameter_template" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      node_type, parameter_values, entity_id,
+    ]
+  }
+}

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_parameter_template_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_parameter_template_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -137,4 +138,114 @@ resource "huaweicloud_dds_parameter_template" "test" {
   }
 }
 `, name)
+}
+
+func TestAccDdsParameterTemplate_withEntityId(t *testing.T) {
+	var (
+		obj        interface{}
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		rName      = "huaweicloud_dds_parameter_template.test"
+
+		rc = acceptance.InitResourceCheck(
+			rName,
+			&obj,
+			getDdsParameterTemplateResourceFunc,
+		)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDdsParameterTemplate_withEntityId_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "entity_id", "huaweicloud_dds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test"),
+				),
+			},
+			{
+				Config: testAccDdsParameterTemplate_withEntityId_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "parameters.0.name", "connPoolMaxConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.value", "800"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.name", "cursorTimeoutMillis"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.value", "800000"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"entity_id", "parameter_values"},
+			},
+		},
+	})
+}
+
+func testAccDdsParameterTemplate_withEntityId_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dds_instance" "test" {
+  name                  = "%[2]s"
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  password              = "Terraform@123"
+  mode                  = "ReplicaSet"
+  enterprise_project_id = "%[3]s"
+
+  datastore {
+    type           = "DDS-Community"
+    version        = "4.0"
+    storage_engine = "wiredTiger"
+  }
+
+  flavor {
+    type      = "replica"
+    storage   = "ULTRAHIGH"
+    num       = 3
+    size      = 10
+    spec_code = "dds.mongodb.s6.large.2.repset"
+  }
+}`, common.TestBaseNetwork(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccDdsParameterTemplate_withEntityId_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dds_parameter_template" "test" {
+  name        = "%[2]s"
+  entity_id   = huaweicloud_dds_instance.test.id
+  description = "terraform test"
+}
+`, testAccDdsParameterTemplate_withEntityId_base(name), name)
+}
+
+func testAccDdsParameterTemplate_withEntityId_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dds_parameter_template" "test" {
+  name        = "%s"
+  entity_id   = huaweicloud_dds_instance.test.id
+  description = ""
+
+  parameter_values = {
+    connPoolMaxConnsPerHost = 800
+    cursorTimeoutMillis     = 800000
+  }
+}
+`, testAccDdsParameterTemplate_withEntityId_base(name), name)
 }

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template.go
@@ -49,13 +49,14 @@ func ResourceDdsParameterTemplate() *schema.Resource {
 			},
 			"node_type": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 				Description: `Specifies the node type of parameter template.`,
 			},
 			"node_version": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: `Specifies the database version.`,
 			},
@@ -70,19 +71,32 @@ func ResourceDdsParameterTemplate() *schema.Resource {
 				Optional:    true,
 				Description: `Specifies the parameter template description.`,
 			},
+			"entity_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the instance ID or group ID or node ID.`,
+			},
 			"parameters": {
 				Type:        schema.TypeList,
 				Elem:        ParameterTemplateParameterSchema(),
 				Computed:    true,
 				Description: `Indicates the parameters defined by users based on the default parameter templates.`,
 			},
+			"datastore_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the database type.`,
+			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creation time of the parameter template.`,
 			},
 			"updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the update time of the parameter template.`,
 			},
 		},
 	}
@@ -177,18 +191,25 @@ func resourceDdsParameterTemplateCreate(ctx context.Context, d *schema.ResourceD
 }
 
 func buildCreateParameterTemplateBodyParams(d *schema.ResourceData) map[string]interface{} {
-	datastoreParams := map[string]interface{}{
-		"node_type": utils.ValueIgnoreEmpty(d.Get("node_type")),
-		"version":   utils.ValueIgnoreEmpty(d.Get("node_version")),
-	}
 	bodyParams := map[string]interface{}{
 		"name": utils.ValueIgnoreEmpty(d.Get("name")),
 		// this param can be empty
 		"parameter_values": d.Get("parameter_values"),
+		"entity_id":        utils.ValueIgnoreEmpty(d.Get("entity_id")),
 		"description":      utils.ValueIgnoreEmpty(d.Get("description")),
-		"datastore":        datastoreParams,
+		"datastore":        buildParameterTemplateDatastoreBodyParams(d),
 	}
+
 	return bodyParams
+}
+
+func buildParameterTemplateDatastoreBodyParams(d *schema.ResourceData) map[string]interface{} {
+	datastoreParams := map[string]interface{}{
+		"node_type": utils.ValueIgnoreEmpty(d.Get("node_type")),
+		"version":   utils.ValueIgnoreEmpty(d.Get("node_version")),
+	}
+
+	return utils.RemoveNil(datastoreParams)
 }
 
 func resourceDdsParameterTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -280,10 +301,9 @@ func resourceDdsParameterTemplateRead(_ context.Context, d *schema.ResourceData,
 		mErr,
 		d.Set("region", region),
 		d.Set("name", utils.PathSearch("name", getParameterTemplateRespBody, nil)),
-		d.Set("node_version", utils.PathSearch("datastore_version",
-			getParameterTemplateRespBody, nil)),
-		d.Set("description", utils.PathSearch("description",
-			getParameterTemplateRespBody, nil)),
+		d.Set("node_version", utils.PathSearch("datastore_version", getParameterTemplateRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getParameterTemplateRespBody, nil)),
+		d.Set("datastore_name", utils.PathSearch("datastore_name", getParameterTemplateRespBody, nil)),
 		d.Set("parameters", flattenGetParameterTemplateResponseBodyParameter(getParameterTemplateRespBody)),
 		d.Set("created_at", utils.PathSearch("created", getParameterTemplateRespBody, nil)),
 		d.Set("updated_at", utils.PathSearch("updated", getParameterTemplateRespBody, nil)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The parameter template resource supports new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  parameter template resource supports new fields: `entity_id`, `datastore_name`.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o dds -f TestAccDdsParameterTemplate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dds" -v -coverprofile="./huaweicloud/services/acceptance/dds/dds_coverage.cov" -coverpkg="./huaweicloud/services/dds" -run TestAccDdsParameterTemplate_basic -timeout 360m -parallel 10
=== RUN   TestAccDdsParameterTemplate_basic
=== PAUSE TestAccDdsParameterTemplate_basic
=== CONT  TestAccDdsParameterTemplate_basic
--- PASS: TestAccDdsParameterTemplate_basic (21.60s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       23.138s coverage: 3.7% of statements in ./huaweicloud/services/dds
```
```
$ ./scripts/coverage.sh -o dds -f TestAccDdsParameterTemplate_withEntityId
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dds" -v -coverprofile="./huaweicloud/services/acceptance/dds/dds_coverage.cov" -coverpkg="./huaweicloud/services/dds" -run TestAccDdsParameterTemplate_withEntityId -timeout 360m -parallel 10
=== RUN   TestAccDdsParameterTemplate_withEntityId
=== PAUSE TestAccDdsParameterTemplate_withEntityId
=== CONT  TestAccDdsParameterTemplate_withEntityId
--- PASS: TestAccDdsParameterTemplate_withEntityId (691.08s)
PASS
coverage: 9.1% of statements in ./huaweicloud/services/dds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       692.780s        coverage: 9.1% of statements in ./huaweicloud/services/dds
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
