### PR TITLE
fix(ces): restore the logic which part of parameters support default value

### DIFF
--- a/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go
+++ b/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go
@@ -341,11 +341,25 @@ func testCESAlarmRule_instanceBase(rName string) string {
 	return fmt.Sprintf(`
 %s
 
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_images_images" "test" {
+  name                  = "Ubuntu 18.04 server 64bit"
+  enterprise_project_id = "0"
+}
+
 resource "huaweicloud_compute_instance" "test" {
   count = 2
 
   name               = "ecs-%[2]s"
-  image_id           = data.huaweicloud_images_image.test.id
+  image_id           = data.huaweicloud_images_images.test.images[0].id
   flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids = [huaweicloud_networking_secgroup.test.id]
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
@@ -354,7 +368,7 @@ resource "huaweicloud_compute_instance" "test" {
     uuid = huaweicloud_vpc_subnet.test.id
   }
 }
-`, common.TestBaseComputeResources(rName), rName)
+`, common.TestBaseNetwork(rName), rName)
 }
 
 func testCESAlarmRule_topicBase(rName string) string {

--- a/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
@@ -476,10 +476,10 @@ func buildPoliciesOpts(d *schema.ResourceData, globalMetricName string) []map[st
 			"period":              condition["period"],
 			"filter":              condition["filter"],
 			"comparison_operator": condition["comparison_operator"],
-			"value":               utils.ValueIgnoreEmpty(condition["value"]),
+			"value":               condition["value"],
 			"unit":                utils.ValueIgnoreEmpty(condition["unit"]),
 			"count":               condition["count"],
-			"suppress_duration":   utils.ValueIgnoreEmpty(condition["suppress_duration"]),
+			"suppress_duration":   condition["suppress_duration"],
 		}
 
 		if condition["metric_name"].(string) != "" {
@@ -835,10 +835,10 @@ func buildUpdatePoliciesOptsWithAlarmLevel(d *schema.ResourceData, level int, me
 			"period":              condition["period"],
 			"filter":              condition["filter"],
 			"comparison_operator": condition["comparison_operator"],
-			"value":               utils.ValueIgnoreEmpty(condition["value"]),
+			"value":               condition["value"],
 			"unit":                utils.ValueIgnoreEmpty(condition["unit"]),
 			"count":               condition["count"],
-			"suppress_duration":   utils.ValueIgnoreEmpty(condition["suppress_duration"]),
+			"suppress_duration":   condition["suppress_duration"],
 			"level":               level,
 		}
 
@@ -868,10 +868,10 @@ func buildUpdatePoliciesOptsWithMetricName(d *schema.ResourceData, level int, me
 			"period":              condition["period"],
 			"filter":              condition["filter"],
 			"comparison_operator": condition["comparison_operator"],
-			"value":               utils.ValueIgnoreEmpty(condition["value"]),
+			"value":               condition["value"],
 			"unit":                utils.ValueIgnoreEmpty(condition["unit"]),
 			"count":               condition["count"],
-			"suppress_duration":   utils.ValueIgnoreEmpty(condition["suppress_duration"]),
+			"suppress_duration":   condition["suppress_duration"],
 			"metric_name":         metricName,
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Restore the logic which part of parameters support default value.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
Restore the logic which part of parameters support default value in CES alarm rule resource.
1.Create:
<img width="622" height="725" alt="s1" src="https://github.com/user-attachments/assets/942940c6-e9e5-4201-aa22-8cdf26941017" />
<img width="1137" height="801" alt="s2" src="https://github.com/user-attachments/assets/38ad2aa6-4d65-4788-9f74-27ae41e6d7c1" />
2.Update:
<img width="540" height="715" alt="s3" src="https://github.com/user-attachments/assets/6ab5cf22-ea1b-42c7-aaa5-836254c8cd0b" />
<img width="1433" height="531" alt="s4" src="https://github.com/user-attachments/assets/6d26ef93-ed7a-4f5c-9a81-4941633c099c" />

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o ces -f TestAccCESAlarmRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ces" -v -coverprofile="./huaweicloud/services/acceptance/ces/ces_coverage.cov" -coverpkg="./huaweicloud/services/ces" -run TestAccCESAlarmRule_basic -timeout 360m -parallel 10
=== RUN   TestAccCESAlarmRule_basic
=== PAUSE TestAccCESAlarmRule_basic
=== CONT  TestAccCESAlarmRule_basic
--- PASS: TestAccCESAlarmRule_basic (186.27s)
PASS
coverage: 14.8% of statements in ./huaweicloud/services/ces
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       187.818s        coverage: 14.8% of statements in ./huaweicloud/services/ces
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
