### PR TITLE
feat(iam): support new data source to query groups

### DIFF
--- a/docs/data-sources/identity_groups.md
+++ b/docs/data-sources/identity_groups.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_identity_groups"
+description: |-
+  Use this data source to get the list of the IAM user groups.
+---
+
+# huaweicloud_identity_groups
+
+Use this data source to get the list of the IAM user groups.
+
+## Example Usage
+
+### Query all user groups
+
+```hcl
+data "huaweicloud_identity_groups" "test" {}
+```
+
+### Query user groups by name
+
+```hcl
+variable "group_name" {}
+
+data "huaweicloud_identity_groups" "test" {
+  name = var.group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, String) Specifies the name of the user group.
+
+* `domain_id` - (Optional, String) Specifies the ID of the account to which the user groups belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `groups` - The list of user groups that match the filter parameters.  
+  The [groups](#identity_user_groups) structure is documented below.
+
+<a name="identity_user_groups"></a>
+The `groups` block supports:
+
+* `id` - The ID of the user group.
+
+* `name` - The name of the user group.
+
+* `description` - The description of the user group.
+
+* `domain_id` - The ID of the account to which the user group belongs.
+
+* `created_at` - The creation time of the user group, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1973,6 +1973,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_federation_projects":          iam.DataSourceIdentityFederationProjects(),
 			"huaweicloud_identity_keystone_metadata_file":       iam.DataSourceIdentityKeystoneMetadataFile(),
 			"huaweicloud_identity_group":                        iam.DataSourceIdentityGroup(),
+			"huaweicloud_identity_groups":                       iam.DataSourceV3Groups(),
 			"huaweicloud_identity_check_agency_role_assignment": iam.DataSourceIdentityCheckAgencyRoleAssignment(),
 			"huaweicloud_identity_check_group_membership":       iam.DataSourceIdentityCheckGroupMembership(),
 			"huaweicloud_identity_check_group_role_assignment":  iam.DataSourceIdentityCheckGroupRoleAssignment(),

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_groups_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_groups_test.go
@@ -1,0 +1,103 @@
+package iam
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV3Groups_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_identity_groups.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_identity_groups.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byDomainId   = "data.huaweicloud_identity_groups.filter_by_domain_id"
+		dcByDomainId = acceptance.InitDataSourceCheck(byDomainId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3Groups_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by name.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byName, "groups.0.id", "huaweicloud_identity_group.test", "id"),
+					resource.TestCheckResourceAttrPair(byName, "groups.0.name", "huaweicloud_identity_group.test", "name"),
+					resource.TestCheckResourceAttrPair(byName, "groups.0.description", "huaweicloud_identity_group.test", "description"),
+					resource.TestCheckResourceAttrSet(byName, "groups.0.domain_id"),
+					resource.TestMatchResourceAttr(byName, "groups.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Filter by domain ID.
+					dcByDomainId.CheckResourceExists(),
+					resource.TestCheckOutput("is_domain_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataV3Groups_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_group" "test" {
+  name        = "%[1]s"
+  description = "created by terraform script"
+}
+
+data "huaweicloud_identity_groups" "test" {
+  depends_on = [huaweicloud_identity_group.test]
+}
+
+# Filter by name parameter.
+locals {
+  group_name = huaweicloud_identity_group.test.name
+}
+
+data "huaweicloud_identity_groups" "filter_by_name" {
+  depends_on = [huaweicloud_identity_group.test]
+
+  name = local.group_name
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_identity_groups.filter_by_name.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_identity_groups.filter_by_name.groups[*].name : v == local.group_name]
+  )
+}
+
+# Filter by domain ID parameter.
+locals {
+  domain_id = "%[2]s"
+}
+
+data "huaweicloud_identity_groups" "filter_by_domain_id" {
+  depends_on = [huaweicloud_identity_group.test]
+
+  domain_id = local.domain_id
+}
+
+output "is_domain_id_filter_useful" {
+  value = length(data.huaweicloud_identity_groups.filter_by_domain_id.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_identity_groups.filter_by_domain_id.groups[*].domain_id : v == local.domain_id]
+  )
+}
+`, name, acceptance.HW_DOMAIN_ID)
+}

--- a/huaweicloud/services/iam/data_source_huaweicloud_identity_groups.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identity_groups.go
@@ -1,0 +1,148 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IAM GET /v3/groups
+func DataSourceV3Groups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3GroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the user group to be queried.`,
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the account to which the user groups belong.`,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the user group.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the user group.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the user group.`,
+						},
+						"domain_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the account to which the user group belongs.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the user group, in RFC3339 format.`,
+						},
+					},
+					Description: `The list of user groups that match the filter parameters.`,
+				},
+			},
+		},
+	}
+}
+
+func buildV3GroupsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("domain_id"); ok {
+		res = fmt.Sprintf("%s&domain_id=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+
+	return res
+}
+
+// The current interface does not support pagination parameters.
+func listV3Groups(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var httpUrl = "v3/groups"
+
+	listPath := client.Endpoint + httpUrl + buildV3GroupsQueryParams(d)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	groups := utils.PathSearch("groups", respBody, make([]interface{}, 0)).([]interface{})
+	return groups, nil
+}
+
+func flattenV3Groups(groups []interface{}) []interface{} {
+	if len(groups) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(groups))
+	for _, group := range groups {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("id", group, nil),
+			"name":        utils.PathSearch("name", group, nil),
+			"description": utils.PathSearch("description", group, nil),
+			"domain_id":   utils.PathSearch("domain_id", group, nil),
+			"created_at":  utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", group, float64(0)).(float64))/1000, false),
+		})
+	}
+	return result
+}
+
+func dataSourceV3GroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("iam", region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	groups, err := listV3Groups(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving groups: %s", err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomId)
+
+	return diag.FromErr(d.Set("groups", flattenV3Groups(groups)))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support a new data source to query groups.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the basic acceptance test:
<img width="1013" height="237" alt="image" src="https://github.com/user-attachments/assets/f9e0ed1a-8dc4-4caa-b7e8-160025e3020e" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new data source to query groups
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccDataV3Groups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV3Groups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3Groups_basic
=== PAUSE TestAccDataV3Groups_basic
=== CONT  TestAccDataV3Groups_basic
--- PASS: TestAccDataV3Groups_basic (8.83s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       8.961s  coverage: 2.7% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
