### PR TITLE
refactor(format): replace []byte(fmt.Sprintf) with fmt.Appendf for error bod

### DIFF
--- a/huaweicloud/common/errors.go
+++ b/huaweicloud/common/errors.go
@@ -291,7 +291,7 @@ func getExpectedErrCode(err error, errStatusNum int, errCodeKey string) (string,
 	if jsonErr != nil {
 		return "", golangsdk.ErrDefault400{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("error parsing the request error: %s", jsonErr)),
+				Body: fmt.Appendf(nil, "error parsing the request error: %s", jsonErr),
 			},
 		}
 	}
@@ -300,8 +300,8 @@ func getExpectedErrCode(err error, errStatusNum int, errCodeKey string) (string,
 		// 4xx means the client parsing was failed.
 		return errCode, golangsdk.ErrDefault400{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given status "+
-					"number (%d) and the error code key (%s), the error is: '%v'", errStatusNum, errCodeKey, err)),
+				Body: fmt.Appendf(nil, "Unable to find the error code from the error body using given status "+
+					"number (%d) and the error code key (%s), the error is: '%v'", errStatusNum, errCodeKey, err),
 			},
 		}
 	}

--- a/huaweicloud/config/eps_management.go
+++ b/huaweicloud/config/eps_management.go
@@ -180,7 +180,7 @@ func getAssociatedResourceById(client *golangsdk.ServiceClient, projectId, epsId
 	}
 	return nil, golangsdk.ErrDefault404{
 		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-			Body: []byte(fmt.Sprintf("unable to find the resource under a specified enterprise_project_id (%s)", epsId)),
+			Body: fmt.Appendf(nil, "unable to find the resource under a specified enterprise_project_id (%s)", epsId),
 		},
 	}
 }

--- a/huaweicloud/services/aad/resource_huaweicloud_aad_forward_rule.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_forward_rule.go
@@ -131,7 +131,7 @@ func GetForwardRuleFromServer(client *golangsdk.ServiceClient, instanceId, advan
 				Method:    "GET",
 				URL:       "/v1/aad/instances/{instance_id}/{ip}/rules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the Advanced Anti-DDoS forward rule (%s/%s) does not exist", instanceId, advancedIp)),
+				Body:      fmt.Appendf(nil, "the Advanced Anti-DDoS forward rule (%s/%s) does not exist", instanceId, advancedIp),
 			},
 		}
 	}
@@ -143,7 +143,7 @@ func GetForwardRuleFromServer(client *golangsdk.ServiceClient, instanceId, advan
 			Method:    "GET",
 			URL:       "/v1/aad/instances/{instance_id}/{ip}/rules",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("no Advanced Anti-DDoS forward rule matched the given protocol (%s) and (or) port (%d)", protocol, port)),
+			Body:      fmt.Appendf(nil, "no Advanced Anti-DDoS forward rule matched the given protocol (%s) and (or) port (%d)", protocol, port),
 		},
 	}
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_publication_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_publication_test.go
@@ -59,7 +59,7 @@ func getPublication(cfg *config.Config, state *terraform.ResourceState) (interfa
 				Method:    "GET",
 				URL:       "/v3/{project_id}/instances/{instance_id}/replication/publications",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the RDS publication (%s) does not exist", state.Primary.ID)),
+				Body:      fmt.Appendf(nil, "the RDS publication (%s) does not exist", state.Primary.ID),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_group_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_group_rule.go
@@ -252,7 +252,7 @@ func GetAlarmGroupRule(client *golangsdk.ServiceClient, name string) (interface{
 				Method:    "GET",
 				URL:       "/v2/{project_id}/alert/group-rules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the alarm group rule (%s) does not exist", name)),
+				Body:      fmt.Appendf(nil, "the alarm group rule (%s) does not exist", name),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_inhibit_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_inhibit_rule.go
@@ -229,7 +229,7 @@ func GetAlarmInhibitRuleByName(client *golangsdk.ServiceClient, epsId, name stri
 				Method:    "GET",
 				URL:       "/v2/{project_id}/alert/inhibit-rules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("The alarm inhibit rule (%s) not found", name)),
+				Body:      fmt.Appendf(nil, "The alarm inhibit rule (%s) not found", name),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rule.go
@@ -335,7 +335,7 @@ func GetV2AlarmRule(client *golangsdk.ServiceClient, ruleId string) (interface{}
 				Method:    "GET",
 				URL:       "/v2/{project_id}/alarm-rules/{alarm_rule_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the alarm rule (%s) does not exist", ruleId)),
+				Body:      fmt.Appendf(nil, "the alarm rule (%s) does not exist", ruleId),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rules_template.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rules_template.go
@@ -729,7 +729,7 @@ func getAlarmRulesTemplate(client *golangsdk.ServiceClient, d *schema.ResourceDa
 				Method:    "GET",
 				URL:       "/v4/{project_id}/alarm-rules-template",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the alarm rules template (%s) does not exist", templateId)),
+				Body:      fmt.Appendf(nil, "the alarm rules template (%s) does not exist", templateId),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_cloud_service_access.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_cloud_service_access.go
@@ -180,7 +180,7 @@ func getCloudServiceAccesss(client *golangsdk.ServiceClient, d *schema.ResourceD
 				Method:    "GET",
 				URL:       "/v1/{project_id}/prometheus/{prom_instance_id}/cloud-service/{provider}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the cloud service access (%s/%s) does not exist", instanceId, service)),
+				Body:      fmt.Appendf(nil, "the cloud service access (%s/%s) does not exist", instanceId, service),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_dashboard.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_dashboard.go
@@ -247,7 +247,7 @@ func filterDashboard(client *golangsdk.ServiceClient, d *schema.ResourceData) er
 				Method:    "GET",
 				URL:       "/v2/{project_id}/aom/dashboards",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the dashboard (%s) does not exist", dashboardId)),
+				Body:      fmt.Appendf(nil, "the dashboard (%s) does not exist", dashboardId),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_dashboards_folder.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_dashboards_folder.go
@@ -173,7 +173,7 @@ func getDashboardsFolder(client *golangsdk.ServiceClient, d *schema.ResourceData
 				Method:    "GET",
 				URL:       "/v2/{project_id}/aom/dashboards-folder",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the dashboards folder (%s) does not exist", folderId)),
+				Body:      fmt.Appendf(nil, "the dashboards folder (%s) does not exist", folderId),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_multi_account_aggregation_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_multi_account_aggregation_rule.go
@@ -229,7 +229,7 @@ func getMultiAccountAggregationRule(client *golangsdk.ServiceClient, d *schema.R
 				Method:    "GET",
 				URL:       "/v1/{project_id}/aom/aggr-config",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the multi account aggregation rule (%s) does not exist", ruleId)),
+				Body:      fmt.Appendf(nil, "the multi account aggregation rule (%s) does not exist", ruleId),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
@@ -194,7 +194,7 @@ func GetPrometheusInstanceById(client *golangsdk.ServiceClient, isntanceId strin
 				Method:    "GET",
 				URL:       "/v1/{project_id}/aom/prometheus",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("prometheus instance (%s) not found", isntanceId)),
+				Body:      fmt.Appendf(nil, "prometheus instance (%s) not found", isntanceId),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
@@ -364,7 +364,7 @@ func GetServiceDiscoveryRule(client *golangsdk.ServiceClient, name string) (inte
 				Method:    "GET",
 				URL:       "/v1/{project_id}/inv/servicediscoveryrules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the service discovery rule (%s) does not exist", name)),
+				Body:      fmt.Appendf(nil, "the service discovery rule (%s) does not exist", name),
 			},
 		}
 	}

--- a/huaweicloud/services/aom/resource_huaweicloud_aomv4_alarm_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aomv4_alarm_rule.go
@@ -751,7 +751,7 @@ func getAlarmRule(cfg *config.Config, client *golangsdk.ServiceClient, d *schema
 				Method:    "GET",
 				URL:       "/v4/{project_id}/alarm-rules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the alarm rule (%s) does not exist", ruleName)),
+				Body:      fmt.Appendf(nil, "the alarm rule (%s) does not exist", ruleName),
 			},
 		}
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_batch_plugins_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_batch_plugins_associate.go
@@ -250,7 +250,7 @@ func GetLocalBoundPluginIdsForApi(client *golangsdk.ServiceClient, instanceId, a
 				Method:    "GET",
 				URL:       "/v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/attached-plugins",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("all locally managed plugins have been unbound: %v", originPluginIds)),
+				Body:      fmt.Appendf(nil, "all locally managed plugins have been unbound: %v", originPluginIds),
 			},
 		}
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_authorization.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_authorization.go
@@ -226,7 +226,7 @@ func GetLocalAuthorizedApiIds(client *golangsdk.ServiceClient, instanceId, envId
 				Method:    "GET",
 				URL:       "/v2/{project_id}/apigw/instances/{instance_id}/app-auths/binded-apis",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("all locally managed APIs have been deauthorized: %v", originApiIds)),
+				Body:      fmt.Appendf(nil, "all locally managed APIs have been deauthorized: %v", originApiIds),
 			},
 		}
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group_domain_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group_domain_associate.go
@@ -191,7 +191,7 @@ func GetGroupAssociatedDomainByUrl(client *golangsdk.ServiceClient, instanceId, 
 				Method:    "GET",
 				URL:       "/v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the domain (%s) does not bound to the API group (%s)", urlDomain, groupId)),
+				Body:      fmt.Appendf(nil, "the domain (%s) does not bound to the API group (%s)", urlDomain, groupId),
 			},
 		}
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_ingress_port.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_ingress_port.go
@@ -206,7 +206,7 @@ func GetInstanceIngressPortById(client *golangsdk.ServiceClient, instanceId, ing
 			Method:    "GET",
 			URL:       "/v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("ingress port (%s) is not found", ingressPortId)),
+			Body:      fmt.Appendf(nil, "ingress port (%s) is not found", ingressPortId),
 		},
 	}
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_plugin_batch_apis_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_plugin_batch_apis_associate.go
@@ -230,7 +230,7 @@ func GetLocalBoundApiIdsForPlugin(client *golangsdk.ServiceClient, instanceId, p
 				Method:    "GET",
 				URL:       "/v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attached-apis",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("all locally managed APIs have been unbound: %v", originApiIds)),
+				Body:      fmt.Appendf(nil, "all locally managed APIs have been unbound: %v", originApiIds),
 			},
 		}
 	}

--- a/huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go
@@ -324,7 +324,7 @@ func getGroupInstanceByID(client *golangsdk.ServiceClient, groupID, instanceID s
 			Method:    "GET",
 			URL:       "/autoscaling-api/v1/{project_id}/scaling_group_instance/{scaling_group_id}/list",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the instance (%s) does not exist in AS group (%s)", instanceID, groupID)),
+			Body:      fmt.Appendf(nil, "the instance (%s) does not exist in AS group (%s)", instanceID, groupID),
 		},
 	}
 }

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_environment.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_environment.go
@@ -274,7 +274,7 @@ func getEnvironmentByName(client *golangsdk.ServiceClient, epsId, envName string
 				Method:    "GET",
 				URL:       "/v1/{project_id}/cae/environments",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the environment (%s) does not exist", envName)),
+				Body:      fmt.Appendf(nil, "the environment (%s) does not exist", envName),
 			},
 		}
 	}
@@ -346,7 +346,7 @@ func GetEnvironmentById(client *golangsdk.ServiceClient, epsId, resourceId strin
 				Method:    "GET",
 				URL:       "/v1/{project_id}/cae/environments",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the environment (%s) does not exist", resourceId)),
+				Body:      fmt.Appendf(nil, "the environment (%s) does not exist", resourceId),
 			},
 		}
 	}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_organization_policy.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_organization_policy.go
@@ -546,7 +546,7 @@ func getOrganizationPolicyByName(client *golangsdk.ServiceClient, name string) (
 				Method:    "GET",
 				URL:       "/v3/{project_id}/organization-policies",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the organization policy (%s) does not exist", name)),
+				Body:      fmt.Appendf(nil, "the organization policy (%s) does not exist", name),
 			},
 		}
 	}

--- a/huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go
+++ b/huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go
@@ -314,7 +314,7 @@ func GetCciNamespaceInfoById(c *golangsdk.ServiceClient, id string) (*namespaces
 			Method:    "GET",
 			URL:       "/api/v1/namespaces",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the namespace (%s) does not exist", id)),
+			Body:      fmt.Appendf(nil, "the namespace (%s) does not exist", id),
 		},
 	}
 }

--- a/huaweicloud/services/cci/resource_huaweicloud_cci_pvc.go
+++ b/huaweicloud/services/cci/resource_huaweicloud_cci_pvc.go
@@ -297,7 +297,7 @@ func GetPvcInfoById(client *golangsdk.ServiceClient, ns, volumeType,
 	if !ok {
 		return nil, golangsdk.ErrDefault400{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("the volume type (%s) is not available", volumeType)),
+				Body: fmt.Appendf(nil, "the volume type (%s) is not available", volumeType),
 			},
 		}
 	}
@@ -323,7 +323,7 @@ func GetPvcInfoById(client *golangsdk.ServiceClient, ns, volumeType,
 			Method:    "GET",
 			URL:       "/api/v1/namespaces/{ns}/extended-persistentvolumeclaims",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the PVC (%s) does not exist", id)),
+			Body:      fmt.Appendf(nil, "the PVC (%s) does not exist", id),
 		},
 	}
 }

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_refresh.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_refresh.go
@@ -236,7 +236,7 @@ func GetCacheDetailById(client *golangsdk.ServiceClient, id string) (interface{}
 				Method:    "GET",
 				URL:       "/v1.0/cdn/historytasks/{history_tasks_id}/detail",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the cache detail (%s) does not exist", id)),
+				Body:      fmt.Appendf(nil, "the cache detail (%s) does not exist", id),
 			},
 		}
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_sharing_group.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_sharing_group.go
@@ -171,7 +171,7 @@ func GetCacheSharingGroupByName(client *golangsdk.ServiceClient, groupName strin
 				Method:    "GET",
 				URL:       "/v1.0/cdn/configuration/share-cache-groups",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the cache sharing group with name '%s' has been removed", groupName)),
+				Body:      fmt.Appendf(nil, "the cache sharing group with name '%s' has been removed", groupName),
 			},
 		}
 	}
@@ -214,7 +214,7 @@ func GetCacheSharingGroupById(client *golangsdk.ServiceClient, groupId string) (
 				Method:    "GET",
 				URL:       "/v1.0/cdn/configuration/share-cache-groups",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the cache sharing group with ID '%s' has been removed", groupId)),
+				Body:      fmt.Appendf(nil, "the cache sharing group with ID '%s' has been removed", groupId),
 			},
 		}
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_template.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_template.go
@@ -156,7 +156,7 @@ func GetDomainTemplateById(client *golangsdk.ServiceClient, tmlId string) (inter
 				Method:    "GET",
 				URL:       "/v1.0/cdn/configuration/templates",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the template with ID '%s' has been removed", tmlId)),
+				Body:      fmt.Appendf(nil, "the template with ID '%s' has been removed", tmlId),
 			},
 		}
 	}
@@ -176,7 +176,7 @@ func GetDomainTemplateByName(client *golangsdk.ServiceClient, tmlName string) (i
 				Method:    "GET",
 				URL:       "/v1.0/cdn/configuration/templates",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the template with name '%s' has been removed", tmlName)),
+				Body:      fmt.Appendf(nil, "the template with name '%s' has been removed", tmlName),
 			},
 		}
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_rule_engine_rule.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_rule_engine_rule.go
@@ -755,7 +755,7 @@ func GetRuleEngineRuleByName(client *golangsdk.ServiceClient, domainName string,
 				Method:    "GET",
 				URL:       "/v1.0/cdn/configuration/domains/{domain_name}/rules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the rule with name '%s' has been removed", ruleName)),
+				Body:      fmt.Appendf(nil, "the rule with name '%s' has been removed", ruleName),
 			},
 		}
 	}
@@ -998,7 +998,7 @@ func GetRuleEngineRuleById(client *golangsdk.ServiceClient, domainName string, r
 				Method:    "GET",
 				URL:       "/v1.0/cdn/configuration/domains/{domain_name}/rules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the rule with ID '%s' has been removed", ruleId)),
+				Body:      fmt.Appendf(nil, "the rule with ID '%s' has been removed", ruleId),
 			},
 		}
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_statistic_subscription_task.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_statistic_subscription_task.go
@@ -158,7 +158,7 @@ func getStatisticSubscriptionTaskByName(client *golangsdk.ServiceClient, taskNam
 				Method:    "GET",
 				URL:       "/v1/cdn/statistics/subscription-tasks",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the subscription task with name '%s' has been removed", taskName)),
+				Body:      fmt.Appendf(nil, "the subscription task with name '%s' has been removed", taskName),
 			},
 		}
 	}
@@ -178,7 +178,7 @@ func GetStatisticSubscriptionTaskById(client *golangsdk.ServiceClient, taskId st
 				Method:    "GET",
 				URL:       "/v1/cdn/statistics/subscription-tasks",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the subscription task with ID '%s' has been removed", taskId)),
+				Body:      fmt.Appendf(nil, "the subscription task with ID '%s' has been removed", taskId),
 			},
 		}
 	}

--- a/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
@@ -678,7 +678,7 @@ func getAlarmV1(client *golangsdk.ServiceClient, alarmId string) (interface{}, e
 				Method:    "GET",
 				URL:       "/V1.0/{project_id}/alarms/{alarm_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the (v1) alarm rule (%s) does not exist", alarmId)),
+				Body:      fmt.Appendf(nil, "the (v1) alarm rule (%s) does not exist", alarmId),
 			},
 		}
 	}
@@ -714,7 +714,7 @@ func getAlarmV2(client *golangsdk.ServiceClient, alarmId string) (interface{}, e
 				Method:    "GET",
 				URL:       "/v2/{project_id}/alarms",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the (v2) alarm rule (%s) does not exist", alarmId)),
+				Body:      fmt.Appendf(nil, "the (v2) alarm rule (%s) does not exist", alarmId),
 			},
 		}
 	}

--- a/huaweicloud/services/ces/resource_huaweicloud_ces_one_click_alarm.go
+++ b/huaweicloud/services/ces/resource_huaweicloud_ces_one_click_alarm.go
@@ -283,7 +283,7 @@ func GetOneClickAlarm(client *golangsdk.ServiceClient, id string) (interface{}, 
 				Method:    "GET",
 				URL:       "/v2/{project_id}/one-click-alarms",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the one-click alarm (%s) does not exist", id)),
+				Body:      fmt.Appendf(nil, "the one-click alarm (%s) does not exist", id),
 			},
 		}
 	}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_lts_log.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_lts_log.go
@@ -221,7 +221,7 @@ func getLtsLog(client *golangsdk.ServiceClient, id string) (interface{}, error) 
 				Method:    "GET",
 				URL:       "/v1/{project_id}/cfw/logs/configuration",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the LTS log configuration (%s) does not exist, the data field is empty", id)),
+				Body:      fmt.Appendf(nil, "the LTS log configuration (%s) does not exist, the data field is empty", id),
 			},
 		}
 	}

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_application.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_application.go
@@ -186,7 +186,7 @@ func GetApplication(client *golangsdk.ServiceClient, applicationID string) (inte
 				Method:    "GET",
 				URL:       "/v1/applications",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the application (%s) does not exist", applicationID)),
+				Body:      fmt.Appendf(nil, "the application (%s) does not exist", applicationID),
 			},
 		}
 	}

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_enterprise_project_collection.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_enterprise_project_collection.go
@@ -116,7 +116,7 @@ func getEnterpriseProjectCollection(client *golangsdk.ServiceClient, collectionI
 				Method:    "GET",
 				URL:       "/v1/enterprise-project-collect",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the enterprise project collection (%s) does not exist", collectionID)),
+				Body:      fmt.Appendf(nil, "the enterprise project collection (%s) does not exist", collectionID),
 			},
 		}
 	}

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_group.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_group.go
@@ -310,7 +310,7 @@ func GetGroup(client *golangsdk.ServiceClient, componentID string, groupID strin
 				Method:    "GET",
 				URL:       "/v1/groups",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the group (%s) does not exist", groupID)),
+				Body:      fmt.Appendf(nil, "the group (%s) does not exist", groupID),
 			},
 		}
 	}

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_war_room.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_war_room.go
@@ -421,7 +421,7 @@ func GetWarRoom(client *golangsdk.ServiceClient, warRoomNum string) (interface{}
 				Method:    "POST",
 				URL:       "/v1/external/warrooms/list",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the war room (%s) does not exist", warRoomNum)),
+				Body:      fmt.Appendf(nil, "the war room (%s) does not exist", warRoomNum),
 			},
 		}
 	}

--- a/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_application.go
+++ b/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_application.go
@@ -592,7 +592,7 @@ func getDeployApplication(client *golangsdk.ServiceClient, d *schema.ResourceDat
 				Method:    "GET",
 				URL:       "/v1/applications/{app_id}/info",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the application (%s) does not exist", applicationId)),
+				Body:      fmt.Appendf(nil, "the application (%s) does not exist", applicationId),
 			},
 		}
 	}

--- a/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_permission.go
+++ b/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_permission.go
@@ -263,7 +263,7 @@ func GetPipelineUesrPermissions(client *golangsdk.ServiceClient, projectId, pipe
 					Method:    "GET",
 					URL:       "/v5/{project_id}/api/pipeline-permissions/{pipeline_id}/user-permission",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("the user permission (user_id: %s) does not exist", userId)),
+					Body:      fmt.Appendf(nil, "the user permission (user_id: %s) does not exist", userId),
 				},
 			}
 		}
@@ -301,7 +301,7 @@ func GetPipelineRolePermissions(client *golangsdk.ServiceClient, projectId, pipe
 				Method:    "GET",
 				URL:       "/v5/{project_id}/api/pipeline-permissions/{pipeline_id}/role-permission",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the role permission (role_id: %s) does not exist", roleId)),
+				Body:      fmt.Appendf(nil, "the role permission (role_id: %s) does not exist", roleId),
 			},
 		}
 	}

--- a/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_plugin_version.go
+++ b/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_plugin_version.go
@@ -377,7 +377,7 @@ func getPipelinePluginBasicInfos(client *golangsdk.ServiceClient, d *schema.Reso
 				Method:    "POST",
 				URL:       "/v1/{domain_id}/agent-plugin/query-all",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the pipeline plugin (%s) does not exist", pluginName)),
+				Body:      fmt.Appendf(nil, "the pipeline plugin (%s) does not exist", pluginName),
 			},
 		}
 	}

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_nacos_namespace.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_nacos_namespace.go
@@ -174,7 +174,7 @@ func listNacosNamespaces(client *golangsdk.ServiceClient, engineId, enterprisePr
 					Method:    "GET",
 					URL:       httpUrl,
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("the Nacos engine (%s) does not exist", engineId)),
+					Body:      fmt.Appendf(nil, "the Nacos engine (%s) does not exist", engineId),
 				},
 			}
 		default:
@@ -203,8 +203,8 @@ func GetNacosNamespaceById(client *golangsdk.ServiceClient, engineId, enterprise
 				Method:    "GET",
 				URL:       "v1/{project_id}/nacos/v1/console/namespaces",
 				RequestId: "NONE",
-				Body: []byte(fmt.Sprintf("the namespace (%s) has been removed from the Nacos microservice engine (%s)",
-					namespaceId, engineId)),
+				Body: fmt.Appendf(nil, "the namespace (%s) has been removed from the Nacos microservice engine (%s)",
+					namespaceId, engineId),
 			},
 		}
 	}
@@ -328,8 +328,8 @@ func resourceNacosNamespaceDelete(_ context.Context, d *schema.ResourceData, met
 					Method:    "DELETE",
 					URL:       "v1/{project_id}/nacos/v1/console/namespaces?namespaceId={namespace_id}",
 					RequestId: "NONE",
-					Body: []byte(fmt.Sprintf("unable to delete the namespace because the Nacos microservice engine (%s) does not exist",
-						engineId)),
+					Body: fmt.Appendf(nil, "unable to delete the namespace because the Nacos microservice engine (%s) does not exist",
+						engineId),
 				},
 			}
 		}

--- a/huaweicloud/services/css/resource_huaweicloud_css_scan_task.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_scan_task.go
@@ -346,7 +346,7 @@ func getScanTaskByName(client *golangsdk.ServiceClient, clusterId, taskName stri
 			Method:    "GET",
 			URL:       "/v1.0/{project_id}/clusters/{cluster_id}/ai-ops",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the scan task (%s) does not exist", taskName)),
+			Body:      fmt.Appendf(nil, "the scan task (%s) does not exist", taskName),
 		},
 	}
 }

--- a/huaweicloud/services/das/resource_huaweicloud_das_email_template.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_email_template.go
@@ -220,7 +220,7 @@ func GetEmailTemplateById(client *golangsdk.ServiceClient, datastoreType, templa
 			Method:    "GET",
 			URL:       "/v3/{project_id}/batch-inspection/email-template",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the email template (%s) has been removed", templateId)),
+			Body:      fmt.Appendf(nil, "the email template (%s) has been removed", templateId),
 		},
 	}
 }

--- a/huaweicloud/services/das/resource_huaweicloud_das_instance_group.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_instance_group.go
@@ -150,7 +150,7 @@ func GetInstanceGroupById(client *golangsdk.ServiceClient, datastoreType, groupI
 			Method:    "GET",
 			URL:       "/v3/{project_id}/batch-inspection/instance-group",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the instance group (%s) has been removed", groupId)),
+			Body:      fmt.Appendf(nil, "the instance group (%s) has been removed", groupId),
 		},
 	}
 }

--- a/huaweicloud/services/das/resource_huaweicloud_das_shared_connection.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_shared_connection.go
@@ -235,8 +235,8 @@ func GetSharedConnectionById(client *golangsdk.ServiceClient, connectionId, user
 				Method:    "GET",
 				URL:       "/v3/{project_id}/connections/{connection_id}/get-shared-list",
 				RequestId: "NONE",
-				Body: []byte(fmt.Sprintf("DAS shared connection (connection_id: %s, user_id: %s) not found in list response",
-					connectionId, userId)),
+				Body: fmt.Appendf(nil, "DAS shared connection (connection_id: %s, user_id: %s) not found in list response",
+					connectionId, userId),
 			},
 		}
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_aggregation_logic_table.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_aggregation_logic_table.go
@@ -722,7 +722,7 @@ func GetArchitectureAggregationLogicTableById(client *golangsdk.ServiceClient, w
 				Method:    "GET",
 				URL:       "/v2/{project_id}/design/aggregation-logic-tables/{id}?latest=true",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the aggregation logic table (%s) does not exist", aggregationLogicTableId)),
+				Body:      fmt.Appendf(nil, "the aggregation logic table (%s) does not exist", aggregationLogicTableId),
 			},
 		}
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_dimension.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_dimension.go
@@ -663,7 +663,7 @@ func GetArchitectureDimensionById(client *golangsdk.ServiceClient, workspaceId, 
 				Method:    "GET",
 				URL:       "/v2/{project_id}/design/dimensions/{id}",
 				RequestId: requestId.(string),
-				Body:      []byte(fmt.Sprintf("error message: %s. dimension ID: %s", errMsg, dimensionId)),
+				Body:      fmt.Appendf(nil, "error message: %s. dimension ID: %s", errMsg, dimensionId),
 			},
 		}
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_publishment.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_publishment.go
@@ -173,7 +173,7 @@ func QueryApiPublishInfoByInstanceId(client *golangsdk.ServiceClient, workspaceI
 				Method:    "GET",
 				URL:       "/v1/{project_id}/service/apis/{api_id}/publish-info",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the API has been unpublished (%s)", apiId)),
+				Body:      fmt.Appendf(nil, "the API has been unpublished (%s)", apiId),
 			},
 		}
 	}
@@ -183,8 +183,8 @@ func QueryApiPublishInfoByInstanceId(client *golangsdk.ServiceClient, workspaceI
 				Method:    "GET",
 				URL:       "/v1/{project_id}/service/apis/{api_id}/publish-info",
 				RequestId: "NONE",
-				Body: []byte(fmt.Sprintf("the API status is not in expect, want 'API_STATUS_PUBLISHED', "+
-					"but got '%s'", apiStatus)),
+				Body: fmt.Appendf(nil, "the API status is not in expect, want 'API_STATUS_PUBLISHED', "+
+					"but got '%s'", apiStatus),
 			},
 		}
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_instance_log_dump.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_instance_log_dump.go
@@ -208,7 +208,7 @@ func GetDataServiceInstanceLogDump(client *golangsdk.ServiceClient, workspaceId,
 				Method:    "GET",
 				URL:       "/v1/{project_id}/service/instances/{instance_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the exclusive cluster (%s) log dump has been disabled", instanceId)),
+				Body:      fmt.Appendf(nil, "the exclusive cluster (%s) log dump has been disabled", instanceId),
 			},
 		}
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
@@ -327,7 +327,7 @@ func getJobByName(client *golangsdk.ServiceClient, workspaceId, jobName, jobType
 			Method:    "GET",
 			URL:       "/v1/{project_id}/jobs",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the job (%s) is not found", jobName)),
+			Body:      fmt.Appendf(nil, "the job (%s) is not found", jobName),
 		},
 	}
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_group.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_group.go
@@ -215,7 +215,7 @@ func GetSecurityDataRecognitionRuleGroupById(client *golangsdk.ServiceClient, wo
 				Method:    "GET",
 				URL:       "/v1/{project_id}/security/data-classification/rule/group",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the data recognition rule group (%s) does not exist", groupId)),
+				Body:      fmt.Appendf(nil, "the data recognition rule group (%s) does not exist", groupId),
 			},
 		}
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_member.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_member.go
@@ -150,7 +150,7 @@ func GetMemberByObjectId(cfg *config.Config, region, workspaceId, permissionSetI
 			Method:    "GET",
 			URL:       "/v1/{project_id}/security/permission-sets/{permission_set_id}/members",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("unable to find the member using object ID (%s) in the permission set", objectId)),
+			Body:      fmt.Appendf(nil, "unable to find the member using object ID (%s) in the permission set", objectId),
 		},
 	}
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
@@ -294,7 +294,7 @@ func GetPrivilegeById(client *golangsdk.ServiceClient, workspaceId, permissionSe
 				Method:    "GET",
 				URL:       "/v1/{project_id}/security/permission-sets/{permission_set_id}/permissions",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the privilege (%s) does not exist", privilegeId)),
+				Body:      fmt.Appendf(nil, "the privilege (%s) does not exist", privilegeId),
 			},
 		}
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_workspace_queue_associate.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_workspace_queue_associate.go
@@ -199,7 +199,7 @@ func GetSecurityWorkspaceAssociatedQueueByName(client *golangsdk.ServiceClient, 
 				Method:    "GET",
 				URL:       "/v1/{project_id}/security/permission/queue/assigned-source",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the workspace queue associate with queue name '%s' has been removed", queueName)),
+				Body:      fmt.Appendf(nil, "the workspace queue associate with queue name '%s' has been removed", queueName),
 			},
 		}
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_workspace_user.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_workspace_user.go
@@ -288,7 +288,7 @@ func GetStudioWorkspaceUserById(client *golangsdk.ServiceClient, workspaceId, us
 				Method:    "GET",
 				URL:       "/v2/{project_id}/{workspace_id}/users",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the workspace user (%s) does not exist", userId)),
+				Body:      fmt.Appendf(nil, "the workspace user (%s) does not exist", userId),
 			},
 		}
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fgs_trigger.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fgs_trigger.go
@@ -818,8 +818,8 @@ func resourceFunctionGraphTriggerRead(_ context.Context, d *schema.ResourceData,
 	}
 	return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{
 		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-			Body: []byte(fmt.Sprintf("unable to find the FunctionGraph trigger (%s) from function (%s), the trigger "+
-				"has been deleted", d.Id(), urn)),
+			Body: fmt.Appendf(nil, "unable to find the FunctionGraph trigger (%s) from function (%s), the trigger "+
+				"has been deleted", d.Id(), urn),
 		},
 	}, "error retrieving FunctionGraph trigger")
 }

--- a/huaweicloud/services/deprecated/resource_huaweicloud_images_image.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_images_image.go
@@ -381,7 +381,7 @@ func GetCloudImage(client *golangsdk.ServiceClient, id string) (*cloudimages.Ima
 				Method:    "GET",
 				URL:       "/v2/cloudimages",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("unexpected image result (image ID is not matched, expected: %s, actual: %s)", id, img.ID)),
+				Body:      fmt.Appendf(nil, "unexpected image result (image ID is not matched, expected: %s, actual: %s)", id, img.ID),
 			},
 		}
 	}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_database.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_database.go
@@ -146,7 +146,7 @@ func GetDliSQLDatabaseByName(c *golangsdk.ServiceClient, dbName string) (databas
 				Method:    "GET",
 				URL:       "/v1.0/{project_id}/databases",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("unable to query the database: %s", resp.Message)),
+				Body:      fmt.Appendf(nil, "unable to query the database: %s", resp.Message),
 			},
 		}
 	}
@@ -157,7 +157,7 @@ func GetDliSQLDatabaseByName(c *golangsdk.ServiceClient, dbName string) (databas
 				Method:    "GET",
 				URL:       "/v1.0/{project_id}/databases",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("no database matched the keyword: %s", dbName)),
+				Body:      fmt.Appendf(nil, "no database matched the keyword: %s", dbName),
 			},
 		}
 	}
@@ -172,7 +172,7 @@ func GetDliSQLDatabaseByName(c *golangsdk.ServiceClient, dbName string) (databas
 			Method:    "GET",
 			URL:       "/v1.0/{project_id}/databases",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the database (%s) does not exist", dbName)),
+			Body:      fmt.Appendf(nil, "the database (%s) does not exist", dbName),
 		},
 	}
 }

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_database_privilege.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_database_privilege.go
@@ -170,7 +170,7 @@ func GetObjectPrivilegesForSpecifiedUser(client *golangsdk.ServiceClient, object
 				Method:    "GET",
 				URL:       "/v1.0/{project_id}/authorization/privileges",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("unable to query the privileges: %s", utils.PathSearch("message", respBody, "Message Not Found"))),
+				Body:      fmt.Appendf(nil, "unable to query the privileges: %s", utils.PathSearch("message", respBody, "Message Not Found")),
 			},
 		}
 		return
@@ -191,7 +191,7 @@ func GetObjectPrivilegesForSpecifiedUser(client *golangsdk.ServiceClient, object
 				Method:    "GET",
 				URL:       "/v1.0/{project_id}/authorization/privileges",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the privileges not found for the object (%s) and user (%s)", object, userName)),
+				Body:      fmt.Appendf(nil, "the privileges not found for the object (%s) and user (%s)", object, userName),
 			},
 		}
 	}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -433,7 +433,7 @@ func GetElasticResourcePoolByName(client *golangsdk.ServiceClient, resourceName 
 	}
 	return nil, golangsdk.ErrDefault404{
 		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-			Body: []byte(fmt.Sprintf("unable to find the elastic resource pool using its name (%s)", lowercaseName)),
+			Body: fmt.Appendf(nil, "unable to find the elastic resource pool using its name (%s)", lowercaseName),
 		},
 	}
 }

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_queue.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_queue.go
@@ -454,7 +454,7 @@ func filterByQueueName(body interface{}, queueName string) (r *queues.Queue, err
 					Method:    "GET",
 					URL:       "/v1.0/{project_id}/queues",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("unable to query the queue list: %s", queueList.Message)),
+					Body:      fmt.Appendf(nil, "unable to query the queue list: %s", queueList.Message),
 				},
 			}
 		}
@@ -469,7 +469,7 @@ func filterByQueueName(body interface{}, queueName string) (r *queues.Queue, err
 				Method:    "GET",
 				URL:       "/v1.0/{project_id}/queues",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the queue (%s) does not exist", queueName)),
+				Body:      fmt.Appendf(nil, "the queue (%s) does not exist", queueName),
 			},
 		}
 	}
@@ -479,7 +479,7 @@ func filterByQueueName(body interface{}, queueName string) (r *queues.Queue, err
 			Method:    "GET",
 			URL:       "/v1.0/{project_id}/queues",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the response type of sdk-client is wrong, want '*queues.ListResult', but got '%T'", body)),
+			Body:      fmt.Appendf(nil, "the response type of sdk-client is wrong, want '*queues.ListResult', but got '%T'", body),
 		},
 	}
 }

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
@@ -366,7 +366,7 @@ func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interfa
 	if err != nil {
 		return nil, "", golangsdk.ErrDefault400{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("error creating DNS client: %s", err)),
+				Body: fmt.Appendf(nil, "error creating DNS client: %s", err),
 			},
 		}
 	}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_asset_domain_label.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_asset_domain_label.go
@@ -202,7 +202,7 @@ func GetAssetDomainLabelByName(client *golangsdk.ServiceClient, name, parentId s
 				Method:    "GET",
 				URL:       "/v1/{project_id}/metadata/asset-domain-labels",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the asset domain label with name (%s) and parent ID (%s) does not exist", name, parentId)),
+				Body:      fmt.Appendf(nil, "the asset domain label with name (%s) and parent ID (%s) does not exist", name, parentId),
 			},
 		}
 	}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_mask_algorithm.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_mask_algorithm.go
@@ -231,7 +231,7 @@ func GetMaskAlgorithmById(client *golangsdk.ServiceClient, algorithmId string) (
 				Method:    "GET",
 				URL:       "/v2/{project_id}/mask/algorithms",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the mask algorithm (%s) does not exist", algorithmId)),
+				Body:      fmt.Appendf(nil, "the mask algorithm (%s) does not exist", algorithmId),
 			},
 		}
 	}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_security_level.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_security_level.go
@@ -195,7 +195,7 @@ func GetScanSecurityLevelById(client *golangsdk.ServiceClient, levelId string) (
 				Method:    "GET",
 				URL:       "/v1/{project_id}/scan-security-levels",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the security level (%s) does not exist", levelId)),
+				Body:      fmt.Appendf(nil, "the security level (%s) does not exist", levelId),
 			},
 		}
 	}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_template_classification.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_scan_template_classification.go
@@ -230,7 +230,7 @@ func GetScanTemplateClassificationById(client *golangsdk.ServiceClient, template
 				Method:    "GET",
 				URL:       "/v1/{project_id}/scan-templates/{template_id}/classifications",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the classification (%s) does not exist", classificationId)),
+				Body:      fmt.Appendf(nil, "the classification (%s) does not exist", classificationId),
 			},
 		}
 	}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_eip_associate.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_eip_associate.go
@@ -140,7 +140,7 @@ func GetClusterAssociatedEipById(client *golangsdk.ServiceClient, clusterId stri
 			Method:    "GET",
 			URL:       "/v1/{project_id}/clusters/{cluster_id}/endpoints",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the EIP is not associated with the DWS cluster (%s)", clusterId)),
+			Body:      fmt.Appendf(nil, "the EIP is not associated with the DWS cluster (%s)", clusterId),
 		},
 	}
 }

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_elb_associate.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_elb_associate.go
@@ -203,7 +203,7 @@ func GetClusterAssociatedElbById(client *golangsdk.ServiceClient, clusterId stri
 				Method:    "GET",
 				URL:       "/v1.0/{project_id}/clusters/{cluster_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the ELB is not associated with the DWS cluster (%s)", clusterId)),
+				Body:      fmt.Appendf(nil, "the ELB is not associated with the DWS cluster (%s)", clusterId),
 			},
 		}
 	}
@@ -215,7 +215,7 @@ func GetClusterAssociatedElbById(client *golangsdk.ServiceClient, clusterId stri
 				Method:    "GET",
 				URL:       "/v1.0/{project_id}/clusters/{cluster_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the ELB (%s) is not associated with the DWS cluster (%s)", elbId, clusterId)),
+				Body:      fmt.Appendf(nil, "the ELB (%s) is not associated with the DWS cluster (%s)", elbId, clusterId),
 			},
 		}
 	}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_exception_rule.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_exception_rule.go
@@ -278,7 +278,7 @@ func getClusterExceptionRuleByName(client *golangsdk.ServiceClient, clusterId, r
 				Method:    "GET",
 				URL:       "/v1/{project_id}/clusters/{cluster_id}/workload/rules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the exception rule (%s) is not found", ruleName)),
+				Body:      fmt.Appendf(nil, "the exception rule (%s) is not found", ruleName),
 			},
 		}
 	}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_public_domain_associate.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_public_domain_associate.go
@@ -166,7 +166,7 @@ func GetClusterPublicEndpointById(client *golangsdk.ServiceClient, clusterId str
 			Method:    "GET",
 			URL:       "/v1/{project_id}/clusters/{cluster_id}/endpoints",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the public domain is not associated with the cluster (%s)", clusterId)),
+			Body:      fmt.Appendf(nil, "the public domain is not associated with the cluster (%s)", clusterId),
 		},
 	}
 }

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster_plan.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster_plan.go
@@ -349,7 +349,7 @@ func GetLogicalClusterPlanById(client *golangsdk.ServiceClient, clusterId, planI
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
 				Method: "GET",
 				URL:    "/v1/{project_id}/clusters/{cluster_id}/logical-cluster-plans",
-				Body:   []byte(fmt.Sprintf("the logical cluster plan (%s) is not found", planId)),
+				Body:   fmt.Appendf(nil, "the logical cluster plan (%s) is not found", planId),
 			},
 		}
 	}

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_eip_associate.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_eip_associate.go
@@ -386,7 +386,7 @@ func getFloatingIPbyAddress(client *golangsdk.ServiceClient, floatingIP, epsID s
 	if len(allEips) != 1 {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("can not find the EIP by %s", floatingIP)),
+				Body: fmt.Appendf(nil, "can not find the EIP by %s", floatingIP),
 			},
 		}
 	}

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_eventrouter_cluster.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_eventrouter_cluster.go
@@ -272,7 +272,7 @@ func GetEventRouterClusterById(client *golangsdk.ServiceClient, clusterId string
 				Method:    "GET",
 				URL:       "/v1/{project_id}/eventrouter/clusters/{cluster_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("The event router cluster (%s) not found", clusterId)),
+				Body:      fmt.Appendf(nil, "The event router cluster (%s) not found", clusterId),
 			},
 		}
 	}

--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -231,7 +231,7 @@ func GetAssociationById(client *golangsdk.ServiceClient, instanceId, routeTableI
 	if association == nil {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("the association (%s) does not exist", associationId)),
+				Body: fmt.Appendf(nil, "the association (%s) does not exist", associationId),
 			},
 		}
 	}

--- a/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
@@ -232,7 +232,7 @@ func GetPropagationById(client *golangsdk.ServiceClient, instanceId, routeTableI
 	if propagation == nil {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("the propagation (%s) does not exist", propagationId)),
+				Body: fmt.Appendf(nil, "the propagation (%s) does not exist", propagationId),
 			},
 		}
 	}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
@@ -331,7 +331,7 @@ func refreshSpecifiedDependencyVersion(client *golangsdk.ServiceClient, resource
 		if dependId == "" {
 			return dependId, dependVersion, golangsdk.ErrDefault404{
 				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-					Body: []byte(fmt.Sprintf("unable to find the dependency package using its name: %s", dependId)),
+					Body: fmt.Appendf(nil, "unable to find the dependency package using its name: %s", dependId),
 				},
 			}
 		}
@@ -349,7 +349,7 @@ func refreshSpecifiedDependencyVersion(client *golangsdk.ServiceClient, resource
 		if dependVersion == "" {
 			return dependId, dependVersion, golangsdk.ErrDefault404{
 				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-					Body: []byte(fmt.Sprintf("unable to find the dependency package version using its ID: %s", dependVersion)),
+					Body: fmt.Appendf(nil, "unable to find the dependency package version using its ID: %s", dependVersion),
 				},
 			}
 		}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_vulnerability_scan_task.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_vulnerability_scan_task.go
@@ -209,7 +209,7 @@ func GetVulnerabilityScanTask(client *golangsdk.ServiceClient, taskId, epsId str
 				Method:    "GET",
 				URL:       "/v5/{project_id}/vulnerability/scan-tasks",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the vulnerability scan task (%s) does not exist", taskId)),
+				Body:      fmt.Appendf(nil, "the vulnerability scan task (%s) does not exist", taskId),
 			},
 		}
 	}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_webtamper_protection.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_webtamper_protection.go
@@ -236,7 +236,7 @@ func GetWebTamperProtectionHost(client *golangsdk.ServiceClient, region, epsId, 
 				Method:    "GET",
 				URL:       "/v5/{project_id}/webtamper/hosts",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the HSS web tamper protection host (%s) does not exist", hostId)),
+				Body:      fmt.Appendf(nil, "the HSS web tamper protection host (%s) does not exist", hostId),
 			},
 		}
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_acl.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_acl.go
@@ -466,7 +466,7 @@ func GetV3AclByDomainId(client *golangsdk.ServiceClient, aclType, domainId strin
 					Method:    "GET",
 					URL:       "/v3.0/OS-SECURITYPOLICY/domains/{domain_id}/console-acl-policy",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("identity ACL for console access <%s> has been reverted", domainId)),
+					Body:      fmt.Appendf(nil, "identity ACL for console access <%s> has been reverted", domainId),
 				},
 			}
 		}
@@ -481,7 +481,7 @@ func GetV3AclByDomainId(client *golangsdk.ServiceClient, aclType, domainId strin
 					Method:    "GET",
 					URL:       "/v3.0/OS-SECURITYPOLICY/domains/{domain_id}/api-acl-policy",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("identity ACL for API access (domain: %s) has been reverted", domainId)),
+					Body:      fmt.Appendf(nil, "identity ACL for API access (domain: %s) has been reverted", domainId),
 				},
 			}
 		}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group_membership.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group_membership.go
@@ -149,7 +149,7 @@ func ListV3AssociatedUsersForGroup(client *golangsdk.ServiceClient, groupId stri
 				Method:    "GET",
 				URL:       "/v3/groups/{group_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the group (%s) does not exist", groupId)),
+				Body:      fmt.Appendf(nil, "the group (%s) does not exist", groupId),
 			},
 		}
 	}
@@ -178,7 +178,7 @@ func ListV3AssociatedUsersForGroup(client *golangsdk.ServiceClient, groupId stri
 				Method:    "GET",
 				URL:       "/v3/groups/{group_id}/users",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the managed membership for group (%s) does not exist", groupId)),
+				Body:      fmt.Appendf(nil, "the managed membership for group (%s) does not exist", groupId),
 			},
 		}
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group_role_assignment.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group_role_assignment.go
@@ -297,8 +297,8 @@ func CheckV3GroupRoleAssignmentWithDomainId(client *golangsdk.ServiceClient, gro
 				Method:    "GET",
 				URL:       "/v3/domains/{domain_id}/groups/{group_id}/roles",
 				RequestId: "NONE",
-				Body: []byte(fmt.Sprintf("the role (%s), which assigned to the domain (%s), is not assigned to the group (%s)",
-					roleId, domainId, groupId)),
+				Body: fmt.Appendf(nil, "the role (%s), which assigned to the domain (%s), is not assigned to the group (%s)",
+					roleId, domainId, groupId),
 			},
 		}
 	}
@@ -341,8 +341,8 @@ func CheckV3GroupRoleAssignmentWithProjectId(client *golangsdk.ServiceClient, gr
 				Method:    "GET",
 				URL:       "/v3/projects/{project_id}/groups/{group_id}/roles",
 				RequestId: "NONE",
-				Body: []byte(fmt.Sprintf("the role (%s), which assigned to the project (%s), is not assigned to the group (%s)",
-					roleId, projectId, groupId)),
+				Body: fmt.Appendf(nil, "the role (%s), which assigned to the project (%s), is not assigned to the group (%s)",
+					roleId, projectId, groupId),
 			},
 		}
 	}
@@ -365,8 +365,8 @@ func CheckV3GroupRoleAssignmentWithEpsId(client *golangsdk.ServiceClient, groupI
 			Method:    "GET",
 			URL:       "/v3.0/OS-PERMISSION/enterprise-projects/{enterprise_project_id}/groups/{group_id}/roles",
 			RequestId: "NONE",
-			Body: []byte(fmt.Sprintf("the role (%s), which assigned to the enterprise project (%s), is not assigned to the group (%s)",
-				roleId, epsId, groupId)),
+			Body: fmt.Appendf(nil, "the role (%s), which assigned to the enterprise project (%s), is not assigned to the group (%s)",
+				roleId, epsId, groupId),
 		},
 	}
 }

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_access_key.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_access_key.go
@@ -204,7 +204,7 @@ func GetV5AccessKeyById(client *golangsdk.ServiceClient, userId string, accessKe
 				Method:    "GET",
 				URL:       "/v5/users/{user_id}/access-keys",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the IAM access key (%s) for user (%s) does not exist", accessKeyId, userId)),
+				Body:      fmt.Appendf(nil, "the IAM access key (%s) for user (%s) does not exist", accessKeyId, userId),
 			},
 		}
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_group_membership.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_group_membership.go
@@ -133,7 +133,7 @@ func GetV5GroupassociateUsers(client *golangsdk.ServiceClient, groupId string) (
 				Method:    "GET",
 				URL:       "v5/users",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the users in group (%s) does not exist", groupId)),
+				Body:      fmt.Appendf(nil, "the users in group (%s) does not exist", groupId),
 			},
 		}
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_login_profile.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_login_profile.go
@@ -152,7 +152,7 @@ func GetV5LoginProfile(client *golangsdk.ServiceClient, userId string) (interfac
 				Method:    "GET",
 				URL:       "/v5/users/{user_id}/login-profile",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the login profile of the user (%s) does not exist", userId)),
+				Body:      fmt.Appendf(nil, "the login profile of the user (%s) does not exist", userId),
 			},
 		}
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_agency_attach.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_agency_attach.go
@@ -135,7 +135,7 @@ func GetV5AgencyAttachedPolicy(client *golangsdk.ServiceClient, agencyId, policy
 				Method:    "GET",
 				URL:       "/v5/agencies/{agency_id}/attached-policies",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("The attached policy (%s) of agency (%s) not found", policyId, agencyId)),
+				Body:      fmt.Appendf(nil, "The attached policy (%s) of agency (%s) not found", policyId, agencyId),
 			},
 		}
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_group_attach.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_group_attach.go
@@ -142,7 +142,7 @@ func GetV5GroupAttachedPolicy(client *golangsdk.ServiceClient, groupId, policyId
 			Method:    "GET",
 			URL:       "/v5/groups/{group_id}/attached-policies",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the policy (%s) associated with the group (%s) does not exist", policyId, groupId)),
+			Body:      fmt.Appendf(nil, "the policy (%s) associated with the group (%s) does not exist", policyId, groupId),
 		},
 	}
 }

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_user_attach.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_user_attach.go
@@ -142,7 +142,7 @@ func GetV5UserAttachedPolicy(client *golangsdk.ServiceClient, userId, policyId s
 			Method:    "GET",
 			URL:       "/v5/users/{user_id}/attached-policies",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the policy (%s) associated with the user (%s) does not exist", policyId, userId)),
+			Body:      fmt.Appendf(nil, "the policy (%s) associated with the user (%s) does not exist", policyId, userId),
 		},
 	}
 }

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_resource_tag.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_resource_tag.go
@@ -82,7 +82,7 @@ func GetV5ResourceTagsById(client *golangsdk.ServiceClient, resourceType string,
 				Method:    "GET",
 				URL:       "/v5/{resource_type}/{resource_id}/tags",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the resource (%s/%s) does not have any tags", resourceType, resourceId)),
+				Body:      fmt.Appendf(nil, "the resource (%s/%s) does not have any tags", resourceType, resourceId),
 			},
 		}
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_virtual_mfa_device.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_virtual_mfa_device.go
@@ -136,7 +136,7 @@ func GetV5VirtualMfaDevice(client *golangsdk.ServiceClient, userId string) (inte
 				Method:    "GET",
 				URL:       "/v5/mfa-devices",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("there are no MFA devices under the user (%s)", userId)),
+				Body:      fmt.Appendf(nil, "there are no MFA devices under the user (%s)", userId),
 			},
 		}
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
@@ -126,7 +126,7 @@ func ReadAmqpById(client *golangsdk.ServiceClient, queueId string) (interface{},
 				Method:    "GET",
 				URL:       "/v5/iot/{project_id}/amqp-queues/{queue_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the IoTDA AMQP queue (%s) does not exist", queueId)),
+				Body:      fmt.Appendf(nil, "the IoTDA AMQP queue (%s) does not exist", queueId),
 			},
 		}
 	}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_consumer_group.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_consumer_group.go
@@ -210,7 +210,7 @@ func GetConsumerGroupByName(client *golangsdk.ServiceClient, instanceId, groupNa
 				Method:    "GET",
 				URL:       getPath,
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the consumer group with name '%s' has been removed", groupName)),
+				Body:      fmt.Appendf(nil, "the consumer group with name '%s' has been removed", groupName),
 			},
 		}
 	}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_log.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_log.go
@@ -234,7 +234,7 @@ func GetInstanceLog(client *golangsdk.ServiceClient, instanceId, logType string)
 				Method:    "GET",
 				URL:       "/v2/{project_id}/kafka/instances/{instance_id}/logs/{log_type}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("The log (%s) of the instance (%s) has been closed.", logType, instanceId)),
+				Body:      fmt.Appendf(nil, "The log (%s) of the instance (%s) has been closed.", logType, instanceId),
 			},
 		}
 	}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_rebalance_log.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_rebalance_log.go
@@ -183,7 +183,7 @@ func GetInstanceRebalanceLog(client *golangsdk.ServiceClient, instanceId string)
 				Method:    "GET",
 				URL:       "/v2/kafka/{project_id}/instances/{instance_id}/log/rebalance-log",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("The rebalance log of the instance (%s) has been closed.", instanceId)),
+				Body:      fmt.Appendf(nil, "The rebalance log of the instance (%s) has been closed.", instanceId),
 			},
 		}
 	}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_message_diagnosis_task.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_message_diagnosis_task.go
@@ -290,7 +290,7 @@ func filterKafkaMessageDiagnosisTaskFromList(client *golangsdk.ServiceClient, in
 		if int(total.(float64)) <= offset {
 			return nil, golangsdk.ErrDefault404{
 				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-					Body: []byte(fmt.Sprintf("unable to find task(%s) from API response", reportID)),
+					Body: fmt.Appendf(nil, "unable to find task(%s) from API response", reportID),
 				}}
 		}
 	}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic_quota.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic_quota.go
@@ -199,7 +199,7 @@ func GetTopicQuotaByTopicName(client *golangsdk.ServiceClient, instanceId, topic
 				Method:    "GET",
 				URL:       "/v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("The topic (%s) quota of the instance (%s) was not found.", topicName, instanceId)),
+				Body:      fmt.Appendf(nil, "The topic (%s) quota of the instance (%s) was not found.", topicName, instanceId),
 			},
 		}
 	}

--- a/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance.go
+++ b/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance.go
@@ -278,7 +278,7 @@ func GetInstanceById(client *golangsdk.ServiceClient, instanceId string) (interf
 				Method:    "GET",
 				URL:       "/v1/{project_id}/instances/{instance_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the instance (%s) has been moved to the recycle bin", instanceId)),
+				Body:      fmt.Appendf(nil, "the instance (%s) has been moved to the recycle bin", instanceId),
 			},
 		}
 	}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_stream.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_stream.go
@@ -226,7 +226,7 @@ func GetLogStreamById(client *golangsdk.ServiceClient, logGroupId, streamId stri
 				Method:    "GET",
 				URL:       "v2/{project_id}/groups/{log_group_id}/streams",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the log stream (%s) has been deleted", streamId)),
+				Body:      fmt.Appendf(nil, "the log stream (%s) has been deleted", streamId),
 			},
 		}
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account.go
@@ -265,7 +265,7 @@ func GetAccountInfoById(client *golangsdk.ServiceClient, accountId string) (inte
 				Method:    "GET",
 				URL:       "/v1/organizations/accounts/{account_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the account (%s) does not exist", accountId)),
+				Body:      fmt.Appendf(nil, "the account (%s) does not exist", accountId),
 			},
 		}
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
@@ -194,7 +194,7 @@ func GetAccountInviteById(client *golangsdk.ServiceClient, handshakeId string) (
 				Method:    "GET",
 				URL:       "/v1/organizations/handshakes/{handshake_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the invitation (%s) does not exist", handshakeId)),
+				Body:      fmt.Appendf(nil, "the invitation (%s) does not exist", handshakeId),
 			},
 		}
 	}
@@ -215,7 +215,7 @@ func GetAccountInvite(client *golangsdk.ServiceClient, handshakeId string) (inte
 				Method:    "GET",
 				URL:       "/v1/organizations/handshakes/{handshake_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the invitation (%s) has been cancelled or expired", handshakeId)),
+				Body:      fmt.Appendf(nil, "the invitation (%s) has been cancelled or expired", handshakeId),
 			},
 		}
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_delegated_administrator.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_delegated_administrator.go
@@ -135,7 +135,7 @@ func GetDelegatedAdministrator(client *golangsdk.ServiceClient, accountId, servi
 				Method:    "GET",
 				URL:       "/v1/organizations/delegated-administrators",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the delegated administrator (%s) does not exist for account (%s)", servicePrincipal, accountId)),
+				Body:      fmt.Appendf(nil, "the delegated administrator (%s) does not exist for account (%s)", servicePrincipal, accountId),
 			},
 		}
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_dry_run_policy_entity_attach.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_dry_run_policy_entity_attach.go
@@ -161,7 +161,7 @@ func GetAttachedEntityForDryRunPolicy(client *golangsdk.ServiceClient, policyId 
 			Method:    "GET",
 			URL:       "/v1/organizations/dry-run-policies/{policy_id}/attached-entities",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the attached entity (%s) for dry-run policy (%s) does not exist", entityId, policyId)),
+			Body:      fmt.Appendf(nil, "the attached entity (%s) for dry-run policy (%s) does not exist", entityId, policyId),
 		},
 	}
 }

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go
@@ -136,7 +136,7 @@ func GetOrganizationalUnit(client *golangsdk.ServiceClient, ouId string) (interf
 				Method:    "GET",
 				URL:       "/v1/organizations/organizational-units/{organizational_unit_id}",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the organizational unit (%s) does not exist", ouId)),
+				Body:      fmt.Appendf(nil, "the organizational unit (%s) does not exist", ouId),
 			},
 		}
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_policy_attach.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_policy_attach.go
@@ -146,7 +146,7 @@ func GetPolicyAttachedEntity(client *golangsdk.ServiceClient, policyId string, e
 				Method:    "GET",
 				URL:       "/v1/organizations/policies/{policy_id}/attached-entities",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("unable to find the entity (%s) attached to the policy (%s)", entityId, policyId)),
+				Body:      fmt.Appendf(nil, "unable to find the entity (%s) attached to the policy (%s)", entityId, policyId),
 			},
 		}
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_trusted_service.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_trusted_service.go
@@ -143,7 +143,7 @@ func GetTrustedService(client *golangsdk.ServiceClient, service string) (interfa
 				Method:    "GET",
 				URL:       "/v1/organizations/trusted-services",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the trusted service (%s) does not exist", service)),
+				Body:      fmt.Appendf(nil, "the trusted service (%s) does not exist", service),
 			},
 		}
 	}

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange.go
@@ -235,7 +235,7 @@ func GetRabbitmqExchange(client *golangsdk.ServiceClient, instanceID, vhost, nam
 					Method:    "GET",
 					URL:       "/v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("the exchange (%s) does not exist", name)),
+					Body:      fmt.Appendf(nil, "the exchange (%s) does not exist", name),
 				},
 			}
 		}

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange_associate.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange_associate.go
@@ -188,7 +188,7 @@ func getRabbitmqExchangeAssociate(client *golangsdk.ServiceClient, d *schema.Res
 			Method:    "GET",
 			URL:       "/v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}/binding",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the exchange (%s) has no association", d.Get("exchange").(string))),
+			Body:      fmt.Appendf(nil, "the exchange (%s) has no association", d.Get("exchange").(string)),
 		},
 	}
 }

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_user.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_user.go
@@ -203,7 +203,7 @@ func GetRabbitmqUser(client *golangsdk.ServiceClient, instanceID, accessKey stri
 					Method:    "GET",
 					URL:       "/v2/rabbitmq/{project_id}/instances/{instance_id}/users",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("the user (%s) does not exist", accessKey)),
+					Body:      fmt.Appendf(nil, "the user (%s) does not exist", accessKey),
 				},
 			}
 		}

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_vhost.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_vhost.go
@@ -147,7 +147,7 @@ func GetRabbitmqVhost(client *golangsdk.ServiceClient, instanceID, name string) 
 					Method:    "GET",
 					URL:       "/v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("the vhost (%s) does not exist", name)),
+					Body:      fmt.Appendf(nil, "the vhost (%s) does not exist", name),
 				},
 			}
 		}

--- a/huaweicloud/services/ram/resource_huaweicloud_ram_resource_share.go
+++ b/huaweicloud/services/ram/resource_huaweicloud_ram_resource_share.go
@@ -250,7 +250,7 @@ func setRAMShareInstance(client *golangsdk.ServiceClient, d *schema.ResourceData
 	if len(curArray) > 1 {
 		return golangsdk.ErrDefault400{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("except retrieving one RAM share, but got %d", len(curArray))),
+				Body: fmt.Appendf(nil, "except retrieving one RAM share, but got %d", len(curArray)),
 			},
 		}
 	}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database_privilege.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database_privilege.go
@@ -427,7 +427,7 @@ func ListMysqlDatabasePrivileges(client *golangsdk.ServiceClient, instanceId, db
 				Method:    "GET",
 				URL:       "/v3/{project_id}/instances/{instance_id}/database/db_user",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the database privileges (%#v) for database (%s) do not exist", usersOrigin, dbName)),
+				Body:      fmt.Appendf(nil, "the database privileges (%#v) for database (%s) do not exist", usersOrigin, dbName),
 			},
 		}
 	}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_pg_plugin.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_pg_plugin.go
@@ -112,7 +112,7 @@ func queryPluginDetail(client *golangsdk.ServiceClient, instanceId, databaseName
 					Method:    "GET",
 					URL:       "/v3/{project_id}/instances/{instance_id}/extensions",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("the PostgreSQL plugin (%s) does not exist", name)),
+					Body:      fmt.Appendf(nil, "the PostgreSQL plugin (%s) does not exist", name),
 				},
 			}
 		}
@@ -138,7 +138,7 @@ func queryPluginDetail(client *golangsdk.ServiceClient, instanceId, databaseName
 				Method:    "GET",
 				URL:       "/v3/{project_id}/instances/{instance_id}/extensions",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the PostgreSQL plugin (%s) does not exist or its creation status is not created", name)),
+				Body:      fmt.Appendf(nil, "the PostgreSQL plugin (%s) does not exist or its creation status is not created", name),
 			},
 		}
 	}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_publication.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_publication.go
@@ -767,7 +767,7 @@ func resourcePublicationRead(_ context.Context, d *schema.ResourceData, meta int
 				Method:    "GET",
 				URL:       "/v3/{project_id}/instances/{instance_id}/replication/publications",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the RDS publication (%s) does not exist", d.Id())),
+				Body:      fmt.Appendf(nil, "the RDS publication (%s) does not exist", d.Id()),
 			},
 		}, "error retrieving RDS publication")
 	}

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_private_hook.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_private_hook.go
@@ -211,7 +211,7 @@ func queryPrivateHookByName(client *golangsdk.ServiceClient, name string) (inter
 	if err != nil {
 		return nil, golangsdk.ErrDefault400{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("unable to generate RFS request ID: %s", err)),
+				Body: fmt.Appendf(nil, "unable to generate RFS request ID: %s", err),
 			},
 		}
 	}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_channel.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_channel.go
@@ -465,7 +465,7 @@ func GetCollectorChannelByTitle(client *golangsdk.ServiceClient, workspaceId, ti
 				Method:    "GET",
 				URL:       "/v1/{project_id}/workspaces/{workspace_id}/collector/channels",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the collector channel (%s) does not exist", title)),
+				Body:      fmt.Appendf(nil, "the collector channel (%s) does not exist", title),
 			},
 		}
 	}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_channel_group.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_channel_group.go
@@ -145,7 +145,7 @@ func GetCollectorChannelGroupByName(client *golangsdk.ServiceClient, workspaceId
 			Method:    "GET",
 			URL:       "/v1/{project_id}/workspaces/{workspace_id}/collector/channels/groups",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the collector channel group (%s) does not exist", groupName)),
+			Body:      fmt.Appendf(nil, "the collector channel group (%s) does not exist", groupName),
 		},
 	}
 }

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
@@ -99,7 +99,7 @@ func getAuthorizationByName(c *golangsdk.ServiceClient, name string) (*repositor
 			Method:    "GET",
 			URL:       "/v1/{project_id}/git/auths",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("the authorization (%s) does not exist", name)),
+			Body:      fmt.Appendf(nil, "the authorization (%s) does not exist", name),
 		},
 	}
 }

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_application_configuration.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_application_configuration.go
@@ -202,8 +202,8 @@ func GetV3ApplicationConfiguration(client *golangsdk.ServiceClient, environmentI
 				Method:    "GET",
 				URL:       "/v3/{project_id}/cas/applications/{application_id}/configuration",
 				RequestId: "NONE",
-				Body: []byte(fmt.Sprintf("the configurations is empty in the application (%s) for the environment (%s)",
-					applicationId, environmentId)),
+				Body: fmt.Appendf(nil, "the configurations is empty in the application (%s) for the environment (%s)",
+					applicationId, environmentId),
 			},
 		}
 	}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment_associate.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment_associate.go
@@ -260,7 +260,7 @@ func resourceV3EnvironmentAssociateRead(_ context.Context, d *schema.ResourceDat
 				Method:    "GET",
 				URL:       "/v3/{project_id}/cas/environments/{environment_id}/resources",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("All assiciated resources have been dissociated from the environment (%s)", envId)),
+				Body:      fmt.Appendf(nil, "All assiciated resources have been dissociated from the environment (%s)", envId),
 			},
 		}, "error retrieving associated resources")
 	}

--- a/huaweicloud/services/smn/resource_huaweicloud_smn_subscription_filter_policy.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_subscription_filter_policy.go
@@ -217,7 +217,7 @@ func GetSubscriptionFilterPolicies(client *golangsdk.ServiceClient, subscription
 	if index == -1 {
 		return nil, golangsdk.ErrDefault400{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("the format of the subscription URN (%s) is incorrect", subscriptionUrn)),
+				Body: fmt.Appendf(nil, "the format of the subscription URN (%s) is incorrect", subscriptionUrn),
 			},
 		}
 	}
@@ -266,7 +266,7 @@ func GetSubscriptionFilterPolicies(client *golangsdk.ServiceClient, subscription
 				Method:    "GET",
 				URL:       "/v2/{project_id}/notifications/topics/{topicUrn}/subscriptions",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the subscription filter policy (%s) does not exist", subscriptionUrn)),
+				Body:      fmt.Appendf(nil, "the subscription filter policy (%s) does not exist", subscriptionUrn),
 			},
 		}
 	}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_backup.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_backup.go
@@ -273,7 +273,7 @@ func getGaussDBBackup(client *golangsdk.ServiceClient, backupID string) (interfa
 				Method:    "GET",
 				URL:       "/v3/{project_id}/backups",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the TaurusDB backup (%s) does not exist", backupID)),
+				Body:      fmt.Appendf(nil, "the TaurusDB backup (%s) does not exist", backupID),
 			},
 		}
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
@@ -313,7 +313,7 @@ func QueryCloudInstance(client *golangsdk.ServiceClient, instanceId, epsId strin
 	ChargingMode, error) {
 	default404Err := golangsdk.ErrDefault404{
 		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-			Body: []byte(fmt.Sprintf("the cloud WAF (%s) does not exist", instanceId)),
+			Body: fmt.Appendf(nil, "the cloud WAF (%s) does not exist", instanceId),
 		},
 	}
 	resp, err := clouds.GetWithEpsID(client, epsId)

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_access_policy.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_access_policy.go
@@ -126,7 +126,7 @@ func GetAccessPolicyByPolicyName(client *golangsdk.ServiceClient, policyName str
 			Method:    "GET",
 			URL:       "/v2/{project_id}/access-policy",
 			RequestId: "NONE",
-			Body:      []byte(fmt.Sprintf("no access policy matched the name '%s'", policyName)),
+			Body:      fmt.Appendf(nil, "no access policy matched the name '%s'", policyName),
 		},
 	}
 }

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_publishment.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_publishment.go
@@ -259,7 +259,7 @@ func GetAppPublishedApplicationByName(client *golangsdk.ServiceClient, appGroupI
 				Method:    "GET",
 				URL:       "/v1/{project_id}/app-groups/{app_group_id}/apps",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the application (%s) does not exist", appName)),
+				Body:      fmt.Appendf(nil, "the application (%s) does not exist", appName),
 			},
 		}
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_nas_storage.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_nas_storage.go
@@ -173,7 +173,7 @@ func GetAppNasStorageById(client *golangsdk.ServiceClient, storageId string) (in
 				Method:    "GET",
 				URL:       "/v1/{project_id}/persistent-storages",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the NAS storage (%s) has been removed from the Workspace APP service", storageId)),
+				Body:      fmt.Appendf(nil, "the NAS storage (%s) has been removed from the Workspace APP service", storageId),
 			},
 		}
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_policy_template.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_policy_template.go
@@ -172,7 +172,7 @@ func GetAppPolicyTemplateById(client *golangsdk.ServiceClient, templateId string
 				Method:    "GET",
 				URL:       "/v1/{project_id}/policy-templates",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the policy template (%s) has been deleted", templateId)),
+				Body:      fmt.Appendf(nil, "the policy template (%s) has been deleted", templateId),
 			},
 		}
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_application.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_application.go
@@ -193,7 +193,7 @@ func GetWarehouseApplicationById(client *golangsdk.ServiceClient, applicationId 
 				Method:    "GET",
 				URL:       "/v1/{project_id}/app-warehouse/apps",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the application (%s) does not exist", applicationId)),
+				Body:      fmt.Appendf(nil, "the application (%s) does not exist", applicationId),
 			},
 		}
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_notification_rule.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_notification_rule.go
@@ -190,7 +190,7 @@ func GetNotificationRuleById(client *golangsdk.ServiceClient, ruleId string) (in
 				Method:    "GET",
 				URL:       "/v2/{project_id}/statistics/notify-rules",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the notification rule with ID '%s' has been removed", ruleId)),
+				Body:      fmt.Appendf(nil, "the notification rule with ID '%s' has been removed", ruleId),
 			},
 		}
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_ou.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_ou.go
@@ -191,7 +191,7 @@ func GetOuByName(client *golangsdk.ServiceClient, ouId string) (interface{}, err
 				Method:    "GET",
 				URL:       "/v2/{project_id}/ous",
 				RequestId: "NONE",
-				Body:      []byte(fmt.Sprintf("the OU '%s' not found", ouId)),
+				Body:      fmt.Appendf(nil, "the OU '%s' not found", ouId),
 			},
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Replace `Body: []byte(fmt.Sprintf(...))` with `Body: fmt.Appendf(nil, ...)` across the provider (~155 call sites in 128 files).
- Avoid an unnecessary string allocation when building synthetic `golangsdk` error bodies (mostly `ErrDefault404` / `ErrUnexpectedResponseCode`).
- Behavior is unchanged: same format strings and arguments, still assigned to `[]byte` `Body`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. replace []byte(fmt.Sprintf) with fmt.Appendf for error bod
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
