### PR TITLE
fix(CCE): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_test.go
@@ -133,7 +133,7 @@ func TestAccCluster_withEip(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"eip", "certificate_users.0.client_certificate_data", "kube_config_raw",
+					"eip", "certificate_users.0.client_key_data", "certificate_users.0.client_certificate_data", "kube_config_raw",
 				},
 			},
 		},
@@ -188,7 +188,6 @@ func TestAccCluster_turbo(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "container_network_type", "eni"),
-					resource.TestCheckResourceAttr(resourceName, "enable_dist_mgt", "true"),
 					resource.TestCheckOutput("is_eni_subnet_id_different", "false"),
 				),
 			},
@@ -638,7 +637,6 @@ resource "huaweicloud_cce_cluster" "test" {
   vpc_id                 = huaweicloud_vpc.test.id
   subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "eni"
-  enable_dist_mgt        = true
   eni_subnet_id          = join(",", huaweicloud_vpc_subnet.eni_test[*].ipv4_subnet_id)
 }
 

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -210,6 +210,7 @@ func ResourceCluster() *schema.Resource {
 			"agency_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"authenticating_proxy_ca": {
 				Type:         schema.TypeString,

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_log_config.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_log_config.go
@@ -22,8 +22,8 @@ var logConfigNonUpdatableParams = []string{"cluster_id"}
 // @API CCE GET /api/v3/projects/{project_id}/cluster/{cluster_id}/log-configs
 func ResourceClusterLogConfig() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceClusterLogConfigCreateOrUpdate,
-		UpdateContext: resourceClusterLogConfigCreateOrUpdate,
+		CreateContext: resourceClusterLogConfigCreate,
+		UpdateContext: resourceClusterLogConfigUpdate,
 		ReadContext:   resourceClusterLogConfigRead,
 		DeleteContext: resourceClusterLogConfigDelete,
 		Importer: &schema.ResourceImporter{
@@ -108,37 +108,58 @@ func buildLogConfigsCreateBodyParams(d *schema.ResourceData) []map[string]interf
 	return bodyParams
 }
 
-func resourceClusterLogConfigCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		createClusterLogConfigHttpUrl = "api/v3/projects/{project_id}/cluster/{cluster_id}/log-configs"
-		createClusterLogConfigProduct = "cce"
-	)
-
-	clusterID := d.Get("cluster_id").(string)
+func resourceClusterLogConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.NewServiceClient(createClusterLogConfigProduct, cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("cce", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	createClusterLogConfigPath := client.Endpoint + createClusterLogConfigHttpUrl
-	createClusterLogConfigPath = strings.ReplaceAll(createClusterLogConfigPath, "{project_id}", client.ProjectID)
-	createClusterLogConfigPath = strings.ReplaceAll(createClusterLogConfigPath, "{cluster_id}", clusterID)
-
-	createClusterLogConfigOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	createClusterLogConfigOpt.JSONBody = utils.RemoveNil(buildClusterLogConfigCreateBodyParams(d))
-	_, err = client.Request("PUT", createClusterLogConfigPath, &createClusterLogConfigOpt)
+	err = updateClusterLogConfig(client, d)
 	if err != nil {
-		return diag.Errorf("error updating CCE cluster log config: %s", err)
+		return diag.Errorf("error creating CCE cluster log config: %s", err)
 	}
 
-	if d.IsNewResource() {
-		d.SetId(clusterID)
-	}
+	d.SetId(d.Get("cluster_id").(string))
 	return resourceClusterLogConfigRead(ctx, d, meta)
+}
+
+func resourceClusterLogConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cce", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CCE Client: %s", err)
+	}
+
+	// Only call the update API when a real field changes. Skip it when only
+	// "enable_force_new" is updated to avoid an unnecessary API call.
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateClusterLogConfig(client, d)
+		if err != nil {
+			return diag.Errorf("error updating CCE cluster log config: %s", err)
+		}
+	}
+
+	return resourceClusterLogConfigRead(ctx, d, meta)
+}
+
+// updateClusterLogConfig is the core function that sends a PUT request to create or update the
+// CCE cluster log config.
+func updateClusterLogConfig(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	clusterID := d.Get("cluster_id").(string)
+	updatePath := client.Endpoint + "api/v3/projects/{project_id}/cluster/{cluster_id}/log-configs"
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", clusterID)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	updateOpt.JSONBody = utils.RemoveNil(buildClusterLogConfigCreateBodyParams(d))
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
 }
 
 func resourceClusterLogConfigRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -966,29 +966,31 @@ func resourceNodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error creating CCE v3 client: %s", err)
 	}
 
-	updateOpts, err := buildNodePoolUpdateOpts(d, cfg)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	clusterId := d.Get("cluster_id").(string)
-	nodePoolId := d.Id()
-	_, err = nodepools.Update(cceClient, clusterId, nodePoolId, updateOpts).Extract()
-	if err != nil {
-		return diag.Errorf("error updating CCE node pool (%s): %s", nodePoolId, err)
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updateOpts, err := buildNodePoolUpdateOpts(d, cfg)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		clusterId := d.Get("cluster_id").(string)
+		nodePoolId := d.Id()
+		_, err = nodepools.Update(cceClient, clusterId, nodePoolId, updateOpts).Extract()
+		if err != nil {
+			return diag.Errorf("error updating CCE node pool (%s): %s", nodePoolId, err)
+		}
 
-	stateConf := &retry.StateChangeConf{
-		// The statuses of pending phase includes "Synchronizing" and "Synchronized".
-		Pending:      []string{"PENDING"},
-		Target:       []string{"COMPLETED"},
-		Refresh:      nodePoolStateRefreshFunc(cceClient, clusterId, nodePoolId, []string{""}),
-		Timeout:      d.Timeout(schema.TimeoutUpdate),
-		Delay:        30 * time.Second,
-		PollInterval: 10 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.Errorf("error waiting for CCE node pool (%s) to become available: %s", nodePoolId, err)
+		stateConf := &retry.StateChangeConf{
+			// The statuses of pending phase includes "Synchronizing" and "Synchronized".
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      nodePoolStateRefreshFunc(cceClient, clusterId, nodePoolId, []string{""}),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			Delay:        30 * time.Second,
+			PollInterval: 10 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error waiting for CCE node pool (%s) to become available: %s", nodePoolId, err)
+		}
 	}
 
 	return resourceNodePoolRead(ctx, d, meta)

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_release.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_release.go
@@ -247,6 +247,9 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	createReleaseOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	bodyParams, err := buildCreateReleaseBodyParams(d)
@@ -284,6 +287,9 @@ func resourceReleaseRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 	getReleaseOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	getReleaseResp, err := getReleaseClient.Request("GET", getReleaseHttpPath, &getReleaseOpt)
@@ -346,23 +352,25 @@ func resourceReleaseUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	updateReleasePath := updateReleaseClient.Endpoint + updateReleaseHttpUrl
-	updateReleasePath = strings.ReplaceAll(updateReleasePath, "{cluster_id}", d.Get("cluster_id").(string))
-	updateReleasePath = strings.ReplaceAll(updateReleasePath, "{namespace}", d.Get("namespace").(string))
-	updateReleasePath = strings.ReplaceAll(updateReleasePath, "{name}", d.Id())
+	if d.HasChangeExcept("enable_force_new") {
+		updateReleasePath := updateReleaseClient.Endpoint + updateReleaseHttpUrl
+		updateReleasePath = strings.ReplaceAll(updateReleasePath, "{cluster_id}", d.Get("cluster_id").(string))
+		updateReleasePath = strings.ReplaceAll(updateReleasePath, "{namespace}", d.Get("namespace").(string))
+		updateReleasePath = strings.ReplaceAll(updateReleasePath, "{name}", d.Id())
 
-	updateReleaseOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
+		updateReleaseOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
 
-	bodyParams, err := buildUpdateReleaseBodyParams(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	updateReleaseOpt.JSONBody = utils.RemoveNil(bodyParams)
-	_, err = updateReleaseClient.Request("PUT", updateReleasePath, &updateReleaseOpt)
-	if err != nil {
-		return diag.Errorf("error updating CCE release: %s", err)
+		bodyParams, err := buildUpdateReleaseBodyParams(d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		updateReleaseOpt.JSONBody = utils.RemoveNil(bodyParams)
+		_, err = updateReleaseClient.Request("PUT", updateReleasePath, &updateReleaseOpt)
+		if err != nil {
+			return diag.Errorf("error updating CCE release: %s", err)
+		}
 	}
 
 	return resourceReleaseRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Skip update logic when only 'enable_force_new' changes for these resources:
- huaweicloud_taurusdb_cce_cluster_log_config
- huaweicloud_taurusdb_cce_node_pool
- huaweicloud_taurusdb_cce_release

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Skip update logic when only 'enable_force_new' changes for CCE resources
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
- huaweicloud_taurusdb_cce_cluster_log_config
 ```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run=TestAccClusterLogConfig'
=== RUN   TestAccClusterLogConfig_basic
=== PAUSE TestAccClusterLogConfig_basic
=== CONT  TestAccClusterLogConfig_basic
--- PASS: TestAccClusterLogConfig_basic (517.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce 517.338s
```

**change attributes excpet `enable_force_new`:**
<img width="1848" height="954" alt="image" src="https://github.com/user-attachments/assets/3439b566-56ae-457f-8a3b-5975e4ad85d0" />

**only change `enable_force_new`:**
<img width="1833" height="941" alt="image" src="https://github.com/user-attachments/assets/c4308b76-1fd1-4d0f-8c2c-0ac89a59cde4" />

- huaweicloud_taurusdb_cce_node_pool
 ```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run=TestAccNodePool'
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== CONT  TestAccNodePool_basic
--- PASS: TestAccNodePool_basic (1101.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce 1101.314s
```

**change attributes excpet `enable_force_new`:**
<img width="1852" height="971" alt="image" src="https://github.com/user-attachments/assets/5c02ded9-2567-41c1-bec8-2e60d2964541" />

**only change `enable_force_new`:**
<img width="1835" height="974" alt="image" src="https://github.com/user-attachments/assets/0bfdf1e5-cc59-4bea-96e5-d0611442f4df" />

- huaweicloud_taurusdb_cce_release
```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run=TestAccRelease'
=== RUN   TestAccRelease_basic
=== PAUSE TestAccRelease_basic
=== CONT  TestAccRelease_basic
--- PASS: TestAccRelease_basic (450.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce 450.306s
```

**change attributes excpet `enable_force_new`:**
<img width="1818" height="943" alt="image" src="https://github.com/user-attachments/assets/e21747cc-e84f-41a9-b3fe-ce6d00b4364a" />
**only change `enable_force_new`:**
<img width="1832" height="950" alt="image" src="https://github.com/user-attachments/assets/c70acb77-1e4a-4cd8-831e-7d043bdc9dd7" />


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
