### PR TITLE
feat(drs): support `drs_start_job` resource

### DIFF
--- a/docs/resources/drs_start_job.md
+++ b/docs/resources/drs_start_job.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_start_job"
+description: |-
+  Manages a resource to start a DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_start_job
+
+Manages a resource to start a DRS job within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to start a DRS job. Deleting this resource will not stop the
+  job or undo the start action, but will only remove the resource information from the tf state file.
+  <br/>2. The resource performs a pre-check before starting the job.
+  <br/>3. You must specify an existing DRS job ID. If the job does not exist or is not in a pending start status,
+  the operation may fail.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+resource "huaweicloud_drs_start_job" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the job ID.
+
+* `start_time` - (Optional, String, NonUpdatable) Specifies the time to start the job. The time format is a timestamp
+  precise to the millisecond, e.g. **1684466549755**, which indicates **2023-05-19 11:22:29.755**.
+  Start immediately by default.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `job_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3902,6 +3902,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_object_compare":                 drs.ResourceObjectCompare(),
 			"huaweicloud_drs_pwd_batch_modify":               drs.ResourcePwdBatchModify(),
 			"huaweicloud_drs_smn_batch_set":                  drs.ResourceDrsSmnBatchSet(),
+			"huaweicloud_drs_start_job":                      drs.ResourceStartJob(),
 			"huaweicloud_drs_stop_job":                       drs.ResourceStopJob(),
 
 			"huaweicloud_dws_alarm_subscription":              dws.ResourceDwsAlarmSubs(),

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_start_job_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_start_job_test.go
@@ -1,0 +1,236 @@
+package drs
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccStartJob_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testStartJob_with_update_data_progress_rules_basic(),
+			},
+		},
+	})
+}
+
+func testStartJob_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = "%[1]s"
+  delete_default_rules = true
+}
+
+resource "huaweicloud_networking_secgroup_rule" "ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  ports             = "3306,9092"
+  protocol          = "tcp"
+  remote_ip_prefix  = "192.168.0.0/16"
+  security_group_id = huaweicloud_networking_secgroup.test.id
+}
+
+resource "huaweicloud_networking_secgroup_rule" "egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  remote_ip_prefix  = "192.168.0.0/16"
+  security_group_id = huaweicloud_networking_secgroup.test.id
+}
+
+resource "huaweicloud_rds_instance" "test1" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.ingress,
+    huaweicloud_networking_secgroup_rule.egress,
+  ]
+
+  name                = "%[1]s_1"
+  flavor              = "rds.mysql.x1.large.2.ha"
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  vpc_id              = huaweicloud_vpc.test.id
+  fixed_ip            = "192.168.0.50"
+  ha_replication_mode = "semisync"
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0],
+    data.huaweicloud_availability_zones.test.names[3],
+  ]
+
+  db {
+    password = "TestDrs@123"
+    type     = "MySQL"
+    version  = "5.7"
+    port     = 3306
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 40
+  }
+}
+
+resource "huaweicloud_rds_instance" "test2" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.ingress,
+    huaweicloud_networking_secgroup_rule.egress,
+  ]
+
+  name                = "%[1]s_2"
+  flavor              = "rds.mysql.x1.large.2.ha"
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  vpc_id              = huaweicloud_vpc.test.id
+  fixed_ip            = "192.168.0.51"
+  ha_replication_mode = "semisync"
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0],
+    data.huaweicloud_availability_zones.test.names[3],
+  ]
+
+  db {
+    password = "TestDrs@123"
+    type     = "MySQL"
+    version  = "5.7"
+    port     = 3306
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 40
+  }
+}
+
+resource "huaweicloud_rds_mysql_database" "test" {
+  instance_id   = huaweicloud_rds_instance.test1.id
+  name          = "%[1]s"
+  character_set = "utf8"
+}
+
+data "huaweicloud_drs_node_types" "test" {
+  engine_type = "mysql"
+  type        = "sync"
+  direction   = "up"
+}
+
+resource "huaweicloud_drs_job" "test" {
+  name           = "%[1]s"
+  type           = "sync"
+  engine_type    = "mysql"
+  direction      = "up"
+  node_type      = data.huaweicloud_drs_node_types.test.node_types[0]
+  net_type       = "vpc"
+  migration_type = "FULL_INCR_TRANS"
+  description    = "description test"
+  force_destroy  = true
+
+  source_db {
+    engine_type = "mysql"
+    ip          = huaweicloud_rds_instance.test1.fixed_ip
+    port        = 3306
+    user        = "root"
+    password    = "TestDrs@123"
+    vpc_id      = huaweicloud_rds_instance.test1.vpc_id
+    subnet_id   = huaweicloud_rds_instance.test1.subnet_id
+  }
+
+  destination_db {
+    region      = huaweicloud_rds_instance.test2.region
+    ip          = huaweicloud_rds_instance.test2.fixed_ip
+    port        = 3306
+    engine_type = "mysql"
+    user        = "root"
+    password    = "TestDrs@123"
+    instance_id = huaweicloud_rds_instance.test2.id
+    subnet_id   = huaweicloud_rds_instance.test2.subnet_id
+  }
+
+  databases = [huaweicloud_rds_mysql_database.test.name]
+
+  policy_config {
+    filter_ddl_policy = "drop_database"
+    conflict_policy   = "overwrite"
+    index_trans       = true
+  }
+
+  is_start_job  = false
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "true"
+
+  limit_speed {
+    speed      = "15"
+    start_time = "16:00"
+    end_time   = "17:59"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      source_db.0.password, destination_db.0.password, force_destroy,
+    ]
+  }
+}
+`, name)
+}
+
+func testStartJob_with_update_data_progress_rules_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_drs_update_data_progress_rules" "test" {
+  job_id = huaweicloud_drs_job.test.id
+
+  data_process_info {
+    add_columns {
+      column_type  = "ADDITIONALCOLUMN,create_time"
+      column_name  = "name"
+      column_value = "__create_timestamp"
+      data_type    = "long"
+    }
+
+    db_object {
+      object_scope = "database"
+
+      object_info = jsonencode({
+        (huaweicloud_rds_mysql_database.test.name) = {
+          "all" = true
+        }
+      })
+    }
+  }
+}
+
+resource "huaweicloud_drs_start_job" "test" {
+  depends_on = [huaweicloud_drs_update_data_progress_rules.test]
+
+  job_id = huaweicloud_drs_job.test.id
+}
+`, testStartJob_base(name))
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -154,6 +154,12 @@ func ResourceDrsJob() *schema.Resource {
 				ForceNew: true,
 				Default:  14,
 			},
+			"is_start_job": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "schema: Internal",
+			},
 			"start_time": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -772,29 +778,32 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 	}
 
-	startTime := d.Get("start_time").(string)
-	startMode := "start"
-	if startTime != "" && startTime != "0" {
-		startMode = "start_later"
-	}
+	if getIsStartJob(d) {
+		startTime := d.Get("start_time").(string)
+		startMode := "start"
+		if startTime != "" && startTime != "0" {
+			startMode = "start_later"
+		}
 
-	startReq := jobs.StartJobReq{
-		Jobs: []jobs.StartInfo{
-			{
-				JobId:     jobId,
-				StartTime: startTime,
+		startReq := jobs.StartJobReq{
+			Jobs: []jobs.StartInfo{
+				{
+					JobId:     jobId,
+					StartTime: startTime,
+				},
 			},
-		},
-	}
-	_, err = jobs.Start(client, startReq)
-	if err != nil {
-		return diag.Errorf("start DRS job failed,error: %s", err)
+		}
+		_, err = jobs.Start(client, startReq)
+		if err != nil {
+			return diag.Errorf("start DRS job failed,error: %s", err)
+		}
+
+		err = waitingforJobStatus(ctx, client, jobId, startMode, d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
-	err = waitingforJobStatus(ctx, client, jobId, startMode, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return diag.FromErr(err)
-	}
 	return resourceJobRead(ctx, d, meta)
 }
 
@@ -1038,7 +1047,18 @@ func resourceJobRead(_ context.Context, d *schema.ResourceData, meta interface{}
 	)
 
 	// set objects
-	if detail.ObjectSwitch {
+	databases := d.Get("databases")
+	tables := d.Get("tables")
+	if !getIsStartJob(d) {
+		// The job is not started by this resource, the API may not return the selected objects.
+		// Backfill databases/tables from the configuration.
+		if dbSet, ok := databases.(*schema.Set); ok && dbSet.Len() > 0 {
+			mErr = multierror.Append(mErr, d.Set("databases", databases))
+		}
+		if tableSet, ok := tables.(*schema.Set); ok && tableSet.Len() > 0 {
+			mErr = multierror.Append(mErr, d.Set("tables", tables))
+		}
+	} else if detail.ObjectSwitch {
 		objectName := flattenObjectName(detail.ObjectInfos, detail.SyncDatabase)
 		if detail.SyncDatabase {
 			mErr = multierror.Append(mErr,
@@ -1076,6 +1096,18 @@ func resourceJobRead(_ context.Context, d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
+}
+
+func getIsStartJob(d *schema.ResourceData) bool {
+	if v := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "is_start_job"); v != nil {
+		return v.(bool)
+	}
+	// Import/refresh may not provide RawConfig. Keep the value already stored in state.
+	if v := utils.GetNestedObjectFromRawConfig(d.GetRawState(), "is_start_job"); v != nil {
+		return v.(bool)
+	}
+	// Omitted in configuration: keep the historical behavior of starting the job.
+	return true
 }
 
 func flattenObjectName(objectInfos []jobs.ObjectInfo, isDateBase bool) []interface{} {

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_start_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_start_job.go
@@ -1,0 +1,126 @@
+package drs
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/drs/v3/jobs"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var startJobNonUpdatableParams = []string{"job_id", "start_time"}
+
+// @API DRS POST /v3/{project_id}/jobs/batch-precheck
+// @API DRS POST /v3/{project_id}/jobs/batch-precheck-result
+// @API DRS POST /v3/{project_id}/jobs/batch-starting
+// @API DRS POST /v3/{project_id}/jobs/batch-status
+func ResourceStartJob() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStartJobCreate,
+		ReadContext:   resourceStartJobRead,
+		UpdateContext: resourceStartJobUpdate,
+		DeleteContext: resourceStartJobDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(startJobNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceStartJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		jobId  = d.Get("job_id").(string)
+	)
+
+	client, err := cfg.DrsV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DRS v3 client: %s", err)
+	}
+
+	err = preCheck(ctx, client, jobId, d.Timeout(schema.TimeoutCreate), "forStartJob")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	startTime := d.Get("start_time").(string)
+	startMode := "start"
+	if startTime != "" && startTime != "0" {
+		startMode = "start_later"
+	}
+
+	startReq := jobs.StartJobReq{
+		Jobs: []jobs.StartInfo{
+			{
+				JobId:     jobId,
+				StartTime: startTime,
+			},
+		},
+	}
+	_, err = jobs.Start(client, startReq)
+	if err != nil {
+		return diag.Errorf("Start DRS job failed: %s", err)
+	}
+
+	err = waitingforJobStatus(ctx, client, jobId, startMode, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(jobId)
+
+	return nil
+}
+
+func resourceStartJobRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceStartJobUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceStartJobDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to start a DRS job. Deleting this resource will not
+    stop the job or undo the start action, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Resource `huaweicloud_drs_update_data_progress_rules` requires that a job be in a non-started state when it is invoked. However, job involving resource `huaweicloud_drs_job` currently start automatically upon creation. Therefore, resource `huaweicloud_drs_job` needs to support the creation of a job in a non-started state, followed by the use of resource `huaweicloud_drs_start_job` to start the job.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

commit1: resource `huaweicloud_drs_job` has added an internal parameter that supports the creation of tasks that do not start immediately.

commit2: support `drs_start_job` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccStartJob_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccStartJob_basic -timeout 360m -parallel 4
=== RUN   TestAccStartJob_basic
=== PAUSE TestAccStartJob_basic
=== CONT  TestAccStartJob_basic
--- PASS: TestAccStartJob_basic (1200.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1200.603s
```

```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccResourceDrsJob_sync"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_sync -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_sync
=== PAUSE TestAccResourceDrsJob_sync
=== CONT  TestAccResourceDrsJob_sync
--- PASS: TestAccResourceDrsJob_sync (1394.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1394.520s
```



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
