### PR TITLE
fix(TaurusDB): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/docs/resources/networking_secgroup.md
+++ b/docs/resources/networking_secgroup.md
@@ -104,7 +104,7 @@ The `rules` block supports:
 
 This resource provides the following timeouts configuration options:
 
-* `delete` - Default is 10 minutes.
+* `delete` - Default is 20 minutes.
 
 ## Import
 

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -78,7 +78,7 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 10 minutes.
-* `delete` - Default is 3 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -141,7 +141,7 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 5 minutes.
-* `delete` - Default is 10 minutes.
+* `delete` - Default is 20 minutes.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_lts_config_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_lts_config_test.go
@@ -47,7 +47,6 @@ func TestAccTaurusDBHtapStarrocksLtsConfig_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -56,7 +55,8 @@ func TestAccTaurusDBHtapStarrocksLtsConfig_basic(t *testing.T) {
 				Config: testAccTaurusDBHtapStarrocksLtsConfig_basic(rName, logType),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_taurusdb_htap_starrocks_instance.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "lts_group_id",
 						"huaweicloud_lts_group.test.0", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "lts_stream_id",
@@ -68,7 +68,8 @@ func TestAccTaurusDBHtapStarrocksLtsConfig_basic(t *testing.T) {
 				Config: testAccTaurusDBHtapStarrocksLtsConfig_update(rName, logType),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_taurusdb_htap_starrocks_instance.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "lts_group_id",
 						"huaweicloud_lts_group.test.1", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "lts_stream_id",
@@ -101,7 +102,6 @@ func TestAccTaurusDBHtapStarrocksLtsConfig_slowLog(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -110,7 +110,8 @@ func TestAccTaurusDBHtapStarrocksLtsConfig_slowLog(t *testing.T) {
 				Config: testAccTaurusDBHtapStarrocksLtsConfig_basic(rName, logType),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_taurusdb_htap_starrocks_instance.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "lts_group_id",
 						"huaweicloud_lts_group.test.0", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "lts_stream_id",
@@ -122,7 +123,8 @@ func TestAccTaurusDBHtapStarrocksLtsConfig_slowLog(t *testing.T) {
 				Config: testAccTaurusDBHtapStarrocksLtsConfig_update(rName, logType),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_taurusdb_htap_starrocks_instance.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "lts_group_id",
 						"huaweicloud_lts_group.test.1", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "lts_stream_id",
@@ -142,10 +144,12 @@ func TestAccTaurusDBHtapStarrocksLtsConfig_slowLog(t *testing.T) {
 
 func testAccTaurusDBHtapStarrocksLtsConfig_base(rName string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_lts_group" "test" {
   count = 2
 
-  group_name  = "%[1]s_${count.index}"
+  group_name  = "%[2]s_${count.index}"
   ttl_in_days = 1
 }
 
@@ -153,9 +157,9 @@ resource "huaweicloud_lts_stream" "test" {
   count = 2
 
   group_id    = huaweicloud_lts_group.test[count.index].id
-  stream_name = "%[1]s_${count.index}"
+  stream_name = "%[2]s_${count.index}"
 }
-`, rName)
+`, testAccTaurusDBHtapStarrocksInstance_basic(rName), rName)
 }
 
 func testAccTaurusDBHtapStarrocksLtsConfig_basic(rName string, logType string) string {
@@ -163,11 +167,11 @@ func testAccTaurusDBHtapStarrocksLtsConfig_basic(rName string, logType string) s
 %[1]s
 
 resource "huaweicloud_taurusdb_htap_starrocks_lts_config" "test" {
-  instance_id   = "%[2]s"
-  log_type      = "%[3]s"
+  instance_id   = huaweicloud_taurusdb_htap_starrocks_instance.test.id
+  log_type      = "%[2]s"
   lts_group_id  = huaweicloud_lts_group.test[0].id
   lts_stream_id = huaweicloud_lts_stream.test[0].id
-}`, testAccTaurusDBHtapStarrocksLtsConfig_base(rName), acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID, logType)
+}`, testAccTaurusDBHtapStarrocksLtsConfig_base(rName), logType)
 }
 
 func testAccTaurusDBHtapStarrocksLtsConfig_update(rName string, logType string) string {
@@ -175,11 +179,11 @@ func testAccTaurusDBHtapStarrocksLtsConfig_update(rName string, logType string) 
 %[1]s
 
 resource "huaweicloud_taurusdb_htap_starrocks_lts_config" "test" {
-  instance_id   = "%[2]s"
-  log_type      = "%[3]s"
+  instance_id   = huaweicloud_taurusdb_htap_starrocks_instance.test.id
+  log_type      = "%[2]s"
   lts_group_id  = huaweicloud_lts_group.test[1].id
   lts_stream_id = huaweicloud_lts_stream.test[1].id
-}`, testAccTaurusDBHtapStarrocksLtsConfig_base(rName), acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID, logType)
+}`, testAccTaurusDBHtapStarrocksLtsConfig_base(rName), logType)
 }
 
 func testAccTaurusDBHtapStarrocksLtsConfigImportStateIdFunc(name string) resource.ImportStateIdFunc {

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_sql_auto_throttling_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_sql_auto_throttling_test.go
@@ -18,19 +18,18 @@ import (
 func TestAccTaurusDBSqlAutoThrottling_basic(t *testing.T) {
 	var obj interface{}
 	rName := "huaweicloud_taurusdb_sql_auto_throttling.test"
+	name := acceptance.RandomAccResourceName()
 	rc := acceptance.InitResourceCheck(rName, &obj, getResourceSqlAutoThrottlingFunc)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckTaurusDBInstanceId(t)
-			acceptance.TestAccPreCheckTaurusDBNodeId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaurusDBSqlAutoThrottling_basic(),
+				Config: testAccTaurusDBSqlAutoThrottling_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "start_time", "00:00"),
@@ -45,7 +44,7 @@ func TestAccTaurusDBSqlAutoThrottling_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTaurusDBSqlAutoThrottling_update(),
+				Config: testAccTaurusDBSqlAutoThrottling_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "start_time", "02:00"),
@@ -122,11 +121,17 @@ func getResourceSqlAutoThrottlingByQuery(client *golangsdk.ServiceClient, instan
 	return filteredRules[0], nil
 }
 
-func testAccTaurusDBSqlAutoThrottling_basic() string {
+func testAccTaurusDBSqlAutoThrottling_basic(name string) string {
 	return fmt.Sprintf(`
+%s
+
+locals {
+  master_node_id = try([for node in huaweicloud_taurusdb_instance.test.nodes : node.id if node.type == "master"][0], "")
+}
+
 resource "huaweicloud_taurusdb_sql_auto_throttling" "test" {
-  instance_id     = "%[1]s"
-  node_id         = "%[2]s"
+  instance_id     = huaweicloud_taurusdb_instance.test.id
+  node_id         = local.master_node_id
   start_time      = "00:00"
   end_time        = "01:00"
   condition       = "and"
@@ -137,14 +142,20 @@ resource "huaweicloud_taurusdb_sql_auto_throttling" "test" {
   max_concurrency = 1000
   retain_sql_rule = "true"
 }
-`, acceptance.HW_TAURUSDB_INSTANCE_ID, acceptance.HW_TAURUSDB_NODE_ID)
+`, testAccTaurusDBInstanceConfig_basic(name))
 }
 
-func testAccTaurusDBSqlAutoThrottling_update() string {
+func testAccTaurusDBSqlAutoThrottling_update(name string) string {
 	return fmt.Sprintf(`
+%s
+
+locals {
+  master_node_id = try([for node in huaweicloud_taurusdb_instance.test.nodes : node.id if node.type == "master"][0], "")
+}
+
 resource "huaweicloud_taurusdb_sql_auto_throttling" "test" {
-  instance_id     = "%[1]s"
-  node_id         = "%[2]s"
+  instance_id     = huaweicloud_taurusdb_instance.test.id
+  node_id         = local.master_node_id
   start_time      = "02:00"
   end_time        = "03:00"
   condition       = "or"
@@ -155,5 +166,5 @@ resource "huaweicloud_taurusdb_sql_auto_throttling" "test" {
   max_concurrency = 2000
   retain_sql_rule = "false"
 }
-`, acceptance.HW_TAURUSDB_INSTANCE_ID, acceptance.HW_TAURUSDB_NODE_ID)
+`, testAccTaurusDBInstanceConfig_basic(name))
 }

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_lts_config.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_lts_config.go
@@ -28,9 +28,9 @@ var htapLTSConfigNoneUpdatableParams = []string{
 // @API TaurusDB DELETE /v3/{project_id}/starrocks/instances/logs/lts-configs
 func ResourceTaurusDBHtapStarrocksLtsConfig() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceTaurusDBHtapStarrocksLtsConfigCreateOrUpdate,
+		CreateContext: resourceTaurusDBHtapStarrocksLtsConfigCreate,
 		ReadContext:   resourceTaurusDBHtapStarrocksLtsConfigRead,
-		UpdateContext: resourceTaurusDBHtapStarrocksLtsConfigCreateOrUpdate,
+		UpdateContext: resourceTaurusDBHtapStarrocksLtsConfigUpdate,
 		DeleteContext: resourceTaurusDBHtapStarrocksLtsConfigDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceTaurusDBHtapStarrocksLtsConfigImportState,
@@ -71,11 +71,10 @@ func ResourceTaurusDBHtapStarrocksLtsConfig() *schema.Resource {
 	}
 }
 
-func resourceTaurusDBHtapStarrocksLtsConfigCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaurusDBHtapStarrocksLtsConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg        = meta.(*config.Config)
 		region     = cfg.GetRegion(d)
-		httpUrl    = "v3/{project_id}/starrocks/instances/logs/lts-configs"
 		instanceID = d.Get("instance_id").(string)
 		logType    = d.Get("log_type").(string)
 	)
@@ -84,14 +83,7 @@ func resourceTaurusDBHtapStarrocksLtsConfigCreateOrUpdate(ctx context.Context, d
 		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
-	createPath := client.Endpoint + httpUrl
-	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
-	createOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-		JSONBody:         buildTaurusDBHtapStarrocksLtsConfigBodyParams(d),
-	}
-	_, err = client.Request("POST", createPath, &createOpt)
+	err = createOrUpdateHtapStarrocksLtsConfig(client, d)
 	if err != nil {
 		return diag.Errorf("error creating TaurusDB HTAP StarRocks LTS config: %s", err)
 	}
@@ -99,6 +91,41 @@ func resourceTaurusDBHtapStarrocksLtsConfigCreateOrUpdate(ctx context.Context, d
 	d.SetId(fmt.Sprintf("%s/%s", instanceID, logType))
 
 	return resourceTaurusDBHtapStarrocksLtsConfigRead(ctx, d, meta)
+}
+
+func resourceTaurusDBHtapStarrocksLtsConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		err = createOrUpdateHtapStarrocksLtsConfig(client, d)
+		if err != nil {
+			return diag.Errorf("error updating TaurusDB HTAP StarRocks LTS config: %s", err)
+		}
+	}
+
+	return resourceTaurusDBHtapStarrocksLtsConfigRead(ctx, d, meta)
+}
+
+func createOrUpdateHtapStarrocksLtsConfig(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	updatePath := client.Endpoint + "v3/{project_id}/starrocks/instances/logs/lts-configs"
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildTaurusDBHtapStarrocksLtsConfigBodyParams(d),
+	}
+	_, err := client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func buildTaurusDBHtapStarrocksLtsConfigBodyParams(d *schema.ResourceData) map[string]interface{} {

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_sql_auto_throttling.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_sql_auto_throttling.go
@@ -109,52 +109,52 @@ func ResourceTaurusDBSqlAutoThrottling() *schema.Resource {
 func resourceTaurusDBSqlAutoThrottlingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		httpUrl = "v3/{project_id}/instances/{instance_id}/auto-sql-limiting"
-		product = "gaussdb"
-	)
-
-	client, err := cfg.NewServiceClient(product, region)
+	instanceId := d.Get("instance_id").(string)
+	nodeId := d.Get("node_id").(string)
+	client, err := cfg.NewServiceClient("gaussdb", region)
 	if err != nil {
 		return diag.Errorf("error creating TaurusDB client: %s", err)
 	}
 
-	createPath := client.Endpoint + httpUrl
-	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
-	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
-
-	createOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-	}
-	createOpt.JSONBody = utils.RemoveNil(buildCreateSqlAutoThrottlingBodyParams(d))
-
-	createResp, err := client.Request("PUT", createPath, &createOpt)
+	err = createOrUpdateSqlAutoThrottling(ctx, client, d)
 	if err != nil {
-		return diag.Errorf("error creating TaurusDB SQL auto throttling: %s", err)
+		return diag.Errorf("error creating sql auto throttling for TaurusDB instance (%s): %s", instanceId, err)
 	}
-
-	createRespBody, err := utils.FlattenResponse(createResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	instanceId := d.Get("instance_id").(string)
-	nodeId := d.Get("node_id").(string)
 	d.SetId(fmt.Sprintf("%s/%s", instanceId, nodeId))
 
-	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	return resourceTaurusDBSqlAutoThrottlingRead(ctx, d, meta)
+}
+
+func createOrUpdateSqlAutoThrottling(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v3/{project_id}/instances/{instance_id}/auto-sql-limiting"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", d.Get("instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildCreateSqlAutoThrottlingBodyParams(d),
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
 	if jobId == "" {
-		return diag.Errorf("unable to find the job ID from the API response")
+		return fmt.Errorf("error requesting TaurusDB SQL auto throttling: job_id is not found in API response")
 	}
 
 	err = checkGaussDBMySQLProxyJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error waiting for TaurusDB SQL auto throttling job (%s) to complete: %s", jobId, err)
+		return fmt.Errorf("error waiting for TaurusDB SQL auto throttling job (%s) to complete: %s", jobId, err)
 	}
-
-	return resourceTaurusDBSqlAutoThrottlingRead(ctx, d, meta)
+	return nil
 }
 
 func buildCreateSqlAutoThrottlingBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -250,45 +250,17 @@ func resourceTaurusDBSqlAutoThrottlingRead(_ context.Context, d *schema.Resource
 func resourceTaurusDBSqlAutoThrottlingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		httpUrl = "v3/{project_id}/instances/{instance_id}/auto-sql-limiting"
-		product = "gaussdb"
-	)
-
-	client, err := cfg.NewServiceClient(product, region)
+	instanceId := d.Get("instance_id").(string)
+	client, err := cfg.NewServiceClient("gaussdb", region)
 	if err != nil {
 		return diag.Errorf("error creating TaurusDB client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
-
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-	}
-	updateOpt.JSONBody = utils.RemoveNil(buildCreateSqlAutoThrottlingBodyParams(d))
-
-	updateResp, err := client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating TaurusDB SQL auto throttling: %s", err)
-	}
-
-	updateRespBody, err := utils.FlattenResponse(updateResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	jobId := utils.PathSearch("job_id", updateRespBody, "").(string)
-	if jobId == "" {
-		return diag.Errorf("unable to find the job ID from the API response")
-	}
-
-	err = checkGaussDBMySQLProxyJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return diag.Errorf("error waiting for TaurusDB SQL auto throttling job (%s) to complete: %s", jobId, err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = createOrUpdateSqlAutoThrottling(ctx, client, d)
+		if err != nil {
+			return diag.Errorf("error updating sql auto throttling for TaurusDB instance (%s): %s", instanceId, err)
+		}
 	}
 
 	return resourceTaurusDBSqlAutoThrottlingRead(ctx, d, meta)

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup.go
@@ -113,7 +113,7 @@ func ResourceNetworkingSecGroup() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		CustomizeDiff: config.MergeDefaultTags(),

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -46,7 +46,7 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		CustomizeDiff: config.MergeDefaultTags(),

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -113,7 +113,7 @@ func ResourceVpcSubnetV1() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		CustomizeDiff: config.MergeDefaultTags(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Skip update logic when only 'enable_force_new' changes for these resources:
- huaweicloud_taurusdb_htap_starrocks_lts_config
- huaweicloud_taurusdb_htap_sql_auto_throttling

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
skip update logic when only 'enable_force_new' changes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

**1. huaweicloud_taurusdb_htap_starrocks_lts_config**

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBSqlAutoThrottling'
=== RUN   TestAccTaurusDBSqlAutoThrottling_basic
=== PAUSE TestAccTaurusDBSqlAutoThrottling_basic
=== CONT  TestAccTaurusDBSqlAutoThrottling_basic
--- PASS: TestAccTaurusDBSqlAutoThrottling_basic (1771.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 1771.563s
```

**change attributes excpet `enable_force_new`:**
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/15a4fb9c-d028-4e6b-9700-72b2c84b50f1" />

 **only change attribute `enable_force_new`:**
<img width="1833" height="958" alt="image" src="https://github.com/user-attachments/assets/b84c2ea4-b582-4993-adfb-c8304d380037" />

**2. huaweicloud_taurusdb_htap_sql_auto_throttling**

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBHtapStarrocksLtsConfig'
=== RUN   TestAccTaurusDBHtapStarrocksLtsConfig_basic
=== PAUSE TestAccTaurusDBHtapStarrocksLtsConfig_basic
=== CONT  TestAccTaurusDBHtapStarrocksLtsConfig_basic
--- PASS: TestAccTaurusDBHtapStarrocksLtsConfig_basic (1762.76s)
=== RUN   TestAccTaurusDBHtapStarrocksLtsConfig_slowLog
=== PAUSE TestAccTaurusDBHtapStarrocksLtsConfig_slowLog
=== CONT  TestAccTaurusDBHtapStarrocksLtsConfig_slowLog
--- PASS: TestAccTaurusDBHtapStarrocksLtsConfig_slowLog (1728.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 1762.789s
```

**change attributes excpet `enable_force_new`:**
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/d215ddbb-6700-4e00-9d17-fd9f0eb317a1" />

 **only change attribute `enable_force_new`:**
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/9c711919-c709-4c0c-8c81-d904925e8d50" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
