### PR TITLE
fix(coding): correct error handling and resource id consistency

### DIFF
--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_metric_data.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_metric_data.go
@@ -185,7 +185,7 @@ func dataSourceInstanceMetricDataRead(_ context.Context, d *schema.ResourceData,
 
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 
 	randomUUID, err := uuid.GenerateUUID()

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
@@ -574,7 +574,7 @@ func resourceNodeCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	// Add loginSpec here so it wouldn't go in the above log entry
 	loginSpec, err := buildResourceNodeLoginSpec(d)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 	createOpts.Spec.Login = loginSpec
 

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
@@ -449,7 +449,7 @@ func buildNodeAttachCreateOpts(d *schema.ResourceData) (*nodes.AddOpts, error) {
 	// Add loginSpec here so it wouldn't go in the above log entry
 	loginSpec, err := buildResourceNodeLoginSpec(d)
 	if err != nil {
-		diag.FromErr(err)
+		return &result, err
 	}
 	result.NodeList[0].Spec.Login = loginSpec
 	return &result, nil
@@ -535,7 +535,7 @@ func buildNodeAttachUpdateOpts(d *schema.ResourceData) (*nodes.ResetOpts, error)
 	// Add loginSpec here so it wouldn't go in the above log entry
 	loginSpec, err := buildResourceNodeLoginSpec(d)
 	if err != nil {
-		diag.FromErr(err)
+		return &result, err
 	}
 	result.NodeList[0].Spec.Login = loginSpec
 	return &result, nil
@@ -675,7 +675,7 @@ func resourceNodeAttachDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	loginSpec, err = buildResourceNodeLoginSpec(d)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 	removeOpts.Spec.Login = loginSpec
 

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_owner_verification.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_owner_verification.go
@@ -97,7 +97,7 @@ func dataSourceDomainOwnerVerificationRead(_ context.Context, d *schema.Resource
 
 	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 
 	randomUUID, err := uuid.GenerateUUID()

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_black_white_list.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_black_white_list.go
@@ -202,7 +202,7 @@ func resourceBlackWhiteListRead(_ context.Context, d *schema.ResourceData, meta 
 
 	val, ok := lists.([]interface{})
 	if !ok {
-		diag.Errorf("data.records is not a list, data.records= %#v", lists)
+		return diag.Errorf("data.records is not a list, data.records= %#v", lists)
 	}
 
 	if len(val) != 1 {

--- a/huaweicloud/services/css/resource_huaweicloud_css_logstash_configuration.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_logstash_configuration.go
@@ -241,7 +241,7 @@ func resourceLogstashConfigurationUpdate(ctx context.Context, d *schema.Resource
 	updateLogstashConfigOpt.JSONBody = utils.RemoveNil(buildCreateLogstashCnfParameters(d))
 	_, err = client.Request("POST", updateLogstashConfigPath, &updateLogstashConfigOpt)
 	if err != nil {
-		diag.Errorf("error updating CSS logstash cluster configuration: %s", err)
+		return diag.Errorf("error updating CSS logstash cluster configuration: %s", err)
 	}
 
 	checkErr := configFileStatusCheck(ctx, d, client)
@@ -274,7 +274,7 @@ func resourceLogstashConfigurationDelete(_ context.Context, d *schema.ResourceDa
 	}
 	_, err = client.Request("DELETE", deleteLogstashConfigPath, &deleteLogstashConfigOpt)
 	if err != nil {
-		diag.Errorf("error updating CSS logstash cluster configuration: %s", err)
+		return diag.Errorf("error updating CSS logstash cluster configuration: %s", err)
 	}
 	if err != nil {
 		// 1. "CSS.0001" : Incorrect parameters. Status code is 400.

--- a/huaweicloud/services/dbss/resource_huaweicloud_dbss_rds_database.go
+++ b/huaweicloud/services/dbss/resource_huaweicloud_dbss_rds_database.go
@@ -297,7 +297,7 @@ func resourceAddRdsDatabaseUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	if d.HasChanges("status", "lts_audit_switch") {
 		if databaseId == "" {
-			diag.Errorf("edit audit status is not currently supported: 'db_id' is not found in API response")
+			return diag.Errorf("edit audit status is not currently supported: 'db_id' is not found in API response")
 		}
 		err := updateAuditStatus(client, d, instanceId, databaseId)
 		if err != nil {

--- a/huaweicloud/services/ddm/data_source_huaweicloud_ddm_available_rds_instances.go
+++ b/huaweicloud/services/ddm/data_source_huaweicloud_ddm_available_rds_instances.go
@@ -121,7 +121,7 @@ func resourceDdmAvailableRdsInstancesRead(_ context.Context, d *schema.ResourceD
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		diag.Errorf("error retrieving DDM instance available rds instances: %s", err)
+		return diag.Errorf("error retrieving DDM instance available rds instances: %s", err)
 	}
 
 	getDdmAvailableRdsInstancesRespJson, err := json.Marshal(getDdmAvailableRdsInstancesResp)

--- a/huaweicloud/services/ddm/data_source_huaweicloud_ddm_configurations.go
+++ b/huaweicloud/services/ddm/data_source_huaweicloud_ddm_configurations.go
@@ -97,7 +97,7 @@ func resourceDdmConfigurationsRead(_ context.Context, d *schema.ResourceData, me
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		diag.Errorf("error retrieving DDM configurations: %s", err)
+		return diag.Errorf("error retrieving DDM configurations: %s", err)
 	}
 
 	getDdmConfigurationsRespJson, err := json.Marshal(getDdmConfigurationsResp)

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_key_material.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_key_material.go
@@ -183,7 +183,7 @@ func ResourceKmsKeyMaterialDelete(_ context.Context, d *schema.ResourceData, met
 		}
 	}
 	if err != nil {
-		diag.Errorf("error deleting key material (%s): %s", d.Id(), err)
+		return diag.Errorf("error deleting key material (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -189,7 +189,7 @@ func resourceElasticResourcePoolCreate(ctx context.Context, d *schema.ResourceDa
 
 	err = waitForElasticResourcePoolStatusCompleted(ctx, client, d)
 	if err != nil {
-		diag.Errorf("error waiting for the elastic resource pool (%s) status to become success: %s", resourceId, err)
+		return diag.Errorf("error waiting for the elastic resource pool (%s) status to become success: %s", resourceId, err)
 	}
 
 	return resourceElasticResourcePoolRead(ctx, d, meta)
@@ -551,7 +551,7 @@ func resourceElasticResourcePoolDelete(ctx context.Context, d *schema.ResourceDa
 
 	err = waitForElasticResourcePoolDeleted(ctx, client, d)
 	if err != nil {
-		diag.Errorf("error waiting for the elastic resource pool (%s) status to become deleted: %s", resourceName, err)
+		return diag.Errorf("error waiting for the elastic resource pool (%s) status to become deleted: %s", resourceName, err)
 	}
 	return nil
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_application.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_application.go
@@ -397,7 +397,7 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	err = waitForApplicationDeleteCompleted(ctx, client, appId, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		diag.Errorf("error waiting for the application (%s) status to become deleted: %s", appId, err)
+		return diag.Errorf("error waiting for the application (%s) status to become deleted: %s", appId, err)
 	}
 	return nil
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger.go
@@ -336,7 +336,7 @@ func resourceFunctionTriggerUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = waitForFunctionTriggerStatusCompleted(ctx, client, d)
 	if err != nil {
-		diag.Errorf("error waiting for the function trigger (%s) status to become available: %s", triggerId, err)
+		return diag.Errorf("error waiting for the function trigger (%s) status to become available: %s", triggerId, err)
 	}
 	return nil
 }
@@ -415,7 +415,7 @@ func resourceFunctionTriggerDelete(ctx context.Context, d *schema.ResourceData, 
 
 	err = waitForFunctionTriggerDeleted(ctx, fgsClient, d)
 	if err != nil {
-		diag.Errorf("error waiting for the function trigger (%s) status to become deleted: %s", triggerId, err)
+		return diag.Errorf("error waiting for the function trigger (%s) status to become deleted: %s", triggerId, err)
 	}
 	return nil
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger_status_action.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger_status_action.go
@@ -131,7 +131,7 @@ func resourceFunctionTriggerStatusActionCreate(ctx context.Context, d *schema.Re
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		diag.Errorf("error waiting for the function trigger (%s) status to become expected value (%s): %s",
+		return diag.Errorf("error waiting for the function trigger (%s) status to become expected value (%s): %s",
 			triggerId, triggerStatus, err)
 	}
 

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider_protocol.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider_protocol.go
@@ -115,6 +115,7 @@ func resourceV3ProviderProtocolCreate(ctx context.Context, d *schema.ResourceDat
 		if strings.Contains(err.Error(), "got 409") && strings.Contains(err.Error(), conflictMsg) {
 			log.Printf("protocol `%s` of identity provider `%s` has already existed. Now Update it with mapping `%s`",
 				idpId, protocolId, mappingId)
+			d.SetId(fmt.Sprintf("%s:%s", idpId, protocolId))
 			return resourceV3ProviderProtocolUpdate(ctx, d, meta)
 		}
 		return diag.Errorf("CreateProtocol error : %s", err)

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_temporary_access_key.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_temporary_access_key.go
@@ -161,7 +161,7 @@ func buildCreateSecurityTokensBodyParams(d *schema.ResourceData) map[string]inte
 func resourceIdentityTemporaryRead(c context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	expiresAt, err := time.ParseInLocation(`2006-01-02T15:04:05Z`, d.Get("expires_at").(string), time.UTC)
 	if err != nil {
-		diag.Errorf("error parsing expires at: %s", err)
+		return diag.Errorf("error parsing expires at: %s", err)
 	}
 	if time.Now().After(expiresAt) {
 		return resourceIdentityTemporaryCreate(c, d, meta)

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_user_role_assignment.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_user_role_assignment.go
@@ -66,7 +66,7 @@ func resourceIdentityUserRoleAssignmentCreate(ctx context.Context, d *schema.Res
 			roleID, enterpriseProjectID, userID, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s/%s", enterpriseProjectID, roleID, userID))
+	d.SetId(fmt.Sprintf("%s/%s/%s", userID, roleID, enterpriseProjectID))
 
 	return resourceIdentityUserRoleAssignmentRead(ctx, d, meta)
 }
@@ -85,8 +85,6 @@ func resourceIdentityUserRoleAssignmentRead(_ context.Context, d *schema.Resourc
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error getting role assignment")
 	}
-
-	d.SetId(fmt.Sprintf("%s/%s/%s", userID, roleID, enterpriseProjectID))
 
 	mErr := multierror.Append(nil,
 		d.Set("role_id", role.ID),
@@ -110,11 +108,18 @@ func GetUserRoleAssignmentWithEpsID(client *golangsdk.ServiceClient, userID, rol
 	for _, role := range roles {
 		if role.ID == roleID {
 			assignment = role
-			break
+			return assignment, nil
 		}
 	}
 
-	return assignment, nil
+	return assignment, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v3.0/OS-PERMISSION/enterprise-projects/{enterprise_project_id}/users/{user_id}/roles",
+			RequestId: "NONE",
+			Body:      fmt.Appendf(nil, "the role assignment (%s/%s/%s) does not exist", userID, roleID, enterpriseProjectID),
+		},
+	}
 }
 
 func resourceIdentityUserRoleAssignmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -142,13 +147,15 @@ func resourceIdentityUserRoleAssignmentDelete(_ context.Context, d *schema.Resou
 func resourceIdentityUserRoleAssignmentImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid format specified for import id," +
-			" must be <user_id>/<role_id>/<enterprise_project_id>")
+		return nil, fmt.Errorf("invalid format specified for import ID, want "+
+			"'<user_id>/<role_id>/<enterprise_project_id>', but got '%s'", d.Id())
 	}
 
-	d.Set("user_id", parts[0])
-	d.Set("role_id", parts[1])
-	d.Set("enterprise_project_id", parts[2])
+	mErr := multierror.Append(nil,
+		d.Set("user_id", parts[0]),
+		d.Set("role_id", parts[1]),
+		d.Set("enterprise_project_id", parts[2]),
+	)
 
-	return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_l7rule.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_l7rule.go
@@ -174,7 +174,7 @@ func resourceL7RuleV2Create(ctx context.Context, d *schema.ResourceData, meta in
 	// Wait for L7 Rule to become active before continuing
 	err = waitForLBV2L7Rule(ctx, lbClient, parentListener, parentL7Policy, l7Rule, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(l7Rule.ID)

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
@@ -234,7 +234,7 @@ func resourceWAFAccessDelete(_ context.Context, d *schema.ResourceData, meta int
 
 	_, err = client.Request("PUT", deletePath, &deleteOpt)
 	if err != nil {
-		diag.Errorf("error deleting LTS access WAF logs configuration: %s", err)
+		return diag.Errorf("error deleting LTS access WAF logs configuration: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
@@ -618,7 +618,7 @@ func resourceDevServerDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	err = waitForDevServerDeleted(ctx, client, devServerId, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		diag.Errorf("error waiting for the DevServer (%s) deletion to complete: %s", devServerId, err)
+		return diag.Errorf("error waiting for the DevServer (%s) deletion to complete: %s", devServerId, err)
 	}
 
 	return nil

--- a/huaweicloud/services/oms/resource_huaweicloud_oms_migration_task.go
+++ b/huaweicloud/services/oms/resource_huaweicloud_oms_migration_task.go
@@ -561,7 +561,7 @@ func resourceMigrationTaskCreate(ctx context.Context, d *schema.ResourceData, me
 
 	createOpts, err := buildcreateTaskBodyParams(d, cfg)
 	if err != nil {
-		return nil
+		return diag.Errorf("error building migration task body params: %s", err)
 	}
 
 	log.Printf("[DEBUG] Create Task options: %#v", createOpts)

--- a/huaweicloud/services/oms/resource_huaweicloud_oms_migration_task_group.go
+++ b/huaweicloud/services/oms/resource_huaweicloud_oms_migration_task_group.go
@@ -460,7 +460,7 @@ func resourceMigrationTaskGroupCreate(ctx context.Context, d *schema.ResourceDat
 
 	createOpts, err := buildTaskGroupCreateOpts(cfg, d)
 	if err != nil {
-		return nil
+		return diag.Errorf("error building migration task group body params: %s", err)
 	}
 
 	log.Printf("[DEBUG] Create Task Group options: %#v", createOpts)
@@ -475,12 +475,10 @@ func resourceMigrationTaskGroupCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id := utils.PathSearch("group_id", createTaskGroupRespBody, nil)
-	if id == nil {
+	groupID := utils.PathSearch("group_id", createTaskGroupRespBody, "").(string)
+	if groupID == "" {
 		return diag.Errorf("error creating OMS migration task group: ID is not found in API response")
 	}
-
-	groupID := id.(string)
 
 	d.SetId(groupID)
 

--- a/huaweicloud/services/rgc/resource_huaweicloud_rgc_control.go
+++ b/huaweicloud/services/rgc/resource_huaweicloud_rgc_control.go
@@ -103,7 +103,7 @@ func resourceControlCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	body, err := buildControlBodyParams(d)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 	enableControlOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -220,7 +220,7 @@ func resourceControlDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	body, err := buildControlBodyParams(d)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 	disableControlOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/smn/resource_huaweicloud_smn_topic.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_topic.go
@@ -131,7 +131,7 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	// set policies
 	err = updatePolicies(client, d, d.Id())
 	if err != nil {
-		diag.Errorf("error updating the policies of topic: %s", err)
+		return diag.Errorf("error updating the policies of topic: %s", err)
 	}
 
 	// set tags
@@ -267,7 +267,7 @@ func resourceTopicUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	if d.HasChanges("access_policy", "users_publish_allowed", "services_publish_allowed", "introduction") {
 		err := updatePolicies(client, d, id)
 		if err != nil {
-			diag.Errorf("error updating the policies of topic: %s", err)
+			return diag.Errorf("error updating the policies of topic: %s", err)
 		}
 	}
 

--- a/huaweicloud/services/sms/data_source_huaweicloud_sms_source_servers.go
+++ b/huaweicloud/services/sms/data_source_huaweicloud_sms_source_servers.go
@@ -151,7 +151,7 @@ func dataSourceServersRead(_ context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err := d.Set("servers", stateServers); err != nil {
-		diag.Errorf("error setting SMS source servers: %s", err)
+		return diag.Errorf("error setting SMS source servers: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
@@ -159,7 +159,7 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 
 	res, err := obtainV3VpcResp(v3Client, d.Id())
 	if err != nil {
-		diag.Errorf("error retrieving VPC (%s) v3 detail: %s", d.Id(), err)
+		return diag.Errorf("error retrieving VPC (%s) v3 detail: %s", d.Id(), err)
 	}
 	d.Set("secondary_cidrs", utils.PathSearch("vpc.extend_cidrs", res, nil))
 

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
@@ -165,7 +165,7 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 		// save VirtualPrivateCloudV3 extend_cidr
 		res, err := obtainV3VpcResp(v3Client, vpcResource.ID)
 		if err != nil {
-			diag.Errorf("error retrieving VPC (%s) v3 detail: %s", vpcResource.ID, err)
+			return diag.Errorf("error retrieving VPC (%s) v3 detail: %s", vpcResource.ID, err)
 		}
 		queriedVpc["secondary_cidrs"] = utils.PathSearch("vpc.extend_cidrs", res, nil)
 

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_terminal_binding.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_terminal_binding.go
@@ -169,7 +169,7 @@ func resourceTerminalBindingRead(_ context.Context, d *schema.ResourceData, meta
 
 	configStatus, err := terminals.GetConfig(client)
 	if err != nil {
-		diag.Errorf("error getting terminal binding configuration: %s", err)
+		return diag.Errorf("error getting terminal binding configuration: %s", err)
 	}
 
 	opts := terminals.ListOpts{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There are some incorrect errors pending provider to fix:

- OMS migration task/group: return diagnostics when building create request body fails
  instead of silently returning nil.
- SMN topic: return diagnostics when access/introduction policy updates fail on create
  and update.
- IAM identity provider protocol: set resource ID before falling back to update on 409
  conflict during create.
- IAM user role assignment: align create ID format with read/import
  (user_id/role_id/enterprise_project_id); return 404 when the assignment is missing
  so deleted resources are removed from state.
- Workspace terminal binding: return diagnostics when fetching binding configuration
  fails during read.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. correct error handling and resource id consistency
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV3ProviderProtocol_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3ProviderProtocol_basic -timeout 360m -parallel 10
=== RUN   TestAccV3ProviderProtocol_basic
=== PAUSE TestAccV3ProviderProtocol_basic
=== CONT  TestAccV3ProviderProtocol_basic
--- PASS: TestAccV3ProviderProtocol_basic (24.74s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       24.877s coverage: 4.7% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o oms -f TestAccMigrationTask_object
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/oms" -v -coverprofile="./huaweicloud/services/acceptance/oms/oms_coverage.cov" -coverpkg="./huaweicloud/services/oms" -run TestAccMigrationTask_object -timeout 360m -parallel 10
=== RUN   TestAccMigrationTask_object
=== PAUSE TestAccMigrationTask_object
=== CONT  TestAccMigrationTask_object
--- PASS: TestAccMigrationTask_object (127.86s)
PASS
coverage: 15.1% of statements in ./huaweicloud/services/oms
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/oms       127.976s        coverage: 15.1% of statements in ./huaweicloud/services/oms
```
```
./scripts/coverage.sh -o oms -f TestAccMigrationTaskGroup_prefix
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/oms" -v -coverprofile="./huaweicloud/services/acceptance/oms/oms_coverage.cov" -coverpkg="./huaweicloud/services/oms" -run TestAccMigrationTaskGroup_prefix -timeout 360m -parallel 10
=== RUN   TestAccMigrationTaskGroup_prefix
=== PAUSE TestAccMigrationTaskGroup_prefix
=== CONT  TestAccMigrationTaskGroup_prefix
--- PASS: TestAccMigrationTaskGroup_prefix (580.08s)
PASS
coverage: 16.3% of statements in ./huaweicloud/services/oms
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/oms       580.211s        coverage: 16.3% of statements in ./huaweicloud/services/oms
```
```
./scripts/coverage.sh -o smn -f TestAccSMNV2Topic_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/smn" -v -coverprofile="./huaweicloud/services/acceptance/smn/smn_coverage.cov" -coverpkg="./huaweicloud/services/smn" -run TestAccSMNV2Topic_basic -timeout 360m -parallel 10
=== RUN   TestAccSMNV2Topic_basic
=== PAUSE TestAccSMNV2Topic_basic
=== CONT  TestAccSMNV2Topic_basic
--- PASS: TestAccSMNV2Topic_basic (27.06s)
PASS
coverage: 9.2% of statements in ./huaweicloud/services/smn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn       27.181s coverage: 9.2% of statements in ./huaweicloud/services/smn
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
