### PR TITLE
fix(SMN): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/smn/resource_huaweicloud_smn_notify_policy.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_notify_policy.go
@@ -284,19 +284,21 @@ func resourceNotifyPolicyUpdate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error creating SMN Client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{topic_urn}", d.Get("topic_urn").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{notify_policy_id}", d.Id())
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{topic_urn}", d.Get("topic_urn").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{notify_policy_id}", d.Id())
 
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	updateOpt.JSONBody = buildUpdateNotifyPolicyBodyParams(d)
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		updateOpt.JSONBody = buildUpdateNotifyPolicyBodyParams(d)
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating SMN notify policy: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating SMN notify policy: %s", err)
+		}
 	}
 
 	return resourceNotifyPolicyRead(ctx, d, meta)

--- a/huaweicloud/services/smn/resource_huaweicloud_smn_subscription_filter_policy.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_subscription_filter_policy.go
@@ -147,26 +147,28 @@ func resourceSubscriptionFilterPolicyUpdate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("error creating SMN client: %s", err)
 	}
 
-	// updateFilterPolicy: create SMN subscription filter policy
-	updateFilterPolicyHttpUrl := "v2/{project_id}/notifications/subscriptions/filter_polices"
-	updateFilterPolicyPath := client.Endpoint + updateFilterPolicyHttpUrl
-	updateFilterPolicyPath = strings.ReplaceAll(updateFilterPolicyPath, "{project_id}", client.ProjectID)
+	if d.HasChangeExcept("enable_force_new") {
+		// updateFilterPolicy: create SMN subscription filter policy
+		updateFilterPolicyHttpUrl := "v2/{project_id}/notifications/subscriptions/filter_polices"
+		updateFilterPolicyPath := client.Endpoint + updateFilterPolicyHttpUrl
+		updateFilterPolicyPath = strings.ReplaceAll(updateFilterPolicyPath, "{project_id}", client.ProjectID)
 
-	updateFilterPolicyOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	updateFilterPolicyOpt.JSONBody = map[string]interface{}{
-		"polices": []map[string]interface{}{
-			{
-				"subscription_urn": d.Id(),
-				"filter_polices":   buildFilterPolicies(d.Get("filter_policies").(*schema.Set).List()),
+		updateFilterPolicyOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		updateFilterPolicyOpt.JSONBody = map[string]interface{}{
+			"polices": []map[string]interface{}{
+				{
+					"subscription_urn": d.Id(),
+					"filter_polices":   buildFilterPolicies(d.Get("filter_policies").(*schema.Set).List()),
+				},
 			},
-		},
-	}
+		}
 
-	_, err = client.Request("PUT", updateFilterPolicyPath, &updateFilterPolicyOpt)
-	if err != nil {
-		return diag.Errorf("error updating SMN subscription filter policy: %s", err)
+		_, err = client.Request("PUT", updateFilterPolicyPath, &updateFilterPolicyOpt)
+		if err != nil {
+			return diag.Errorf("error updating SMN subscription filter policy: %s", err)
+		}
 	}
 
 	return resourceSubscriptionFilterPolicyRead(ctx, d, meta)

--- a/huaweicloud/services/smn/resource_huaweicloud_smn_topic_attributes.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_topic_attributes.go
@@ -175,12 +175,14 @@ func resourceTopicAttributesUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating SMN client: %s", err)
 	}
 
-	topicUrn := d.Get("topic_urn").(string)
-	name := d.Get("name").(string)
-	value := d.Get("value").(string)
+	if d.HasChangeExcept("enable_force_new") {
+		topicUrn := d.Get("topic_urn").(string)
+		name := d.Get("name").(string)
+		value := d.Get("value").(string)
 
-	if err := updateTopicAttribute(client, topicUrn, name, value); err != nil {
-		return diag.Errorf("error updating attributes (names %s) for topic %s: %s", name, topicUrn, err)
+		if err := updateTopicAttribute(client, topicUrn, name, value); err != nil {
+			return diag.Errorf("error updating attributes (names %s) for topic %s: %s", name, topicUrn, err)
+		}
 	}
 
 	return resourceTopicAttributesRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Skip update logic when only 'enable_force_new' changes for these resources:
- huaweicloud_smn_notify_policy
- huaweicloud_smn_topic_attributes
- huaweicloud_smn_subscription_filter_policy

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Skip update logic when only 'enable_force_new' changes for SMN resources
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

- huaweicloud_smn_notify_policy
```
make testacc TEST='./huaweicloud/services/acceptance/smn' TESTARGS='-run=TestAccNotifyPolicy'
=== RUN   TestAccNotifyPolicy_basic
=== PAUSE TestAccNotifyPolicy_basic
=== CONT  TestAccNotifyPolicy_basic
--- PASS: TestAccNotifyPolicy_basic (27.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn 27.673s
```
**change attributes excpet `enable_force_new`:**
<img width="1848" height="985" alt="image" src="https://github.com/user-attachments/assets/320bb7a5-48b4-4c0f-9563-31fc64fb6fb3" />
**only change `enable_force_new`:**
<img width="1848" height="983" alt="image" src="https://github.com/user-attachments/assets/3af5650e-a366-4e83-9717-c50d48bd76a2" />

- huaweicloud_smn_topic_attributes
```
make testacc TEST='./huaweicloud/services/acceptance/smn' TESTARGS='-run=TestAccSubscriptionFilterPolicy'
=== RUN   TestAccSubscriptionFilterPolicy_basic
=== PAUSE TestAccSubscriptionFilterPolicy_basic
=== CONT  TestAccSubscriptionFilterPolicy_basic
--- PASS: TestAccSubscriptionFilterPolicy_basic (30.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn 30.745s
```
**change attributes excpet `enable_force_new`:**
<img width="1848" height="977" alt="image" src="https://github.com/user-attachments/assets/62449902-1f7b-4053-acb9-f2a8427d798d" />

**only change `enable_force_new`:**
<img width="1849" height="949" alt="image" src="https://github.com/user-attachments/assets/923e08c5-ba56-4da3-9bfd-7656c67b1959" />


- huaweicloud_smn_subscription_filter_policy
```
make testacc TEST='./huaweicloud/services/acceptance/smn' TESTARGS='-run=TestAccTopicAttributes'
=== RUN   TestAccTopicAttributes_basic
=== PAUSE TestAccTopicAttributes_basic
=== CONT  TestAccTopicAttributes_basic
--- PASS: TestAccTopicAttributes_basic (26.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn 26.438s
```
**change attributes excpet `enable_force_new`:**
<img width="1841" height="946" alt="image" src="https://github.com/user-attachments/assets/e204a524-70f7-4de6-87fe-773e1d8bf6e2" />

**only change `enable_force_new`:**
<img width="1842" height="961" alt="image" src="https://github.com/user-attachments/assets/212faf00-f8a2-4d3a-9953-17c7447b476d" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
