### PR TITLE
chore(log): degrade the report level for type conversion

### DIFF
--- a/huaweicloud/config/upgrade.go
+++ b/huaweicloud/config/upgrade.go
@@ -116,12 +116,12 @@ func compareVersion(ver1, ver2 string) int {
 	for i := range parts1 {
 		num1, err := strconv.Atoi(parts1[i])
 		if err != nil {
-			log.Printf("[ERROR] failed to parse version: %s", err)
+			log.Printf("[WARN] failed to parse version: %s", err)
 		}
 
 		num2, err := strconv.Atoi(parts2[i])
 		if err != nil {
-			log.Printf("[ERROR] failed to parse latest version: %s", err)
+			log.Printf("[WARN] failed to parse latest version: %s", err)
 		}
 
 		if num1 < num2 {

--- a/huaweicloud/helper/httphelper/offset_page.go
+++ b/huaweicloud/helper/httphelper/offset_page.go
@@ -42,7 +42,7 @@ func (p OffsetPager) NextOffset() int {
 	q := p.URL.Query()
 	offset, err := strconv.Atoi(q.Get(p.OffsetKey))
 	if err != nil {
-		log.Printf("[ERROR] [NextOffset] [%v] failed to parse offset key %q, value: %q, err: %s",
+		log.Printf("[WARN] [NextOffset] [%v] failed to parse offset key %q, value: %q, err: %s",
 			p.uuid, p.OffsetKey, q.Get(p.OffsetKey), err)
 	}
 	if offset == 0 {
@@ -52,7 +52,7 @@ func (p OffsetPager) NextOffset() int {
 	// get `limit` according to the following priority:
 	limit, err := strconv.Atoi(q.Get(p.LimitKey))
 	if err != nil {
-		log.Printf("[ERROR] [NextOffset] [%v] failed to parse limit key %q, value: %q, err: %s",
+		log.Printf("[WARN] [NextOffset] [%v] failed to parse limit key %q, value: %q, err: %s",
 			p.uuid, p.LimitKey, q.Get(p.LimitKey), err)
 	}
 	if limit == 0 {

--- a/huaweicloud/helper/httphelper/pagesize_page.go
+++ b/huaweicloud/helper/httphelper/pagesize_page.go
@@ -34,7 +34,7 @@ func (p PageSizePager) CurrentPageNum() int {
 	q := p.URL.Query()
 	page, err := strconv.Atoi(q.Get(p.PageNumKey))
 	if err != nil {
-		log.Printf("[ERROR] [CurrentPageNum] [%v] failed to parse page num key %q, value: %q, err: %s",
+		log.Printf("[WARN] [CurrentPageNum] [%v] failed to parse page num key %q, value: %q, err: %s",
 			p.uuid, p.PageNumKey, q.Get(p.PageNumKey), err)
 	}
 	if page == 0 {

--- a/huaweicloud/services/aad/resource_huaweicloud_aad_policy_black_white_rule.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_policy_black_white_rule.go
@@ -261,7 +261,7 @@ func resourcePolicyBlackWhiteRuleImportState(_ context.Context, d *schema.Resour
 func convertStringtoInt(s string) int {
 	i, err := strconv.Atoi(s)
 	if err != nil {
-		log.Printf("[ERROR] convert the string %s to int failed.", s)
+		log.Printf("[WARN] convert the string %s to int failed.", s)
 	}
 	return i
 }

--- a/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_policy_black_white_rule_test.go
+++ b/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_policy_black_white_rule_test.go
@@ -34,7 +34,7 @@ func getPolicyBlackWhiteRuleFunc(cfg *config.Config, state *terraform.ResourceSt
 func convertStringtoInt(s string) int {
 	i, err := strconv.Atoi(s)
 	if err != nil {
-		log.Printf("[ERROR] convert the string %s to int failed.", s)
+		log.Printf("[WARN] convert the string %s to int failed.", s)
 	}
 	return i
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinkjar_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinkjar_job_test.go
@@ -24,7 +24,7 @@ func getDliFlinkJarJobResourceFunc(cfg *config.Config, state *terraform.Resource
 	}
 	jobId, err := strconv.Atoi(state.Primary.ID)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse DLI Flink Jar job ID: %s", err)
+		log.Printf("[WARN] failed to parse DLI Flink Jar job ID: %s", err)
 	}
 	return flinkjob.Get(client, jobId)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinksql_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinksql_job_test.go
@@ -22,7 +22,7 @@ func getDliFlinkSqlJobResourceFunc(cfg *config.Config, state *terraform.Resource
 	}
 	jobId, err := strconv.Atoi(state.Primary.ID)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse DLI Flink SQL job ID: %s", err)
+		log.Printf("[WARN] failed to parse DLI Flink SQL job ID: %s", err)
 	}
 	return flinkjob.Get(client, jobId)
 }

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_user_client_quota_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_user_client_quota_test.go
@@ -71,11 +71,11 @@ func filterUserClientQuota(parts []string, resp interface{}) interface{} {
 
 	rawUserDefault, err := strconv.ParseBool(parts[2])
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'user_default' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'user_default' field to Boolean: %s", err)
 	}
 	rawClientDefault, err := strconv.ParseBool(parts[4])
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'client_default' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'client_default' field to Boolean: %s", err)
 	}
 
 	for _, quota := range quotaArray {

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_node_sessions_kill_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_node_sessions_kill_test.go
@@ -39,7 +39,7 @@ func TestAccTaurusDBNodeSessionsKill_basic(t *testing.T) {
 func testAccTaurusDBNodeSessionsKill_basic() string {
 	processId, err := strconv.Atoi(acceptance.HW_TAURUSDB_NODE_SESSION_ID)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse TaurusDB node session ID: %s", err)
+		log.Printf("[WARN] failed to parse TaurusDB node session ID: %s", err)
 	}
 	return fmt.Sprintf(`
 resource "huaweicloud_taurusdb_node_sessions_kill" "test" {

--- a/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_resource_tags_test.go
+++ b/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_resource_tags_test.go
@@ -33,11 +33,11 @@ func getResourceTagsFunc(cfg *config.Config, state *terraform.ResourceState) (in
 
 	resourcesLen, err = strconv.Atoi(state.Primary.Attributes["resources.#"])
 	if err != nil {
-		log.Printf("[ERROR] failed to parse resources length: %s", err)
+		log.Printf("[WARN] failed to parse resources length: %s", err)
 	}
 	tagsLen, err = strconv.Atoi(state.Primary.Attributes["tags.%"])
 	if err != nil {
-		log.Printf("[ERROR] failed to parse tags length: %s", err)
+		log.Printf("[WARN] failed to parse tags length: %s", err)
 	}
 
 	for i := 0; i < resourcesLen; i++ {

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_rule_restriction_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_rule_restriction_test.go
@@ -29,7 +29,7 @@ func getApplicationRuleRestrictionFunc(cfg *config.Config, state *terraform.Reso
 
 	count, err := strconv.Atoi(countStr)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse number of rule IDs: %s", err)
+		log.Printf("[WARN] failed to parse number of rule IDs: %s", err)
 	}
 	ruleIds := make([]string, 0)
 	for i := 0; i < count; i++ {

--- a/huaweicloud/services/aom/data_source_huaweicloud_aom_service_discovery_rules.go
+++ b/huaweicloud/services/aom/data_source_huaweicloud_aom_service_discovery_rules.go
@@ -210,17 +210,17 @@ func flattenServiceDiscoveryRules(rules []interface{}) []interface{} {
 	for _, rule := range rules {
 		isDefaultRule, err := strconv.ParseBool(utils.PathSearch("spec.isDefaultRule", rule, "false").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'isDefaultRule' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'isDefaultRule' field to Boolean: %s", err)
 		}
 
 		detectLogEnabled, err := strconv.ParseBool(utils.PathSearch("spec.detectLog", rule, "false").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'detectLog' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'detectLog' field to Boolean: %s", err)
 		}
 
 		createdAt, err := strconv.ParseInt(utils.PathSearch("createTime", rule, "").(string), 10, 64)
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'createTime' field to Int: %s", err)
+			log.Printf("[WARN] error parsing 'createTime' field to Int: %s", err)
 		}
 
 		result = append(result, map[string]interface{}{

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rule.go
@@ -277,7 +277,7 @@ func resourceAlarmRuleRead(_ context.Context, d *schema.ResourceData, meta inter
 
 	alarmLevel, err := strconv.Atoi(utils.PathSearch("alarm_level", rule, "0").(string))
 	if err != nil {
-		log.Printf("[ERROR] failed to parse alarm level: %s", err)
+		log.Printf("[WARN] failed to parse alarm level: %s", err)
 	}
 
 	mErr := multierror.Append(nil,

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_message_template.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_message_template.go
@@ -154,7 +154,7 @@ func buildMessageTemplateDetail(d *schema.ResourceData) interface{} {
 
 	jsonTemplates, err := json.Marshal(rst)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert the templates into JSON encoding")
+		log.Printf("[WARN] unable to convert the templates into JSON encoding")
 		return ""
 	}
 

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
@@ -297,17 +297,17 @@ func resourceServiceDiscoveryRuleRead(_ context.Context, d *schema.ResourceData,
 
 	isDefaultRule, err := strconv.ParseBool(utils.PathSearch("spec.isDefaultRule", rule, "false").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'isDefaultRule' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'isDefaultRule' field to Boolean: %s", err)
 	}
 
 	detectLogEnabled, err := strconv.ParseBool(utils.PathSearch("spec.detectLog", rule, "false").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'detectLog' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'detectLog' field to Boolean: %s", err)
 	}
 
 	createdAt, err := strconv.ParseInt(utils.PathSearch("createTime", rule, "").(string), 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'createTime' field to Int: %s", err)
+		log.Printf("[WARN] error parsing 'createTime' field to Int: %s", err)
 	}
 
 	mErr := multierror.Append(nil,

--- a/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
+++ b/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
@@ -156,7 +156,7 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 func flattenBmsFlavor(flavor flavors.Flavor) map[string]interface{} {
 	vcpus, err := strconv.Atoi(flavor.VCPUs)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse BMS flavor VCPUs: %s", err)
+		log.Printf("[WARN] failed to parse BMS flavor VCPUs: %s", err)
 	}
 	ram := flavor.RAM / 1024
 

--- a/huaweicloud/services/cae/common.go
+++ b/huaweicloud/services/cae/common.go
@@ -9,7 +9,7 @@ func unmarshalJsonFormatParamster(paramName, paramVal string) map[string]interfa
 	parseResult := make(map[string]interface{})
 	err := json.Unmarshal([]byte(paramVal), &parseResult)
 	if err != nil {
-		log.Printf("[ERROR] Invalid type of the %s, it's not JSON format", paramName)
+		log.Printf("[WARN] Invalid type of the %s, it's not JSON format", paramName)
 	}
 	return parseResult
 }
@@ -17,7 +17,7 @@ func unmarshalJsonFormatParamster(paramName, paramVal string) map[string]interfa
 func marshalJsonFormatParamster(paramName, paramVal interface{}) interface{} {
 	jsonDetail, err := json.Marshal(paramVal)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert the %s, it's not JSON format", paramName)
+		log.Printf("[WARN] unable to convert the %s, it's not JSON format", paramName)
 		return nil
 	}
 	return string(jsonDetail)

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -334,13 +334,13 @@ func buildBillingStructure(d *schema.ResourceData) map[string]interface{} {
 
 		autoRenew, err := strconv.ParseBool(d.Get("auto_renew").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'auto_renew' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'auto_renew' field to Boolean: %s", err)
 		}
 		billing["is_auto_renew"] = autoRenew
 
 		autoPay, err := strconv.ParseBool(cbc.GetAutoPay(d))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'auto_pay' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'auto_pay' field to Boolean: %s", err)
 		}
 		billing["is_auto_pay"] = autoPay
 	}
@@ -1015,7 +1015,7 @@ func getNumberInGB(megaBytes float64) float64 {
 	denominator := float64(1024)
 	result, err := strconv.ParseFloat(fmt.Sprintf("%.2f", megaBytes/denominator), 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing field to Float: %s", err)
+		log.Printf("[WARN] error parsing field to Float: %s", err)
 	}
 
 	return result

--- a/huaweicloud/services/cc/data_source_huaweicloud_cc_central_network_policies_change_set.go
+++ b/huaweicloud/services/cc/data_source_huaweicloud_cc_central_network_policies_change_set.go
@@ -128,7 +128,7 @@ func (w *CentralNetworkPoliciesChangeSetDSWrapper) listCentralNetworkPolicyChang
 func (*CentralNetworkPoliciesChangeSetDSWrapper) setCenNetChaCon(_, data *gjson.Result) map[string]string {
 	changeContent, err := utils.ConvertStructToMap(data, map[string]string{})
 	if err != nil {
-		log.Printf("[ERROR] error converting CC central network policy change set: %s", err)
+		log.Printf("[WARN] error converting CC central network policy change set: %s", err)
 	}
 	return utils.ExpandToStringMap(changeContent)
 }

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_upgrade.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_upgrade.go
@@ -248,7 +248,7 @@ func buildClusterUpgradeCreateOpts(d *schema.ResourceData, targetVersion string)
 	if v, ok := d.GetOk("is_only_upgrade"); ok {
 		isOnlyUpgradeRaw, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'is_only_upgrade' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'is_only_upgrade' field to Boolean: %s", err)
 		}
 		result["spec"].(map[string]interface{})["clusterUpgradeAction"].(map[string]interface{})["isOnlyUpgrade"] = isOnlyUpgradeRaw
 	}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_report_profile.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_report_profile.go
@@ -152,7 +152,7 @@ func convertStringToInt(rawValue string) interface{} {
 
 	r, err := strconv.Atoi(rawValue)
 	if err != nil {
-		log.Printf("[ERROR] convert the string %s to int failed.", rawValue)
+		log.Printf("[WARN] convert the string %s to int failed.", rawValue)
 		return nil
 	}
 

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_schedule.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_schedule.go
@@ -319,7 +319,7 @@ func convertAbsoluteStringToInt(respValue interface{}) int {
 
 	r, err := strconv.Atoi(stringValue)
 	if err != nil {
-		log.Printf("[ERROR] convert the string %s to int failed.", stringValue)
+		log.Printf("[WARN] convert the string %s to int failed.", stringValue)
 	}
 
 	return r

--- a/huaweicloud/services/cph/resource_huaweicloud_cph_server.go
+++ b/huaweicloud/services/cph/resource_huaweicloud_cph_server.go
@@ -488,7 +488,7 @@ func buildCreateCphServerRequestBodyBandWidth(rawParams interface{}) map[string]
 
 		shareType, err := strconv.Atoi(utils.ValueIgnoreEmpty(raw["share_type"]).(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse share type: %s", err)
+			log.Printf("[WARN] failed to parse share type: %s", err)
 		}
 		params["band_width_share_type"] = shareType
 
@@ -496,7 +496,7 @@ func buildCreateCphServerRequestBodyBandWidth(rawParams interface{}) map[string]
 		if len(chargeMode) > 0 {
 			chargeModeInteger, err := strconv.Atoi(chargeMode)
 			if err != nil {
-				log.Printf("[ERROR] failed to parse charge mode: %s", err)
+				log.Printf("[WARN] failed to parse charge mode: %s", err)
 			}
 			params["band_width_charge_mode"] = chargeModeInteger
 		}

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engines.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engines.go
@@ -230,7 +230,7 @@ func convertStrNumberToIntIgnoreErr(strNum string) int {
 	if err != nil {
 		// If the type conversion fails, only the error information is recorded in the log, and the program execution
 		// is not interrupted.
-		log.Printf("[ERROR] unable to convert object from type string to type int: %s", err)
+		log.Printf("[WARN] unable to convert object from type string to type int: %s", err)
 		return 0
 	}
 	return result

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_instances.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_instances.go
@@ -236,7 +236,7 @@ func parseMicroserviceInstanceTimestamp(val interface{}) string {
 		if err != nil {
 			// If the type conversion fails, only the error information is recorded in the log, and the program
 			// execution is not interrupted.
-			log.Printf("[ERROR] unable to convert the string (%s) to int: %v", v, err)
+			log.Printf("[WARN] unable to convert the string (%s) to int: %v", v, err)
 			return ""
 		}
 		return utils.FormatTimeStampRFC3339(int64(r), false)

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservices.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservices.go
@@ -257,7 +257,7 @@ func parseMicroservicesTime(timeStampStr string) string {
 	if err != nil {
 		// If the type conversion fails, only the error information is recorded in the log, and the program execution
 		// is not interrupted.
-		log.Printf("[ERROR] unable to convert the string (%s) to int", timeStampStr)
+		log.Printf("[WARN] unable to convert the string (%s) to int", timeStampStr)
 		return ""
 	}
 

--- a/huaweicloud/services/css/resource_huaweicloud_css_snapshot_setting.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_snapshot_setting.go
@@ -135,7 +135,7 @@ func buildSnapshotSettingRequestBody(d *schema.ResourceData) map[string]interfac
 	// Set the snapshot policy when enable is true
 	enable, err := strconv.ParseBool(d.Get("enable").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'enable' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'enable' field to Boolean: %s", err)
 	}
 	if enable {
 		requestBody["indices"] = utils.ValueIgnoreEmpty(d.Get("indices").(string))

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_debug.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_debug.go
@@ -117,7 +117,7 @@ func buildApiDebugBodyParams(params string) map[string]interface{} {
 	parsedParams := make(map[string]interface{})
 	err := json.Unmarshal([]byte(params), &parsedParams)
 	if err != nil {
-		log.Printf("[ERROR] Invalid type of the debug parameters, not json format")
+		log.Printf("[WARN] Invalid type of the debug parameters, not json format")
 	}
 	return map[string]interface{}{
 		"paras": parsedParams,
@@ -160,7 +160,7 @@ func debugApi(client *golangsdk.ServiceClient, d *schema.ResourceData) (interfac
 func parseApiDebugHeaders(headers interface{}) interface{} {
 	jsonFilter, err := json.Marshal(headers)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert the header content, not json format")
+		log.Printf("[WARN] unable to convert the header content, not json format")
 		return nil
 	}
 	return string(jsonFilter)

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_data_connection.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_data_connection.go
@@ -121,7 +121,7 @@ func unmarshalConfigContent(configVal string) map[string]interface{} {
 	parseResult := make(map[string]interface{})
 	err := json.Unmarshal([]byte(configVal), &parseResult)
 	if err != nil {
-		log.Printf("[ERROR] Invalid type of the dynamic configuration content, it is not JSON format")
+		log.Printf("[WARN] Invalid type of the dynamic configuration content, it is not JSON format")
 		return nil
 	}
 	return parseResult

--- a/huaweicloud/services/dcs/data_source_huaweicloud_dcs_flavors.go
+++ b/huaweicloud/services/dcs/data_source_huaweicloud_dcs_flavors.go
@@ -203,7 +203,7 @@ func flattenDcsFlavors(d *schema.ResourceData, resp interface{}) []map[string]in
 			}
 			capacityFloat, err := strconv.ParseFloat(capacity, floatBitSize)
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'capacity' field to Float: %s", err)
+				log.Printf("[WARN] error parsing 'capacity' field to Float: %s", err)
 			}
 
 			rst = append(rst, map[string]interface{}{

--- a/huaweicloud/services/dcs/data_source_huaweicloud_dcs_instances.go
+++ b/huaweicloud/services/dcs/data_source_huaweicloud_dcs_instances.go
@@ -284,7 +284,7 @@ func flattenGetDCSInstancesResponseBodyInstance(resp interface{}, client *golang
 		if capacity == 0 {
 			capacity, err = strconv.ParseFloat(capacityMinor.(string), floatBitSize)
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'capacity' field to Float: %s", err)
+				log.Printf("[WARN] error parsing 'capacity' field to Float: %s", err)
 			}
 		}
 

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -1873,7 +1873,7 @@ func updateTransparentClientIpEnable(ctx context.Context, d *schema.ResourceData
 func buildUpdateTransparentClientIpEnableBodyParams(d *schema.ResourceData) map[string]interface{} {
 	transparentClientIpEnable, err := strconv.ParseBool(d.Get("transparent_client_ip_enable").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'transparent_client_ip_enable' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'transparent_client_ip_enable' field to Boolean: %s", err)
 	}
 	bodyParams := map[string]interface{}{
 		"transparent_client_ip_enable": transparentClientIpEnable,

--- a/huaweicloud/services/ddm/data_source_huaweicloud_ddm_flavors.go
+++ b/huaweicloud/services/ddm/data_source_huaweicloud_ddm_flavors.go
@@ -264,11 +264,11 @@ func flattenFlavorGroupFlavors(resp interface{}, flavorGroupType string, parma *
 		}
 		vcpusNum, err := strconv.Atoi(vcpus)
 		if err != nil {
-			log.Printf("[ERROR] failed to parse VCPUs: %s", err)
+			log.Printf("[WARN] failed to parse VCPUs: %s", err)
 		}
 		memoryNum, err := strconv.Atoi(memory)
 		if err != nil {
-			log.Printf("[ERROR] failed to parse memory num: %s", err)
+			log.Printf("[WARN] failed to parse memory num: %s", err)
 		}
 		rst = append(rst, map[string]interface{}{
 			"id":       utils.PathSearch("id", v, nil),

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_readonly_node.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_readonly_node.go
@@ -316,7 +316,7 @@ func convertStringToInt(rawValue string) interface{} {
 
 	r, err := strconv.Atoi(rawValue)
 	if err != nil {
-		log.Printf("[ERROR] convert the string %s to int failed.", rawValue)
+		log.Printf("[WARN] convert the string %s to int failed.", rawValue)
 		return nil
 	}
 

--- a/huaweicloud/services/deprecated/networking_port_v2.go
+++ b/huaweicloud/services/deprecated/networking_port_v2.go
@@ -78,7 +78,7 @@ func flattenNetworkingPortDHCPOptsV2(dhcpOpts extradhcpopts.ExtraDHCPOptsExt) []
 	for i, dhcpOpt := range dhcpOpts.ExtraDHCPOpts {
 		ipVersion, err := strconv.Atoi(dhcpOpt.IPVersion)
 		if err != nil {
-			log.Printf("[ERROR] failed to parse IP version: %s", err)
+			log.Printf("[WARN] failed to parse IP version: %s", err)
 		}
 		dhcpOptsSet[i] = map[string]interface{}{
 			"ip_version": ipVersion,

--- a/huaweicloud/services/deprecated/resource_huaweicloud_ecs_auto_recovery_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_ecs_auto_recovery_v1.go
@@ -30,7 +30,7 @@ func resourceECSAutoRecoveryV1Read(d *schema.ResourceData, meta interface{}, ins
 	log.Printf("[DEBUG] Retrieved ECS-AutoRecovery:%#v of instance:%s", rId, r)
 	result, err := strconv.ParseBool(r.SupportAutoRecovery)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'SupportAutoRecovery' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'SupportAutoRecovery' field to Boolean: %s", err)
 	}
 	return result, err
 }

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_key_material.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_key_material.go
@@ -139,7 +139,7 @@ func flatternExpirationTime(expTimeStr string) string {
 	}
 	expTime, err := strconv.ParseInt(expTimeStr, 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'expiration_time' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'expiration_time' field to Integer: %s", err)
 	}
 	return strconv.FormatInt(expTime/1000, 10)
 }

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -276,7 +276,7 @@ func buildCreateElasticResourcePoolBodyParams(d *schema.ResourceData, epsId stri
 func parseElasticResourcePoolAutoRenew(autoRenew string) bool {
 	result, err := strconv.ParseBool(autoRenew)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert auto_renew to bool value")
+		log.Printf("[WARN] unable to convert auto_renew to bool value")
 		return false
 	}
 

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_object_mappings.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_object_mappings.go
@@ -109,7 +109,7 @@ func buildObjectMappingsRequestBody(d *schema.ResourceData, offset int) map[stri
 	if v, ok := d.GetOk("has_column_info"); ok {
 		hasColumnInfo, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'has_column_info' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'has_column_info' field to Boolean: %s", err)
 		}
 		bodyParams["has_column_info"] = hasColumnInfo
 	}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -994,12 +994,12 @@ func resourceJobRead(_ context.Context, d *schema.ResourceData, meta interface{}
 
 	createdAt, err := strconv.ParseInt(detail.CreateTime, 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'created_at' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'created_at' field to Integer: %s", err)
 	}
 
 	updatedAt, err := strconv.ParseInt(detail.UpdateTime, 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'updated_at' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'updated_at' field to Integer: %s", err)
 	}
 
 	// engine_type input mongodb will return mongodb-to-dds

--- a/huaweicloud/services/dsc/data_source_huaweicloud_dsc_database_watermark_embed_tasks.go
+++ b/huaweicloud/services/dsc/data_source_huaweicloud_dsc_database_watermark_embed_tasks.go
@@ -450,12 +450,12 @@ func flattenDatabaseWatermarkEmbedTasksFakeParam(fakeParam map[string]interface{
 
 	beginTime, err := strconv.ParseInt(utils.PathSearch("date_begin", fakeParam, "").(string), 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'date_begin' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'date_begin' field to Integer: %s", err)
 	}
 
 	endTime, err := strconv.ParseInt(utils.PathSearch("date_end", fakeParam, "").(string), 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'date_end' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'date_end' field to Integer: %s", err)
 	}
 
 	return []map[string]interface{}{

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_adg_instance.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_adg_instance.go
@@ -389,7 +389,7 @@ func buildAdgInstanceChargeInfoBodyParams(d *schema.ResourceData) map[string]int
 func parseAutoRenewValue(autoRenew string) bool {
 	result, err := strconv.ParseBool(autoRenew)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert auto_renew to bool value")
+		log.Printf("[WARN] unable to convert auto_renew to bool value")
 		return false
 	}
 	return result

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_database_watermark_embed_task.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_database_watermark_embed_task.go
@@ -705,12 +705,12 @@ func flattenDatabaseWatermarkEmbedTaskFakeParam(fakeParam interface{}) []map[str
 
 	beginTime, err := strconv.ParseInt(utils.PathSearch("date_begin", fakeParam, "").(string), 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'date_begin' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'date_begin' field to Integer: %s", err)
 	}
 
 	endTime, err := strconv.ParseInt(utils.PathSearch("date_end", fakeParam, "").(string), 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'date_end' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'date_end' field to Integer: %s", err)
 	}
 
 	return []map[string]interface{}{

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_rule.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_rule.go
@@ -290,7 +290,7 @@ func convertStringToBool(str string) interface{} {
 
 	boolValue, err := strconv.ParseBool(str)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert string (%s) to boolean: %s", str, err)
+		log.Printf("[WARN] unable to convert string (%s) to boolean: %s", str, err)
 		return nil
 	}
 

--- a/huaweicloud/services/ecs/data_source_huaweicloud_compute_flavors.go
+++ b/huaweicloud/services/ecs/data_source_huaweicloud_compute_flavors.go
@@ -124,7 +124,7 @@ func dataSourceEcsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 	for _, flavor := range allFlavors {
 		vCpu, err := strconv.Atoi(flavor.Vcpus)
 		if err != nil {
-			log.Printf("[ERROR] failed to parse VCPUs: %s", err)
+			log.Printf("[WARN] failed to parse VCPUs: %s", err)
 		}
 		if cpu > 0 && vCpu != cpu {
 			continue

--- a/huaweicloud/services/ecs/data_source_huaweicloud_compute_supply_recommendations.go
+++ b/huaweicloud/services/ecs/data_source_huaweicloud_compute_supply_recommendations.go
@@ -395,7 +395,7 @@ func buildGetSupplyRecommendationsOption(rawParams interface{}) map[string]inter
 	if v, enableSpotOk := raw["enable_spot"]; enableSpotOk {
 		enableSpot, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'enable_spot' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'enable_spot' field to Boolean: %s", err)
 		}
 		params["enable_spot"] = enableSpot
 	}

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -2429,7 +2429,7 @@ func buildInstanceRootVolume(d *schema.ResourceData) cloudservers.RootVolume {
 	if v, ok := d.GetOk("system_pass_through"); ok {
 		systemPassThrough, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'system_pass_through' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'system_pass_through' field to Boolean: %s", err)
 		}
 		volRequest.PassThrough = &systemPassThrough
 	}
@@ -2472,7 +2472,7 @@ func buildInstanceDataVolumes(d *schema.ResourceData) []cloudservers.DataVolume 
 		if vol["delete_on_termination"] != "" {
 			deleteOnTermination, err := strconv.ParseBool(vol["delete_on_termination"].(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'delete_on_termination' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'delete_on_termination' field to Boolean: %s", err)
 			}
 			volRequest.DeleteOnTermination = &deleteOnTermination
 		}
@@ -2485,7 +2485,7 @@ func buildInstanceDataVolumes(d *schema.ResourceData) []cloudservers.DataVolume 
 		if vol["pass_through"] != "" {
 			passThrough, err := strconv.ParseBool(vol["pass_through"].(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'pass_through' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'pass_through' field to Boolean: %s", err)
 			}
 			volRequest.PassThrough = &passThrough
 		}

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_interface_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_interface_attach.go
@@ -447,7 +447,7 @@ func updateAttachInfo(client *golangsdk.ServiceClient, d *schema.ResourceData) e
 func buildUpdateAttachInfoBodyParams(d *schema.ResourceData) map[string]interface{} {
 	deleteOnTermination, err := strconv.ParseBool(d.Get("delete_on_termination").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'delete_on_termination' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'delete_on_termination' field to Boolean: %s", err)
 	}
 	bodyParams := map[string]interface{}{
 		"interface_attachment": map[string]interface{}{

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
@@ -249,7 +249,7 @@ func updateDeleteOnTermination(client *golangsdk.ServiceClient, d *schema.Resour
 func buildUpdateComputeVolumeAttachBodyParams(d *schema.ResourceData) map[string]interface{} {
 	deleteOnTermination, err := strconv.ParseBool(d.Get("delete_on_termination").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'delete_on_termination' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'delete_on_termination' field to Boolean: %s", err)
 	}
 	bodyParams := map[string]interface{}{
 		"delete_on_termination": deleteOnTermination,

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_custom_event_source.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_custom_event_source.go
@@ -119,7 +119,7 @@ func resourceCustomEventSourceCreate(ctx context.Context, d *schema.ResourceData
 func parseCustomEventSourceDetail(detail interface{}) interface{} {
 	jsonDetail, err := json.Marshal(detail)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert the detail of the custom event source, not json format")
+		log.Printf("[WARN] unable to convert the detail of the custom event source, not json format")
 		return nil
 	}
 	return string(jsonDetail)

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_event_stream.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_event_stream.go
@@ -244,7 +244,7 @@ func unmarshalJsonFormatParamster(paramName, paramVal string) map[string]interfa
 	parseResult := make(map[string]interface{})
 	err := json.Unmarshal([]byte(paramVal), &parseResult)
 	if err != nil {
-		log.Printf("[ERROR] Invalid type of the %s, not json format", paramName)
+		log.Printf("[WARN] Invalid type of the %s, not json format", paramName)
 	}
 	return parseResult
 }
@@ -252,7 +252,7 @@ func unmarshalJsonFormatParamster(paramName, paramVal string) map[string]interfa
 func marshalJsonFormatParamster(paramName string, paramVal interface{}) interface{} {
 	jsonFilter, err := json.Marshal(paramVal)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert the %s, not json format", paramName)
+		log.Printf("[WARN] unable to convert the %s, not json format", paramName)
 	}
 	return string(jsonFilter)
 }

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_event_subscription.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_event_subscription.go
@@ -207,7 +207,7 @@ func unmarshalEventSubscriptionParamsters(paramName, paramVal string) map[string
 	parseResult := make(map[string]interface{})
 	err := json.Unmarshal([]byte(paramVal), &parseResult)
 	if err != nil {
-		log.Printf("[ERROR] Invalid type of the %s, not json format", paramName)
+		log.Printf("[WARN] Invalid type of the %s, not json format", paramName)
 	}
 	return parseResult
 }
@@ -302,7 +302,7 @@ func flattenEventSources(sourcesResp []map[string]interface{}) []interface{} {
 			if strings.Contains(key, "detail") {
 				jsonDetail, err := json.Marshal(value)
 				if err != nil {
-					log.Printf("[ERROR] unable to convert the detail of the event source, not json format")
+					log.Printf("[WARN] unable to convert the detail of the event source, not json format")
 				} else {
 					element["detail_name"] = key
 					element["detail"] = string(jsonDetail)
@@ -313,7 +313,7 @@ func flattenEventSources(sourcesResp []map[string]interface{}) []interface{} {
 
 		jsonFilter, err := json.Marshal(source["filter"])
 		if err != nil {
-			log.Printf("[ERROR] unable to convert the event source filter rule, not json format")
+			log.Printf("[WARN] unable to convert the event source filter rule, not json format")
 		} else {
 			element["filter_rule"] = string(jsonFilter)
 		}
@@ -339,7 +339,7 @@ func flattenEventTargets(targetsResp []map[string]interface{}) []interface{} {
 			if strings.Contains(key, "detail") {
 				jsonDetail, err := json.Marshal(value)
 				if err != nil {
-					log.Printf("[ERROR] unable to convert the detail of the event target, not json format")
+					log.Printf("[WARN] unable to convert the detail of the event target, not json format")
 				} else {
 					element["detail_name"] = key
 					element["detail"] = string(jsonDetail)
@@ -351,7 +351,7 @@ func flattenEventTargets(targetsResp []map[string]interface{}) []interface{} {
 		if deadLetterQueue, ok := target["dead_letter_queue"]; ok {
 			jsonQueue, err := json.Marshal(deadLetterQueue)
 			if err != nil {
-				log.Printf("[ERROR] unable to convert the dead letter queue of the event target, not json format")
+				log.Printf("[WARN] unable to convert the dead letter queue of the event target, not json format")
 			} else {
 				element["dead_letter_queue"] = string(jsonQueue)
 			}
@@ -360,7 +360,7 @@ func flattenEventTargets(targetsResp []map[string]interface{}) []interface{} {
 		if transform, ok := target["transform"]; ok {
 			jsonTransform, err := json.Marshal(transform)
 			if err != nil {
-				log.Printf("[ERROR] unable to convert the transform configuration of the event target, not json format")
+				log.Printf("[WARN] unable to convert the transform configuration of the event target, not json format")
 			} else {
 				element["transform"] = string(jsonTransform)
 			}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segment_support_masks.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segment_support_masks.go
@@ -107,7 +107,7 @@ func buildGlobalEipSegmentSupportMasksQueryParams(d *schema.ResourceData, marker
 	if raw, ok := d.GetOk("page_reverse"); ok {
 		pageReverse, err := strconv.ParseBool(raw.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'page_reverse' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'page_reverse' field to Boolean: %s", err)
 		}
 		queryParams += fmt.Sprintf("&page_reverse=%v", pageReverse)
 	}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_active_standby_pools.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_active_standby_pools.go
@@ -584,7 +584,7 @@ func buildListActiveStandbyPoolsQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("connection_drain"); ok {
 		connectionDrain, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'connection_drain' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'connection_drain' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&connection_drain=%v", res, connectionDrain)
 	}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_flavors.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_flavors.go
@@ -225,7 +225,7 @@ func buildListFlavorsQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("shared"); ok {
 		shared, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'shared' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'shared' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&shared=%v", res, shared)
 	}
@@ -238,14 +238,14 @@ func buildListFlavorsQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("flavor_sold_out"); ok {
 		flavorSoldOut, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'flavor_sold_out' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'flavor_sold_out' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&flavor_sold_out=%v", res, flavorSoldOut)
 	}
 	if v, ok := d.GetOk("list_all"); ok {
 		listAll, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'list_all' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'list_all' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&list_all=%v", res, listAll)
 	}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_l7policies.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_l7policies.go
@@ -473,7 +473,7 @@ func buildListL7policiesQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("display_all_rules"); ok {
 		displayAllRules, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'display_all_rules' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'display_all_rules' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&display_all_rules=%v", res, displayAllRules)
 	}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_listeners.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_listeners.go
@@ -460,21 +460,21 @@ func buildListListenersQueryParams(d *schema.ResourceData, enterpriseProjectId s
 	if v, ok := d.GetOk("enable_member_retry"); ok {
 		enableMemberRetry, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'enable_member_retry' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'enable_member_retry' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&enable_member_retry=%v", res, enableMemberRetry)
 	}
 	if v, ok := d.GetOk("advanced_forwarding_enabled"); ok {
 		advancedForwardingEnabled, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'advanced_forwarding_enabled' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'advanced_forwarding_enabled' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&enhance_l7policy_enable=%v", res, advancedForwardingEnabled)
 	}
 	if v, ok := d.GetOk("http2_enable"); ok {
 		http2Enable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'http2_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'http2_enable' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&http2_enable=%v", res, http2Enable)
 	}
@@ -499,14 +499,14 @@ func buildListListenersQueryParams(d *schema.ResourceData, enterpriseProjectId s
 	if v, ok := d.GetOk("proxy_protocol_enable"); ok {
 		proxyProtocolEnable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'proxy_protocol_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'proxy_protocol_enable' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&proxy_protocol_enable=%v", res, proxyProtocolEnable)
 	}
 	if v, ok := d.GetOk("ssl_early_data_enable"); ok {
 		sslEarlyDataEnable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'ssl_early_data_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'ssl_early_data_enable' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&ssl_early_data_enable=%v", res, sslEarlyDataEnable)
 	}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_loadbalancers.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_loadbalancers.go
@@ -460,7 +460,7 @@ func buildListLoadBalancersQueryParams(d *schema.ResourceData, enterpriseProject
 	if v, ok := d.GetOk("deletion_protection_enable"); ok {
 		deletionProtectionEnable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'deletion_protection_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'deletion_protection_enable' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&deletion_protection_enable=%v", res, deletionProtectionEnable)
 	}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_pools.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_pools.go
@@ -631,14 +631,14 @@ func buildListPoolsQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("any_port_enable"); ok {
 		anyPortEnable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'any_port_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'any_port_enable' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&any_port_enable=%v", res, anyPortEnable)
 	}
 	if v, ok := d.GetOk("connection_drain"); ok {
 		connectionDrain, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'connection_drain' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'connection_drain' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&connection_drain=%v", res, connectionDrain)
 	}
@@ -660,7 +660,7 @@ func buildListPoolsQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("member_deletion_protection_enable"); ok {
 		memberDeletionProtectionEnable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'member_deletion_protection_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'member_deletion_protection_enable' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&member_deletion_protection_enable=%v", res, memberDeletionProtectionEnable)
 	}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_recycle_bin_loadbalancers.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_recycle_bin_loadbalancers.go
@@ -525,14 +525,14 @@ func buildListRecycleBinLoadBalancersQueryParams(d *schema.ResourceData) string 
 	if v, ok := d.GetOk("guaranteed"); ok {
 		guaranteed, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'guaranteed' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'guaranteed' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&guaranteed=%v", res, guaranteed)
 	}
 	if v, ok := d.GetOk("deletion_protection_enable"); ok {
 		deletionProtectionEnable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'deletion_protection_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'deletion_protection_enable' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&deletion_protection_enable=%v", res, deletionProtectionEnable)
 	}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_listener.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_listener.go
@@ -377,7 +377,7 @@ func resourceListenerV3Create(ctx context.Context, d *schema.ResourceData, meta 
 		if rawIpGroupEnable, ok := d.GetOk("ip_group_enable"); ok {
 			ipGroupEnable, err := strconv.ParseBool(rawIpGroupEnable.(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'ip_group_enable' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'ip_group_enable' field to Boolean: %s", err)
 			}
 			ipGroup.Enable = &ipGroupEnable
 		}
@@ -441,7 +441,7 @@ func resourceListenerV3Create(ctx context.Context, d *schema.ResourceData, meta 
 	if v, ok := d.GetOk("quic_listener_id"); ok {
 		enableQuicUpgrade, err := strconv.ParseBool(d.Get("enable_quic_upgrade").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'enable_quic_upgrade' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'enable_quic_upgrade' field to Boolean: %s", err)
 		}
 		createOpts.QuicConfig = &listeners.QuicConfig{
 			QuicListenerId:    v.(string),
@@ -451,14 +451,14 @@ func resourceListenerV3Create(ctx context.Context, d *schema.ResourceData, meta 
 	if v, ok := d.GetOk("transparent_client_ip_enable"); ok {
 		transparentClientIpEnable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'transparent_client_ip_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'transparent_client_ip_enable' field to Boolean: %s", err)
 		}
 		createOpts.TransparentClientIP = &transparentClientIpEnable
 	}
 	if v, ok := d.GetOk("nat64_enable"); ok {
 		nat64Enable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'nat64_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'nat64_enable' field to Boolean: %s", err)
 		}
 		createOpts.Nat64Enable = &nat64Enable
 	}
@@ -683,7 +683,7 @@ func updateListener(ctx context.Context, d *schema.ResourceData, elbClient *gola
 	if d.HasChanges("access_policy", "ip_group") {
 		ipGroupEnable, err := strconv.ParseBool(d.Get("ip_group_enable").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'ip_group_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'ip_group_enable' field to Boolean: %s", err)
 		}
 		updateOpts.IpGroup = &listeners.IpGroupUpdate{
 			Type:      d.Get("access_policy").(string),
@@ -783,14 +783,14 @@ func updateListener(ctx context.Context, d *schema.ResourceData, elbClient *gola
 	if d.HasChange("nat64_enable") {
 		nat64Enable, err := strconv.ParseBool(d.Get("nat64_enable").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'nat64_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'nat64_enable' field to Boolean: %s", err)
 		}
 		updateOpts.Nat64Enable = &nat64Enable
 	}
 	if d.HasChange("transparent_client_ip_enable") {
 		transparentClientIpEnable, err := strconv.ParseBool(d.Get("transparent_client_ip_enable").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'transparent_client_ip_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'transparent_client_ip_enable' field to Boolean: %s", err)
 		}
 		updateOpts.TransparentClientIP = &transparentClientIpEnable
 	}
@@ -806,7 +806,7 @@ func updateListener(ctx context.Context, d *schema.ResourceData, elbClient *gola
 	if v, ok := d.GetOk("quic_listener_id"); ok {
 		enableQuicUpgrade, err := strconv.ParseBool(d.Get("enable_quic_upgrade").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'enable_quic_upgrade' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'enable_quic_upgrade' field to Boolean: %s", err)
 		}
 		quicConfig.QuicListenerId = v.(string)
 		quicConfig.EnableQuicUpgrade = &enableQuicUpgrade

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_listener_copy.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_listener_copy.go
@@ -406,7 +406,7 @@ func buildCreateListenerCopyBodyParams(d *schema.ResourceData) map[string]interf
 	if v, ok := d.GetOk("reuse_pool"); ok {
 		reusePool, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'reuse_pool' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'reuse_pool' field to Boolean: %s", err)
 		}
 		bodyParams["reuse_pool"] = reusePool
 	}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -495,7 +495,7 @@ func buildCreateLoadBalancerPrepaidOptionsBodyParams(d *schema.ResourceData) map
 
 	autoRenew, err := strconv.ParseBool(d.Get("auto_renew").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'auto_renew' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'auto_renew' field to Boolean: %s", err)
 	}
 	bodyParams := map[string]interface{}{
 		"period_type": utils.ValueIgnoreEmpty(d.Get("period_unit").(string)),

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer_copy.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer_copy.go
@@ -668,14 +668,14 @@ func buildUpdateLoadBalancerCopyParamsBodyParams(d *schema.ResourceData) map[str
 	if d.HasChange("cross_vpc_backend") {
 		crossVpcBackend, err := strconv.ParseBool(d.Get("cross_vpc_backend").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'cross_vpc_backend' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'cross_vpc_backend' field to Boolean: %s", err)
 		}
 		params["ip_target_enable"] = crossVpcBackend
 	}
 	if d.HasChange("deletion_protection_enable") {
 		deletionProtectionEnable, err := strconv.ParseBool(d.Get("deletion_protection_enable").(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'deletion_protection_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'deletion_protection_enable' field to Boolean: %s", err)
 		}
 		params["deletion_protection_enable"] = deletionProtectionEnable
 	}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_pool.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_pool.go
@@ -391,21 +391,21 @@ func buildAzAffinity(d *schema.ResourceData) map[string]interface{} {
 	if v := azAffinity["enable"]; v != "" {
 		r, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'enable' field to Boolean: %s", err)
 		}
 		bodyParams["enable"] = r
 	}
 	if v := azAffinity["az_minimum_healthy_member_percentage"]; v != "" {
 		r, err := strconv.Atoi(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse AZ minimum healthy member percentage: %s", err)
+			log.Printf("[WARN] failed to parse AZ minimum healthy member percentage: %s", err)
 		}
 		bodyParams["az_minimum_healthy_member_percentage"] = r
 	}
 	if v := azAffinity["az_minimum_healthy_member_count"]; v != "" {
 		r, err := strconv.Atoi(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse AZ minimum healthy member count: %s", err)
+			log.Printf("[WARN] failed to parse AZ minimum healthy member count: %s", err)
 		}
 		bodyParams["az_minimum_healthy_member_count"] = r
 	}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_recycle_bin.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_recycle_bin.go
@@ -237,14 +237,14 @@ func buildRecyclePolicyBodyParams(d *schema.ResourceData) map[string]interface{}
 	if retentionHourOk {
 		r, err := strconv.Atoi(retentionHour.(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse retention hour: %s", err)
+			log.Printf("[WARN] failed to parse retention hour: %s", err)
 		}
 		bodyParams["retention_hour"] = r
 	}
 	if recycleThresholdHourOk {
 		r, err := strconv.Atoi(recycleThresholdHour.(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse recycle threshold hour: %s", err)
+			log.Printf("[WARN] failed to parse recycle threshold hour: %s", err)
 		}
 		bodyParams["recycle_threshold_hour"] = r
 	}

--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
@@ -522,7 +522,7 @@ func flattenBootable(respBody interface{}) bool {
 	bootableString := utils.PathSearch("bootable", respBody, "").(string)
 	bootable, err := strconv.ParseBool(bootableString)
 	if err != nil {
-		log.Printf("[ERROR] the bootable of volume (%s) connot be converted from boolen to string: %s",
+		log.Printf("[WARN] the bootable of volume (%s) connot be converted from boolen to string: %s",
 			utils.PathSearch("id", respBody, "").(string),
 			err)
 	}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -1377,7 +1377,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 		// is disabled.
 		maxInstanceNum, err := strconv.Atoi(strNum.(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse max instance num: %s", err)
+			log.Printf("[WARN] failed to parse max instance num: %s", err)
 		}
 		err = updateFunctionMaxInstanceNum(client, funcUrnWithoutVersion, maxInstanceNum)
 		if err != nil {
@@ -1845,7 +1845,7 @@ func resourceFunctionRead(_ context.Context, d *schema.ResourceData, meta interf
 	versionConfig, err := flattenFunctionVersions(client, funcUrnWithoutVersion)
 	if err != nil {
 		// Not all regions support the version related API calls.
-		log.Printf("[ERROR] Unable to parsing the function versions: %s", err)
+		log.Printf("[WARN] Unable to parsing the function versions: %s", err)
 	}
 	mErr = multierror.Append(mErr, d.Set("versions", versionConfig))
 
@@ -1942,7 +1942,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		// is disabled.
 		maxInstanceNum, err := strconv.Atoi(d.Get("max_instance_num").(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse 'max_instance_num': %s", err)
+			log.Printf("[WARN] failed to parse 'max_instance_num': %s", err)
 		}
 		err = updateFunctionMaxInstanceNum(client, funcUrnWithoutVersion, maxInstanceNum)
 		if err != nil {

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_full_sql_statistics.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_full_sql_statistics.go
@@ -301,7 +301,7 @@ func buildFullSqlStatisticsMultiQueriesInfo(multiQueries []interface{}) []map[st
 		if v, ok := raw["is_fuzzy"]; ok && v.(string) != "" {
 			isFuzzy, err := strconv.ParseBool(v.(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'is_fuzzy' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'is_fuzzy' field to Boolean: %s", err)
 			}
 			params["is_fuzzy"] = isFuzzy
 		}
@@ -331,7 +331,7 @@ func buildFullSqlStatisticsCompareConditionsInfo(compareConditions []interface{}
 		if v, ok := raw["enable_equal"]; ok && v.(string) != "" {
 			enableEqual, err := strconv.ParseBool(v.(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'enable_equal' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'enable_equal' field to Boolean: %s", err)
 			}
 			params["enable_equal"] = enableEqual
 		}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_single_full_sqls.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_single_full_sqls.go
@@ -330,7 +330,7 @@ func buildMultiMergeConditionInfo(multiQueries []interface{}) []map[string]inter
 		if v, ok := raw["is_fuzzy"]; ok && v.(string) != "" {
 			isFuzzy, err := strconv.ParseBool(v.(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'is_fuzzy' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'is_fuzzy' field to Boolean: %s", err)
 			}
 			params["is_fuzzy"] = isFuzzy
 		}
@@ -360,7 +360,7 @@ func buildCompareConditionInfo(compareConditions []interface{}) []map[string]int
 		if v, ok := raw["enable_equal"]; ok && v.(string) != "" {
 			enableEqual, err := strconv.ParseBool(v.(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'is_fuzzy' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'is_fuzzy' field to Boolean: %s", err)
 			}
 			params["enable_equal"] = enableEqual
 		}
@@ -387,7 +387,7 @@ func buildCompareConditionInfo(compareConditions []interface{}) []map[string]int
 func convertStringtoInt(s string) int {
 	i, err := strconv.Atoi(s)
 	if err != nil {
-		log.Printf("[ERROR] convert the string %s to int failed.", s)
+		log.Printf("[WARN] convert the string %s to int failed.", s)
 	}
 
 	return i

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_slow_sql_detail.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_slow_sql_detail.go
@@ -268,7 +268,7 @@ func buildSlowSqlDetailMultiQueries(rawParams []interface{}) []map[string]interf
 		if v, ok := param["is_fuzzy"]; ok && v.(string) != "" {
 			isFuzzy, err := strconv.ParseBool(v.(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'is_fuzzy' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'is_fuzzy' field to Boolean: %s", err)
 			}
 			query["is_fuzzy"] = isFuzzy
 		}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_dr_instance_to_primary.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_dr_instance_to_primary.go
@@ -138,7 +138,7 @@ func buildDrInstanceToPrimaryBodyParams(d *schema.ResourceData) map[string]inter
 	if v, ok := d.GetOk("is_support_restore"); ok {
 		isSupportRestore, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'is_support_restore' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'is_support_restore' field to Boolean: %s", err)
 		}
 		bodyParams["is_support_restore"] = isSupportRestore
 	}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_parameter_templates.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_parameter_templates.go
@@ -160,7 +160,7 @@ func buildParameterTemplatesQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("user_defined"); ok {
 		userDefined, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'user_defined' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'user_defined' field to Boolean: %s", err)
 		}
 		queryParams = fmt.Sprintf("%s&user_defined=%v", queryParams, userDefined)
 	}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -1161,7 +1161,7 @@ func resourceGeminiDbInstanceRead(ctx context.Context, d *schema.ResourceData, m
 
 	port, err := strconv.Atoi(utils.PathSearch("port", instance, "0").(string))
 	if err != nil {
-		log.Printf("[ERROR] failed to parse port: %s", err)
+		log.Printf("[WARN] failed to parse port: %s", err)
 	}
 	mErr = multierror.Append(mErr, d.Set("port", port))
 
@@ -1411,7 +1411,7 @@ func flattenGeminiDbInstanceResponseBodyFlavor(d *schema.ResourceData, instance 
 	sizeRaw := utils.PathSearch("groups[0].volume.size", instance, "0").(string)
 	size, err := strconv.Atoi(sizeRaw)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse volume size: %s", err)
+		log.Printf("[WARN] failed to parse volume size: %s", err)
 	}
 
 	flavorRaw := d.Get("flavor").([]interface{})

--- a/huaweicloud/services/iam/data_source_huaweicloud_identity_role_assignments.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identity_role_assignments.go
@@ -220,14 +220,14 @@ func buildQueryRoleAssignmentsPath(d *schema.ResourceData, getPath string, domai
 	if v, ok := d.GetOk("is_inherited"); ok {
 		isInherited, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'is_inherited' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'is_inherited' field to Boolean: %s", err)
 		}
 		getPath += fmt.Sprintf("&is_inherited=%v", isInherited)
 	}
 	if v, ok := d.GetOk("include_group"); ok {
 		includeGroup, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'include_group' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'include_group' field to Boolean: %s", err)
 		}
 		getPath += fmt.Sprintf("&include_group=%v", includeGroup)
 	}

--- a/huaweicloud/services/iam/data_source_huaweicloud_identity_roles.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identity_roles.go
@@ -203,11 +203,11 @@ func flattenV3Roles(roles []interface{}) []map[string]interface{} {
 	for _, role := range roles {
 		createdAt, err := strconv.ParseInt(utils.PathSearch("created_time", role, "").(string), 10, 64)
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'created_time' field to Integer: %s", err)
+			log.Printf("[WARN] error parsing 'created_time' field to Integer: %s", err)
 		}
 		updatedAt, err := strconv.ParseInt(utils.PathSearch("updated_time", role, "").(string), 10, 64)
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'updated_time' field to Integer: %s", err)
+			log.Printf("[WARN] error parsing 'updated_time' field to Integer: %s", err)
 		}
 
 		result = append(result, map[string]interface{}{

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_application_instance.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_application_instance.go
@@ -851,7 +851,7 @@ func unmarshalJsonFormatParams(paramName, paramVal string) map[string]interface{
 	parseResult := make(map[string]interface{})
 	err := json.Unmarshal([]byte(paramVal), &parseResult)
 	if err != nil {
-		log.Printf("[ERROR] Invalid type of the %s, not json format.", paramName)
+		log.Printf("[WARN] Invalid type of the %s, not json format.", paramName)
 	}
 	return parseResult
 }
@@ -859,7 +859,7 @@ func unmarshalJsonFormatParams(paramName, paramVal string) map[string]interface{
 func marshalJsonFormatParams(paramName string, paramVal interface{}) interface{} {
 	jsonFilter, err := json.Marshal(paramVal)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert the %s, not json format.", paramName)
+		log.Printf("[WARN] unable to convert the %s, not json format.", paramName)
 	}
 	return string(jsonFilter)
 }

--- a/huaweicloud/services/ims/data_source_huaweicloud_ims_images_by_tags.go
+++ b/huaweicloud/services/ims/data_source_huaweicloud_ims_images_by_tags.go
@@ -210,7 +210,7 @@ func buildIMSImagesByTagsQueryParams(d *schema.ResourceData) map[string]interfac
 	if v, ok := d.GetOk("without_any_tag"); ok {
 		withoutAnyTag, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'without_any_tag' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'without_any_tag' field to Boolean: %s", err)
 		}
 		bodyParams["without_any_tag"] = withoutAnyTag
 	}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_linkage_rules.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_linkage_rules.go
@@ -596,7 +596,7 @@ func flattenLinkageRuleActions(ruleActions []interface{}) []interface{} {
 				commandBody := utils.PathSearch("command_body", commandCmd, nil)
 				jsonStr, err := json.Marshal(commandBody)
 				if err != nil {
-					log.Printf("[ERROR] Convert the command_body to string failed: %s", err)
+					log.Printf("[WARN] Convert the command_body to string failed: %s", err)
 				}
 
 				rst = append(rst, flattenActionDeviceCommand(actionType, string(jsonStr), deviceCommand))

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_data_backlog_policy.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_data_backlog_policy.go
@@ -66,7 +66,7 @@ func ResourceDataBacklogPolicy() *schema.Resource {
 func buildBacklogRequestValue(value string) interface{} {
 	r, err := strconv.Atoi(value)
 	if err != nil {
-		log.Printf("[ERROR] error converting string value to int value: %s", err)
+		log.Printf("[WARN] error converting string value to int value: %s", err)
 		return nil
 	}
 

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go
@@ -769,7 +769,7 @@ func flattenTriggerAttributes(respBody interface{}) []interface{} {
 func flattenDeviceCommandAttribute(cmd interface{}, actionType string, actionResp interface{}) map[string]interface{} {
 	jsonStr, err := json.Marshal(utils.PathSearch("command_body", cmd, nil))
 	if err != nil {
-		log.Printf("[ERROR] Convert the command_body to string failed: %s", err)
+		log.Printf("[WARN] Convert the command_body to string failed: %s", err)
 	}
 
 	return map[string]interface{}{

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_message.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_message.go
@@ -192,7 +192,7 @@ func buildCreateDeviceMessagePropertiesParams(properties []interface{}) map[stri
 func buildDeviceMessageTTLRequestValue(value string) interface{} {
 	v, err := strconv.Atoi(value)
 	if err != nil {
-		log.Printf("[ERROR] error converting string value to int value: %s", err)
+		log.Printf("[WARN] error converting string value to int value: %s", err)
 		return nil
 	}
 

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_background_tasks.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_background_tasks.go
@@ -152,7 +152,7 @@ func DataSourceDmsKafkaBackgroundTasksRead(_ context.Context, d *schema.Resource
 		taskCount := utils.PathSearch("task_count", listRespBody, "0").(string)
 		totalCount, err := strconv.Atoi(taskCount)
 		if err != nil {
-			log.Printf("[ERROR] failed to parse task count: %s", err)
+			log.Printf("[WARN] failed to parse task count: %s", err)
 		}
 		if totalCount <= start-1 {
 			break

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_flavors.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_flavors.go
@@ -300,7 +300,7 @@ func flattenIOs(ios []products.IOEntity) []map[string]interface{} {
 func convertStringNumberIgnoreErr(strNum string) int {
 	result, err := strconv.Atoi(strNum)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse string to number: %s", err)
+		log.Printf("[WARN] failed to parse string to number: %s", err)
 	}
 	return result
 }

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_instances.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_instances.go
@@ -570,7 +570,7 @@ func flattenInstances(conf *config.Config, region string, instances []interface{
 
 		createdAt, err := strconv.Atoi(utils.PathSearch("created_at", val, "").(string))
 		if err != nil {
-			log.Printf("[ERROR] error converting created_at to int: %v", err)
+			log.Printf("[WARN] error converting created_at to int: %v", err)
 		}
 
 		instance := map[string]interface{}{

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
@@ -1018,11 +1018,11 @@ func createKafkaInstanceWithProductID(ctx context.Context, d *schema.ResourceDat
 	bandwidth := product.Bandwidth
 	defaultPartitionNum, err := strconv.ParseInt(product.PartitionNum, 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'PartitionNum' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'PartitionNum' field to Integer: %s", err)
 	}
 	defaultStorageSpace, err := strconv.ParseInt(product.Storage, 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'Storage' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'Storage' field to Integer: %s", err)
 	}
 
 	// check storage
@@ -1344,7 +1344,7 @@ func resourceDmsKafkaInstanceRead(ctx context.Context, d *schema.ResourceData, m
 
 	partitionNum, err := strconv.ParseInt(v.PartitionNum, 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'PartitionNum' field to Integer: %s", err)
+		log.Printf("[WARN] error parsing 'PartitionNum' field to Integer: %s", err)
 	}
 	// Convert the AZ ids to AZ codes.
 	availableZoneIDs := v.AvailableZones
@@ -1373,7 +1373,7 @@ func resourceDmsKafkaInstanceRead(ctx context.Context, d *schema.ResourceData, m
 	}
 	createdAt, err := strconv.Atoi(v.CreatedAt)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse created at: %s", err)
+		log.Printf("[WARN] failed to parse created at: %s", err)
 	}
 
 	mErr = multierror.Append(mErr,

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_user_client_quota.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_user_client_quota.go
@@ -247,11 +247,11 @@ func filterUserClientQuota(parts []string, resp interface{}) interface{} {
 	}
 	rawUserDefault, err := strconv.ParseBool(parts[2])
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'user_default' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'user_default' field to Boolean: %s", err)
 	}
 	rawClientDefault, err := strconv.ParseBool(parts[4])
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'client_default' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'client_default' field to Boolean: %s", err)
 	}
 
 	for _, quota := range quotaArray {

--- a/huaweicloud/services/lb/data_source_huaweicloud_lb_listeners.go
+++ b/huaweicloud/services/lb/data_source_huaweicloud_lb_listeners.go
@@ -348,7 +348,7 @@ func buildListListenersQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("http2_enable"); ok {
 		http2Enable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'http2_enable' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'http2_enable' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&http2_enable=%v", res, http2Enable)
 	}

--- a/huaweicloud/services/lb/data_source_huaweicloud_lb_whitelists.go
+++ b/huaweicloud/services/lb/data_source_huaweicloud_lb_whitelists.go
@@ -131,7 +131,7 @@ func buildGetLbWhitelistsQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("enable_whitelist"); ok {
 		enableWhitelist, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'enable_whitelist' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'enable_whitelist' field to Boolean: %s", err)
 		}
 		res = fmt.Sprintf("%s&enable_whitelist=%v", res, enableWhitelist)
 	}

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_listener.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_listener.go
@@ -278,11 +278,11 @@ func buildListenerInsertHeaders(d *schema.ResourceData) map[string]interface{} {
 		if v, ok := rawInsertHeaders.([]interface{})[0].(map[string]interface{}); ok {
 			xForwardedElbIp, err := strconv.ParseBool(v["x_forwarded_elb_ip"].(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'x_forwarded_elb_ip' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'x_forwarded_elb_ip' field to Boolean: %s", err)
 			}
 			xForwardedHost, err := strconv.ParseBool(v["x_forwarded_host"].(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'x_forwarded_host' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'x_forwarded_host' field to Boolean: %s", err)
 			}
 			params := map[string]interface{}{
 				"X-Forwarded-ELB-IP": xForwardedElbIp,
@@ -302,7 +302,7 @@ func updateListenerTransparentClientIP(client *golangsdk.ServiceClient, listener
 
 	enabled, err := strconv.ParseBool(transparentClientIpEnable)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'transparent_client_ip_enable' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'transparent_client_ip_enable' field to Boolean: %s", err)
 	}
 
 	updateOpt := golangsdk.RequestOpts{

--- a/huaweicloud/services/meeting/resource_huaweicloud_meeting_conference.go
+++ b/huaweicloud/services/meeting/resource_huaweicloud_meeting_conference.go
@@ -992,7 +992,7 @@ func resourceConferenceRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("join_password", flattenJoinPasswords(resp.Conference.PasswordEntry)),
 	)
 	if timezoneId, err := strconv.Atoi(resp.Conference.TimeZoneId); err != nil {
-		log.Printf("[ERROR] The format of timezone ID (%#v) is wrong: %v", resp.Conference.TimeZoneId, err)
+		log.Printf("[WARN] The format of timezone ID (%#v) is wrong: %v", resp.Conference.TimeZoneId, err)
 	} else {
 		mErr = multierror.Append(mErr, d.Set("timezone_id", timezoneId))
 	}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
@@ -278,7 +278,7 @@ func buildPrepaidOptionsBodyParams(d *schema.ResourceData) map[string]interface{
 func parseAutoRenewValue(autoRenew string) bool {
 	result, err := strconv.ParseBool(autoRenew)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert auto_renew to bool value")
+		log.Printf("[WARN] unable to convert auto_renew to bool value")
 		return false
 	}
 	return result

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
@@ -661,7 +661,7 @@ func buildNodeGroupOpts(d *schema.ResourceData, optsRaw []interface{}, defaultNa
 func bulidClusterChargeMode(d *schema.ResourceData) *clusterv2.ChargeInfo {
 	autoRenew, err := strconv.ParseBool(d.Get("auto_renew").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'auto_renew' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'auto_renew' field to Boolean: %s", err)
 	}
 	return &clusterv2.ChargeInfo{
 		ChargeMode:  "prePaid",
@@ -690,7 +690,7 @@ func bulidNodeGroupChargeInfo(nodeGroup map[string]interface{}, d *schema.Resour
 	if autoRenew, ok := nodeGroup["auto_renew"].(string); ok && autoRenew != "" {
 		isAutoRenew, err := strconv.ParseBool(autoRenew)
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'auto_renew' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'auto_renew' field to Boolean: %s", err)
 		}
 		nodeChargeInfo.IsAutoRenew = utils.Bool(isAutoRenew)
 	}

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
@@ -526,7 +526,7 @@ func buildUpdatePublicGatewayChargingModeBodyParams(d *schema.ResourceData) map[
 	if v, ok := d.GetOk("auto_renew"); ok {
 		autoRenew, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'auto_renew' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'auto_renew' field to Boolean: %s", err)
 		}
 		bodyParams["is_auto_renew"] = autoRenew
 	}

--- a/huaweicloud/services/rabbitmq/data_source_huaweicloud_dms_rabbitmq_instances.go
+++ b/huaweicloud/services/rabbitmq/data_source_huaweicloud_dms_rabbitmq_instances.go
@@ -311,7 +311,7 @@ func resourceDmsRabbitMQInstancesRead(_ context.Context, d *schema.ResourceData,
 			}
 			createdAt, err := strconv.ParseInt(utils.PathSearch("created_at", v, "").(string), 10, 64)
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'created_at' field to Int: %s", err)
+				log.Printf("[WARN] error parsing 'created_at' field to Int: %s", err)
 			}
 			totalResults = append(totalResults, map[string]interface{}{
 				"id":                         utils.PathSearch("instance_id", v, nil),

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_instance.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_instance.go
@@ -631,7 +631,7 @@ func resourceDmsRabbitmqInstanceRead(_ context.Context, d *schema.ResourceData, 
 
 	createdAt, err := strconv.ParseInt(v.CreatedAt, 10, 64)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'createdAt' field to Int: %s", err)
+		log.Printf("[WARN] error parsing 'createdAt' field to Int: %s", err)
 	}
 	mErr = multierror.Append(mErr,
 		d.Set("region", region),

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_flavors.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_flavors.go
@@ -223,7 +223,7 @@ func flattenGetFlavors(resp interface{}, d *schema.ResourceData) []interface{} {
 
 		vcpusValue, err := strconv.Atoi(vcpusRaw.(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse VCPUs: %s", err)
+			log.Printf("[WARN] failed to parse VCPUs: %s", err)
 		}
 		rst = append(rst, map[string]interface{}{
 			"id":                 utils.PathSearch("id", v, nil),

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_subscriptions.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_subscriptions.go
@@ -328,7 +328,7 @@ func buildListSubscriptionsQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("is_cloud"); ok {
 		isCloud, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'is_cloud' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'is_cloud' field to Boolean: %s", err)
 		}
 		queryParams += fmt.Sprintf("&is_cloud=%v", isCloud)
 	}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -2509,7 +2509,7 @@ func updateDeleteBackupSelection(ctx context.Context, d *schema.ResourceData, cl
 func buildDeleteBackupSelectionBodyParams(d *schema.ResourceData) map[string]interface{} {
 	deleteBackupSelection, err := strconv.ParseBool(d.Get("delete_backup_selection").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'delete_backup_selection' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'delete_backup_selection' field to Boolean: %s", err)
 	}
 	bodyParams := map[string]interface{}{
 		"selection": deleteBackupSelection,

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_intelligent_session_kill.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_intelligent_session_kill.go
@@ -112,7 +112,7 @@ func buildCreateIntelligentSessionKillBodyParams(d *schema.ResourceData) map[str
 	if v, ok := d.GetOk("auto_add_sql_limit_rule"); ok {
 		autoAddSqlLimitRule, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'auto_add_sql_limit_rule' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'auto_add_sql_limit_rule' field to Boolean: %s", err)
 		}
 		bodyParams["auto_add_sql_limit_rule"] = autoAddSqlLimitRule
 	}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_publication.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_publication.go
@@ -472,7 +472,7 @@ func buildCreatePublicationBodyParams(d *schema.ResourceData) (map[string]interf
 	}
 	isCreateSnapshotImmediately, err := strconv.ParseBool(d.Get("is_create_snapshot_immediately").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'is_create_snapshot_immediately' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'is_create_snapshot_immediately' field to Boolean: %s", err)
 	}
 	bodyParams := map[string]interface{}{
 		"publication_name":               d.Get("publication_name"),
@@ -486,7 +486,7 @@ func buildCreatePublicationBodyParams(d *schema.ResourceData) (map[string]interf
 	if v, ok := d.GetOk("is_select_all_table"); ok {
 		isSelectAllTable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'is_select_all_table' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'is_select_all_table' field to Boolean: %s", err)
 		}
 		bodyParams["is_select_all_table"] = isSelectAllTable
 	}
@@ -504,28 +504,28 @@ func buildPublicationSubscriptionOptionsBodyParams(subscriptionOptionsRaw interf
 		if v["independent_agent"] != nil {
 			independentAgent, err := strconv.ParseBool(v["independent_agent"].(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'independent_agent' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'independent_agent' field to Boolean: %s", err)
 			}
 			bodyParams["independent_agent"] = independentAgent
 		}
 		if v["snapshot_always_available"] != nil {
 			snapshotAlwaysAvailable, err := strconv.ParseBool(v["snapshot_always_available"].(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'snapshot_always_available' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'snapshot_always_available' field to Boolean: %s", err)
 			}
 			bodyParams["snapshot_always_available"] = snapshotAlwaysAvailable
 		}
 		if v["replicate_ddl"] != nil {
 			replicateDdl, err := strconv.ParseBool(v["replicate_ddl"].(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'replicate_ddl' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'replicate_ddl' field to Boolean: %s", err)
 			}
 			bodyParams["replicate_ddl"] = replicateDdl
 		}
 		if v["allow_initialize_from_backup"] != nil {
 			allowInitializeFromBackup, err := strconv.ParseBool(v["allow_initialize_from_backup"].(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'allow_initialize_from_backup' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'allow_initialize_from_backup' field to Boolean: %s", err)
 			}
 			bodyParams["allow_initialize_from_backup"] = allowInitializeFromBackup
 		}
@@ -947,7 +947,7 @@ func flattenPublicationTablesFilterFilters(filter interface{}) []interface{} {
 	for _, v := range filterArray {
 		jsonRaw, err := json.Marshal(v)
 		if err != nil {
-			log.Printf("[ERROR] unable to convert the filter to json")
+			log.Printf("[WARN] unable to convert the filter to json")
 		} else {
 			rst = append(rst, string(jsonRaw))
 		}
@@ -1058,7 +1058,7 @@ func buildUpdatePublicationBodyParams(d *schema.ResourceData) (map[string]interf
 	if v, ok := d.GetOk("is_select_all_table"); ok {
 		isSelectAllTable, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'is_select_all_table' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'is_select_all_table' field to Boolean: %s", err)
 		}
 		bodyParams["is_select_all_table"] = isSelectAllTable
 	}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_asset.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_asset.go
@@ -4179,7 +4179,7 @@ func flattenLevelAttribute(respValue interface{}) int {
 
 	r, err := strconv.Atoi(stringValue)
 	if err != nil {
-		log.Printf("[ERROR] convert the string %q to int failed.", stringValue)
+		log.Printf("[WARN] convert the string %q to int failed.", stringValue)
 	}
 
 	return r

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_layout_wizard.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_layout_wizard.go
@@ -169,7 +169,7 @@ func convertStringToBool(stringValue string) interface{} {
 
 	boolValue, err := strconv.ParseBool(stringValue)
 	if err != nil {
-		log.Printf("[ERROR] error converting string %s to boolean: %s", stringValue, err)
+		log.Printf("[WARN] error converting string %s to boolean: %s", stringValue, err)
 		return nil
 	}
 

--- a/huaweicloud/services/sfsturbo/data_source_huaweicloud_sfs_turbos.go
+++ b/huaweicloud/services/sfsturbo/data_source_huaweicloud_sfs_turbos.go
@@ -168,7 +168,7 @@ func flattenTurbos(turbos []interface{}) ([]map[string]interface{}, []string) {
 			// High-precision to low-precision, discarding digits after the dot (.).
 			floatSize, err := strconv.ParseFloat(turbo.Size, 64)
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'size' field to Float: %s", err)
+				log.Printf("[WARN] error parsing 'size' field to Float: %s", err)
 			}
 			rm["size"] = int(floatSize)
 

--- a/huaweicloud/services/smn/data_source_huaweicloud_smn_resources_by_tags.go
+++ b/huaweicloud/services/smn/data_source_huaweicloud_smn_resources_by_tags.go
@@ -258,7 +258,7 @@ func buildResourcesByTagsQueryParams(d *schema.ResourceData) map[string]interfac
 	if v, ok := d.GetOk("without_any_tag"); ok {
 		withoutAnyTag, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'without_any_tag' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'without_any_tag' field to Boolean: %s", err)
 		}
 		bodyParams["without_any_tag"] = withoutAnyTag
 	}

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_image_retention_policy.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_image_retention_policy.go
@@ -254,12 +254,12 @@ func resourceSwrImageRetentionPolicyRead(_ context.Context, d *schema.ResourceDa
 	if template.(string) == "date_rule" {
 		number, err = strconv.Atoi(utils.PathSearch("params.days", policies[0], "0").(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse retention days: %s", err)
+			log.Printf("[WARN] failed to parse retention days: %s", err)
 		}
 	} else {
 		number, err = strconv.Atoi(utils.PathSearch("params.num", policies[0], "0").(string))
 		if err != nil {
-			log.Printf("[ERROR] failed to parse retention number: %s", err)
+			log.Printf("[WARN] failed to parse retention number: %s", err)
 		}
 	}
 	mErr = multierror.Append(

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_instance.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_instance.go
@@ -2752,7 +2752,7 @@ func updatesSecondsLevelMonitoring(ctx context.Context, client *golangsdk.Servic
 func updateSslOption(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData, timeout string) error {
 	sslOption, err := strconv.ParseBool(d.Get("ssl_option").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'ssl_option' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'ssl_option' field to Boolean: %s", err)
 	}
 	updateSslOptionOpts := instances.UpdateSslOptionOpts{
 		SslOption: sslOption,
@@ -2875,7 +2875,7 @@ func updateMultiTenantSwitch(ctx context.Context, client *golangsdk.ServiceClien
 
 	multiTenantSwitch, err := strconv.ParseBool(d.Get("multi_tenant_switch").(string))
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'multi_tenant_switch' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'multi_tenant_switch' field to Boolean: %s", err)
 	}
 	updateOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/tms/data_source_huaweicloud_tms_resource_instances.go
+++ b/huaweicloud/services/tms/data_source_huaweicloud_tms_resource_instances.go
@@ -220,7 +220,7 @@ func buildGetTmsResourceInstancesBodyParams(d *schema.ResourceData, limit, offse
 	if v, ok := d.GetOk("without_any_tag"); ok {
 		withoutAnyTag, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'without_any_tag' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'without_any_tag' field to Boolean: %s", err)
 		}
 		bodyParams["without_any_tag"] = withoutAnyTag
 	}

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup.go
@@ -384,7 +384,7 @@ func flattenSecurityGroupRulesV3(rules []v3rules.SecurityGroupRule) ([]map[strin
 				}
 				minVal, err := strconv.Atoi(rangeSet[1])
 				if err != nil {
-					log.Printf("[ERROR] failed to parse port range min: %s", err)
+					log.Printf("[WARN] failed to parse port range min: %s", err)
 				}
 				ruleInfo["port_range_min"] = minVal
 				if rangeSet[2] == "" {
@@ -392,7 +392,7 @@ func flattenSecurityGroupRulesV3(rules []v3rules.SecurityGroupRule) ([]map[strin
 				} else {
 					maxVal, err := strconv.Atoi(rangeSet[2])
 					if err != nil {
-						log.Printf("[ERROR] failed to parse port range max: %s", err)
+						log.Printf("[WARN] failed to parse port range max: %s", err)
 					}
 					ruleInfo["port_range_max"] = maxVal
 				}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -150,7 +150,7 @@ func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceDa
 	if v, ok := d.GetOk("enhanced_local_route"); ok {
 		enhancedLocalRoute, err := strconv.ParseBool(v.(string))
 		if err != nil {
-			log.Printf("[ERROR] error parsing 'enhanced_local_route' field to Boolean: %s", err)
+			log.Printf("[WARN] error parsing 'enhanced_local_route' field to Boolean: %s", err)
 		}
 		createOpts.EnhancedLocalRoute = &enhancedLocalRoute
 	}
@@ -320,7 +320,7 @@ func resourceVirtualPrivateCloudUpdate(ctx context.Context, d *schema.ResourceDa
 		if d.HasChange("enhanced_local_route") {
 			enhancedLocalRoute, err := strconv.ParseBool(d.Get("enhanced_local_route").(string))
 			if err != nil {
-				log.Printf("[ERROR] error parsing 'enhanced_local_route' field to Boolean: %s", err)
+				log.Printf("[WARN] error parsing 'enhanced_local_route' field to Boolean: %s", err)
 			}
 			updateOpts.EnhancedLocalRoute = &enhancedLocalRoute
 		}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
@@ -180,7 +180,7 @@ func getAutoRenewValue(autoRenew string) bool {
 	}
 	result, err := strconv.ParseBool(autoRenew)
 	if err != nil {
-		log.Printf("[ERROR] error parsing auto_renew to Boolean: %s", err)
+		log.Printf("[WARN] error parsing auto_renew to Boolean: %s", err)
 	}
 	return result
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
@@ -1034,11 +1034,11 @@ func flattenCertificationAttribute(respBody interface{}) map[string]interface{} 
 
 	pciDss, err := strconv.ParseBool(pciDssRaw)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'pci_dss' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'pci_dss' field to Boolean: %s", err)
 	}
 	pci3ds, err := strconv.ParseBool(pci3dsRaw)
 	if err != nil {
-		log.Printf("[ERROR] error parsing 'pci_3ds' field to Boolean: %s", err)
+		log.Printf("[WARN] error parsing 'pci_3ds' field to Boolean: %s", err)
 	}
 	return map[string]interface{}{
 		"pci_dss": pciDss,

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_policy_v2.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_policy_v2.go
@@ -302,7 +302,7 @@ func convertStringToBool(stringValue string) interface{} {
 
 	boolValue, err := strconv.ParseBool(stringValue)
 	if err != nil {
-		log.Printf("[ERROR] error converting string %s to boolean: %s", stringValue, err)
+		log.Printf("[WARN] error converting string %s to boolean: %s", stringValue, err)
 		return nil
 	}
 

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_service.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_service.go
@@ -301,7 +301,7 @@ func parseDataServiceInternetAccessPort(portStr string) int {
 
 	portNum, err = strconv.Atoi(portStr)
 	if err != nil {
-		log.Printf("[ERROR] error converting internet access port (value: %s) from string to integer: %s", portStr, err)
+		log.Printf("[WARN] error converting internet access port (value: %s) from string to integer: %s", portStr, err)
 	}
 	return portNum
 }

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server.go
@@ -242,7 +242,7 @@ func buildCreatePeriodTypeParam(periodUnit string) interface{} {
 func parseAutoRenewValue(autoRenew string) bool {
 	result, err := strconv.ParseBool(autoRenew)
 	if err != nil {
-		log.Printf("[ERROR] unable to convert auto_renew to bool value")
+		log.Printf("[WARN] unable to convert auto_renew to bool value")
 		return false
 	}
 	return result

--- a/huaweicloud/utils/resource_diff.go
+++ b/huaweicloud/utils/resource_diff.go
@@ -825,11 +825,11 @@ func diffStrSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceData,
 	// Get current values
 	oldCount, err := strconv.Atoi(oldVal)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse old count: %s", err)
+		log.Printf("[WARN] failed to parse old count: %s", err)
 	}
 	newCount, err := strconv.Atoi(newVal)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse new count: %s", err)
+		log.Printf("[WARN] failed to parse new count: %s", err)
 	}
 
 	// If origin is empty or nil, this is the first time setting the value
@@ -1923,11 +1923,11 @@ func diffObjectSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceDa
 	// Get current values
 	oldCount, err := strconv.Atoi(oldVal)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse old count: %s", err)
+		log.Printf("[WARN] failed to parse old count: %s", err)
 	}
 	newCount, err := strconv.Atoi(newVal)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse new count: %s", err)
+		log.Printf("[WARN] failed to parse new count: %s", err)
 	}
 
 	// If counts are the same, suppress diff

--- a/huaweicloud/utils/times.go
+++ b/huaweicloud/utils/times.go
@@ -32,7 +32,7 @@ func ConvertTimeStrToNanoTimestamp(timeStr string, customFormat ...string) int64
 	}
 	t, err := time.Parse(timeFormat, timeStr)
 	if err != nil {
-		log.Printf("error parsing the input time (%s), the time string does not match time format (%s): %s",
+		log.Printf("[WARN] error parsing the input time (%s), the time string does not match time format (%s): %s",
 			timeStr, timeFormat, err)
 		return 0
 	}
@@ -51,7 +51,7 @@ func GetTimezoneCode() int {
 	timeStr := strings.Split(time.Now().String(), " ")[2]
 	timezoneNum, err := strconv.Atoi(timeStr)
 	if err != nil {
-		log.Printf("[ERROR] failed to parse timezone string: %s", err)
+		log.Printf("[WARN] failed to parse timezone string: %s", err)
 	}
 	return timezoneNum / 100
 }
@@ -98,7 +98,7 @@ func CalculateNextWholeHourAfterFewTime(inputTimeStr string, interval time.Durat
 	customOutputFormat ...string) string {
 	parsedTime, err := time.Parse(time.RFC3339, inputTimeStr)
 	if err != nil {
-		log.Printf("[ERROR] incorrect time format for the input time: %s", inputTimeStr)
+		log.Printf("[WARN] incorrect time format for the input time: %s", inputTimeStr)
 		return ""
 	}
 

--- a/huaweicloud/utils/type_convert.go
+++ b/huaweicloud/utils/type_convert.go
@@ -46,7 +46,7 @@ func StringToInt(i *string) *int {
 
 	r, err := strconv.Atoi(*i)
 	if err != nil {
-		log.Printf("[ERROR] convert the string %q to int failed.", *i)
+		log.Printf("[WARN] convert the string %q to int failed.", *i)
 	}
 	return &r
 }
@@ -56,7 +56,7 @@ func StringToBool(v interface{}) *bool {
 	if v, ok := v.(string); ok {
 		b, err := strconv.ParseBool(v)
 		if err != nil {
-			log.Printf("[ERROR] convert the string %q to boolean failed.", v)
+			log.Printf("[WARN] convert the string %q to boolean failed.", v)
 		}
 
 		return &b
@@ -101,7 +101,7 @@ func StringToJson(jsonStrObj string, defaultVal ...interface{}) interface{} {
 	var jsonResult interface{}
 	err := json.Unmarshal([]byte(jsonStrObj), &jsonResult)
 	if err != nil {
-		log.Printf("[ERROR] Unable to convert the JSON string to the map object: %s", err)
+		log.Printf("[WARN] Unable to convert the JSON string to the map object: %s", err)
 	}
 	return jsonResult
 }
@@ -115,7 +115,7 @@ func StringToJsonArray(jsonStrArray string) interface{} {
 	jsonArray := make([]map[string]interface{}, 0)
 	err := json.Unmarshal([]byte(jsonStrArray), &jsonArray)
 	if err != nil {
-		log.Printf("[ERROR] Unable to convert the JSON string to the JSON array: %s", err)
+		log.Printf("[WARN] Unable to convert the JSON string to the JSON array: %s", err)
 	}
 	return jsonArray
 }
@@ -127,7 +127,7 @@ func JsonToString(jsonObj interface{}) string {
 	}
 	jsonStr, err := json.Marshal(jsonObj)
 	if err != nil {
-		log.Printf("[ERROR] Unable to convert the JSON object to string: %s", err)
+		log.Printf("[WARN] Unable to convert the JSON object to string: %s", err)
 	}
 	return string(jsonStr)
 }

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -558,11 +558,11 @@ func ConvertMemoryUnit(memory interface{}, diffLevel int) int {
 		var err error
 		memoryInt, err = strconv.Atoi(memory)
 		if err != nil {
-			log.Printf("convert string value (%v) to int fail: %s", memory, err)
+			log.Printf("[WARN] convert string value (%v) to int fail: %s", memory, err)
 			return -1
 		}
 	default:
-		log.Printf("unsupported memory unit type, want 'int' or 'string', but got '%T'", memory)
+		log.Printf("[WARN] unsupported memory unit type, want 'int' or 'string', but got '%T'", memory)
 		return -1
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Type conversion / parsing failure logs, including:

- `strconv` usage (`Atoi`, `ParseBool`, `ParseInt`, `ParseFloat`, etc.)
- Project helpers (`StringToInt` / `StringToBool` / `StringToJson*` / `JsonToString`, time formatting/parsing helpers, memory unit conversion, JSON template comparison)
- Related “failed to parse / convert / JSON” soft-failure paths in service code

Out of scope: unrelated ERROR logs (API failures, missing nested fields from response flatten, etc.).

- Downgrade type-conversion failure logs from `[ERROR]` to `[WARN]` across the provider (~199 call sites in 119 files).
- Align log severity for non-fatal conversion/parsing issues so Terraform runs are not flooded with ERROR noise when values fail to convert but execution continues with defaults or soft handling.
- Cover shared helpers (`utils/type_convert.go`, `utils/times.go`, `utils/utils.go`, `utils/resource_diff.go`), common helpers (e.g. pagination offset/limit parsing), `config/upgrade.go` version parsing, service resources/data sources, and related acceptance-test helpers.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. degrade the report level for type conversion
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
