### PR TITLE
feat(iam): group and user resources support query retries during creation

### DIFF
--- a/docs/resources/identity_group.md
+++ b/docs/resources/identity_group.md
@@ -41,6 +41,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 seconds.
+
 ## Import
 
 Groups can be imported using their `id`, e.g.

--- a/docs/resources/identity_user.md
+++ b/docs/resources/identity_user.md
@@ -83,6 +83,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `last_login` - The time when the IAM user last login.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 seconds.
+
 ## Import
 
 The users can be imported using the `id`, e.g.

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -26,6 +27,10 @@ func ResourceV3Group() *schema.Resource {
 		ReadContext:   resourceV3GroupRead,
 		UpdateContext: resourceV3GroupUpdate,
 		DeleteContext: resourceV3GroupDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Second),
+		},
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -108,7 +113,7 @@ func GetV3GroupById(client *golangsdk.ServiceClient, groupId string) (interface{
 	return utils.FlattenResponse(requestResp)
 }
 
-func resourceV3GroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3GroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
@@ -119,7 +124,28 @@ func resourceV3GroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	group, err := GetV3GroupById(client, groupId)
+	var group interface{}
+	// After creation, the group may not be immediately queryable (usually 2-3s, up to 10s).
+	if d.IsNewResource() {
+		retryFunc := func() (interface{}, bool, error) {
+			resp, err := GetV3GroupById(client, groupId)
+			if err == nil {
+				return resp, false, nil
+			}
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil, true, err
+			}
+			return nil, false, err
+		}
+		group, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			Timeout:      d.Timeout(schema.TimeoutCreate),
+			PollInterval: 3 * time.Second,
+		})
+	} else {
+		group, err = GetV3GroupById(client, groupId)
+	}
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving group (%s)", groupId))
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
@@ -113,6 +114,19 @@ func GetV3GroupById(client *golangsdk.ServiceClient, groupId string) (interface{
 	return utils.FlattenResponse(requestResp)
 }
 
+func refreshV3Group(client *golangsdk.ServiceClient, groupId string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := GetV3GroupById(client, groupId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return "NOT_FOUND", "PENDING", nil
+			}
+			return nil, "ERROR", err
+		}
+		return resp, "COMPLETED", nil
+	}
+}
+
 func resourceV3GroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
@@ -127,22 +141,14 @@ func resourceV3GroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	var group interface{}
 	// After creation, the group may not be immediately queryable (usually 2-3s, up to 10s).
 	if d.IsNewResource() {
-		retryFunc := func() (interface{}, bool, error) {
-			resp, err := GetV3GroupById(client, groupId)
-			if err == nil {
-				return resp, false, nil
-			}
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return nil, true, err
-			}
-			return nil, false, err
+		stateConf := &retry.StateChangeConf{
+			Pending:    []string{"PENDING"},
+			Target:     []string{"COMPLETED"},
+			Refresh:    refreshV3Group(client, groupId),
+			Timeout:    d.Timeout(schema.TimeoutCreate),
+			MinTimeout: 1 * time.Second,
 		}
-		group, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
-			Ctx:          ctx,
-			RetryFunc:    retryFunc,
-			Timeout:      d.Timeout(schema.TimeoutCreate),
-			PollInterval: 3 * time.Second,
-		})
+		group, err = stateConf.WaitForStateContext(ctx)
 	} else {
 		group, err = GetV3GroupById(client, groupId)
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -32,6 +34,10 @@ func ResourceIdentityUser() *schema.Resource {
 		ReadContext:   resourceUserRead,
 		UpdateContext: resourceUserUpdate,
 		DeleteContext: resourceUserDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Second),
+		},
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -214,22 +220,52 @@ func updateLoginProtect(client *golangsdk.ServiceClient, userID, method string) 
 	return nil
 }
 
-func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func refreshIdentityUser(client *golangsdk.ServiceClient, userId string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := users.Get(client, userId).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return "NOT_FOUND", "PENDING", nil
+			}
+			return nil, "ERROR", err
+		}
+		return resp, "COMPLETED", nil
+	}
+}
+
+func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	iamClient, err := cfg.IAMV3Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	user, err := users.Get(iamClient, d.Id()).Extract()
+	var (
+		resp   interface{}
+		method string
+		userId = d.Id()
+	)
+	// After creation, the user may not be immediately queryable (usually 2-3s, up to 10s).
+	if d.IsNewResource() {
+		stateConf := &retry.StateChangeConf{
+			Pending:    []string{"PENDING"},
+			Target:     []string{"COMPLETED"},
+			Refresh:    refreshIdentityUser(iamClient, userId),
+			Timeout:    d.Timeout(schema.TimeoutCreate),
+			MinTimeout: 1 * time.Second,
+		}
+		resp, err = stateConf.WaitForStateContext(ctx)
+	} else {
+		resp, err = users.Get(iamClient, userId).Extract()
+	}
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "user")
 	}
+	user := resp.(*users.User)
 
-	method := ""
-	loginProtect, err := users.GetLoginProtect(iamClient, d.Id()).ExtractLoginProtect()
+	loginProtect, err := users.GetLoginProtect(iamClient, userId).ExtractLoginProtect()
 	if err != nil {
-		log.Printf("[WARN] failed to get the login verification method of user (%s): %s", d.Id(), err)
+		log.Printf("[WARN] failed to get the login verification method of user (%s): %s", userId, err)
 	} else if loginProtect.VerificationMethod != "none" {
 		method = loginProtect.VerificationMethod
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Because of the read-write separation mechanism of the IAM API, data needs some time to be written to the database after a successful POST request. Therefore, if you query the relevant resource immediately (within an interval of 0.01 to 0.015 seconds), there is a chance that the resource will not be found (returning a 404 error).

Currently, we employ the following exponential polling strategy: 1s -> 2s (expected) -> 4s -> 8s

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. group and user resources support query retries during creation
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV3Group_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3Group_basic -timeout 360m -parallel 10
=== RUN   TestAccV3Group_basic
=== PAUSE TestAccV3Group_basic
=== CONT  TestAccV3Group_basic
--- PASS: TestAccV3Group_basic (31.45s)
PASS
coverage: 2.5% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       31.583s coverage: 2.5% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccIdentityUser_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccIdentityUser_basic -timeout 360m -parallel 10
=== RUN   TestAccIdentityUser_basic
=== PAUSE TestAccIdentityUser_basic
=== CONT  TestAccIdentityUser_basic
--- PASS: TestAccIdentityUser_basic (49.56s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       49.737s coverage: 3.0% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
