### PR TITLE
refactor(method): replace manual contains loops with slices.Contains

### DIFF
--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_v2_test.go
@@ -3,6 +3,7 @@ package deprecated
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -236,10 +237,8 @@ func testAccCheckImagesImageV2HasTag(n, tag string) resource.TestCheckFunc {
 			return fmt.Errorf("the image is not found, which ID is %s", rs.Primary.ID)
 		}
 
-		for _, v := range found.Tags {
-			if tag == v {
-				return nil
-			}
+		if slices.Contains(found.Tags, tag) {
+			return nil
 		}
 
 		return fmt.Errorf("the tag is not found: %s", tag)

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_servergroup_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_servergroup_test.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -156,12 +157,8 @@ func testAccCheckComputeServerGroupExists(n string, kp *servergroups.ServerGroup
 
 func testAccCheckComputeInstanceInServerGroup(instance *cloudservers.CloudServer, sg *servergroups.ServerGroup) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
-		if len(sg.Members) > 0 {
-			for _, m := range sg.Members {
-				if m == instance.ID {
-					return nil
-				}
-			}
+		if len(sg.Members) > 0 && slices.Contains(sg.Members, instance.ID) {
+			return nil
 		}
 
 		return fmt.Errorf("instance %s does not belong to server group %s", instance.ID, sg.ID)

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go
@@ -3,6 +3,7 @@ package lb
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -278,10 +279,8 @@ func testAccCheckLBV2LoadBalancerHasSecGroup(
 			return err
 		}
 
-		for _, p := range port.SecurityGroups {
-			if p == sg.ID {
-				return nil
-			}
+		if slices.Contains(port.SecurityGroups, sg.ID) {
+			return nil
 		}
 
 		return fmt.Errorf("LoadBalancer does not have the security group")

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fw_rule_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fw_rule_v2.go
@@ -3,6 +3,7 @@ package deprecated
 import (
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -265,11 +266,9 @@ func assignedPolicyID(fwClient *golangsdk.ServiceClient, ruleID string) (string,
 			return false, err
 		}
 		for _, policy := range policyList {
-			for _, rule := range policy.Rules {
-				if rule == ruleID {
-					policyID = policy.ID
-					return false, nil
-				}
+			if slices.Contains(policy.Rules, ruleID) {
+				policyID = policy.ID
+				return false, nil
 			}
 		}
 		return true, nil

--- a/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_images_image_v2.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -349,10 +350,8 @@ func resourceImagesImageV2ValidateVisibility(v interface{}, k string) (ws []stri
 		"private",
 	}
 
-	for _, v := range validVisibilities {
-		if value == v {
-			return
-		}
+	if slices.Contains(validVisibilities, value) {
+		return
 	}
 
 	err := fmt.Errorf("%s must be one of %s", k, validVisibilities)

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -3,6 +3,7 @@ package deprecated
 import (
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -417,19 +418,12 @@ func buildWeekFrequencyResource(d *schema.ResourceData) ([]string, error) {
 
 	weekRaws := d.Get("week_frequency").([]interface{})
 	for _, wf := range weekRaws {
-		found := false
-		for _, value := range validateList {
-			if wf.(string) == value {
-				found = true
-				break
-			}
-		}
-
-		if found {
-			weeks = append(weeks, wf.(string))
+		week := wf.(string)
+		if slices.Contains(validateList, week) {
+			weeks = append(weeks, week)
 		} else {
 			return nil, fmt.Errorf("expected item of week_frequency to be one of %v, got %s",
-				validateList, wf.(string))
+				validateList, week)
 		}
 	}
 	return weeks, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Replace the manual “contains” loop with `slices.Contains` (gopls `slicescontains` modernize).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. replace manual contains loops with slices.Contains
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lb -f TestAccLBV2LoadBalancer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lb" -v -coverprofile="./huaweicloud/services/acceptance/lb/lb_coverage.cov" -coverpkg="./huaweicloud/services/lb" -run TestAccLBV2LoadBalancer_basic -timeout 360m -parallel 10
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (80.20s)
PASS
coverage: 10.3% of statements in ./huaweicloud/services/lb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        80.323s coverage: 10.3% of statements in ./huaweicloud/services/lb
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
