### PR TITLE
fix(CCE-AutoPilot): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/docs/resources/cce_autopilot_addon.md
+++ b/docs/resources/cce_autopilot_addon.md
@@ -70,6 +70,7 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
 * `delete` - Default is 30 minutes.
 
 ## Import

--- a/docs/resources/cce_autopilot_release.md
+++ b/docs/resources/cce_autopilot_release.md
@@ -116,6 +116,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The update time.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.
+* `update` - Default is 60 minutes.
+* `delete` - Default is 30 minutes.
+
 ## Import
 
 CCE Autopilot release can be imported using the `cluster_id`, `namespace` and `chart_name`, e.g.:
@@ -128,7 +136,7 @@ Note that the imported state may not be identical to your resource definition, d
 API response, security or some other reason. The missing attributes include:
 `version`, `values`, `chart_id`, `description`, `parameters` and `action`. It is generally recommended running
 `terraform plan` after importing an CCE Autopilot release. You can then decide if changes should be applied to the release,
-or the resource definition should be updated to align with the release. Also you can ignore changes as below.
+or the resource definition should be updated to align with the release. You can also ignore changes as below.
 
 ```hcl
 resource "huaweicloud_cce_autopilot_release" "test" {

--- a/docs/resources/cce_release.md
+++ b/docs/resources/cce_release.md
@@ -115,6 +115,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The update time.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.
+* `update` - Default is 60 minutes.
+* `delete` - Default is 30 minutes.
+
 ## Import
 
 CCE release can be imported using the `cluster_id`, `namespace` and `chart_name`, e.g.:
@@ -127,7 +135,7 @@ Note that the imported state may not be identical to your resource definition, d
 API response, security or some other reason. The missing attributes include:
 `version`, `values_json`, `chart_id`, `description`, `parameters` and `action`. It is generally recommended running
 `terraform plan` after importing an CCE release. You can then decide if changes should be applied to the release,
-or the resource definition should be updated to align with the release. Also you can ignore changes as below.
+or the resource definition should be updated to align with the release. You can also ignore changes as below.
 
 ```hcl
 resource "huaweicloud_cce_release" "test" {
@@ -135,7 +143,7 @@ resource "huaweicloud_cce_release" "test" {
 
   lifecycle {
     ignore_changes = [
-      version, values, chart_id, description, parameters, action,
+      version, values_json, chart_id, description, parameters,action,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_release_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_release_test.go
@@ -73,7 +73,7 @@ func TestAccRelease_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "chart_id", "huaweicloud_cce_chart.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "namespace", "default"),
-					resource.TestCheckResourceAttr(resourceName, "version", "4.9.0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.0.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "chart_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "chart_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_name"),
@@ -81,6 +81,14 @@ func TestAccRelease_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "status_description"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttr(resourceName, "release_version", "1"),
+				),
+			},
+			{
+				Config: testAccRelease_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "release_version", "2"),
 				),
 			},
 			{
@@ -89,7 +97,7 @@ func TestAccRelease_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccCCEReleaseImportStateIdFunc("default", name),
 				ImportStateVerifyIgnore: []string{
-					"version", "values_json", "chart_id", "description", "parameters",
+					"action", "version", "values_json", "chart_id", "description", "parameters",
 				},
 			},
 		},
@@ -120,19 +128,12 @@ resource "huaweicloud_cce_release" "test" {
   chart_id   = huaweicloud_cce_chart.test.id
   name       = "%[3]s"
   namespace  = "default"
-  version    = "4.9.0"
+  version    = "1.0.0"
 
   values_json = jsonencode({
-    "key1" : ["value1"]
-    "key2" : "value2"
-    "key3" : "value3"
-    "key4" : {
-      "key1" : "value1",
-      "key2" : "value2",
-      "key3" : {
-         "sub_key1" : "sub_value1",
-         "sub_key2" : "sub_value2"
-      }
+    "image" : {
+      "repository" : "redis",
+      "tag"        : "5.0"
     }
   })
 
@@ -142,5 +143,74 @@ resource "huaweicloud_cce_release" "test" {
     dry_run = false
   }
 }
-`, testAccCluster_basic(name), testAccChart_basic(), name)
+`, testAccRelease_base(name), testAccChart_basic(), name)
+}
+
+func testAccRelease_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  key_pair          = huaweicloud_kps_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+    extend_params = {
+      test_key = "test_val"
+    }
+  }
+
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+    extend_params = {
+      test_key = "test_val"
+    }
+  }
+
+  extend_params {
+    docker_base_size = 20
+    postinstall      = <<EOF
+#! /bin/bash
+date
+EOF
+  }
+}
+`, testAccNode_Base(rName), rName)
+}
+
+func testAccRelease_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_cce_release" "test" {
+  cluster_id = huaweicloud_cce_cluster.test.id
+  chart_id   = huaweicloud_cce_chart.test.id
+  name       = "%[3]s"
+  namespace  = "default"
+  version    = "1.0.0"
+
+  values_json = jsonencode({
+    "image" : {
+      "repository" : "redis",
+      "tag"        : "5.0.6"
+    }
+  })
+
+  description = "created by terraform"
+
+  action = "upgrade"
+
+  parameters {
+    dry_run = false
+  }
+}
+`, testAccRelease_base(name), testAccChart_basic(), name)
 }

--- a/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_addon_test.go
+++ b/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_addon_test.go
@@ -46,6 +46,7 @@ func TestAccAutopilotAddon_basic(t *testing.T) {
 	var (
 		cluster      interface{}
 		resourceName = "huaweicloud_cce_autopilot_addon.test"
+		rName        = acceptance.RandomAccResourceNameWithDash()
 
 		rc = acceptance.InitResourceCheck(
 			resourceName,
@@ -57,26 +58,33 @@ func TestAccAutopilotAddon_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckProjectID(t)
-			acceptance.TestAccPreCheckHSSCCEProtection(t)
-			acceptance.TestAccPreCheckCertificateBase(t)
-			acceptance.TestAccPreCheckCertificateRootCA(t)
-			acceptance.TestAccPreCheckSWRUser(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAddon_basic(),
+				Config: testAccAutopilotAddon_basic(rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_id",
 						"huaweicloud_cce_autopilot_cluster.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "addon_template_name", "log-agent"),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.4.3"),
-					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccAutopilotAddon_update(rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_id",
+						"huaweicloud_cce_autopilot_cluster.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "addon_template_name", "log-agent"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 				),
 			},
 			{
@@ -89,65 +97,95 @@ func TestAccAutopilotAddon_basic(t *testing.T) {
 	})
 }
 
-// nolint:revive
-func testAccAddon_basic() string {
+// testAccAutopilotAddon_base builds the shared infrastructure for addon tests:
+//   - A CCE Autopilot cluster (provides cluster_id, cluster_name, cluster_version)
+//   - An SWR organization (provides swr_user, which equals the organization name)
+//
+// The region is derived from the provider configuration.
+// The enterprise project ID (epsId) is passed via environment variable HW_ENTERPRISE_PROJECT_ID_TEST.
+func testAccAutopilotAddon_base(rName, epsId string) string {
 	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_swr_organization" "test" {
+  name = "%[2]s"
+}
+
+locals {
+  # The SWR user equals the organization name, as the creator of the organization is the SWR user.
+  swr_user = huaweicloud_swr_organization.test.name
+
+  # The enterprise project ID used for LTS log reporting.
+  eps_id = "%[3]s"
+
+  # The cluster ID and name are derived from the CCE Autopilot cluster resource.
+  region_name     = huaweicloud_cce_autopilot_cluster.test.region
+  cluster_id      = huaweicloud_cce_autopilot_cluster.test.id
+  cluster_name    = huaweicloud_cce_autopilot_cluster.test.name
+  cluster_version = huaweicloud_cce_autopilot_cluster.test.version
+}
+`, testAccCluster_basic(rName), rName, epsId)
+}
+
+func testAccAutopilotAddon_basic(rName, epsId string) string {
+	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_cce_autopilot_addon" "test" {
-  cluster_id          = huaweicloud_cce_autopilot_cluster.test.id
-  version             = "1.4.3"
+  cluster_id          = local.cluster_id
   addon_template_name = "log-agent"
 
   values = {
     "basic" = jsonencode({
-      "aomEndpoint" : "https://aom.cn-north-4.myhuaweicloud.com",
-      "iam_url" : "iam.cn-north-4.myhuaweicloud.com",
-      "ltsAccessEndpoint" : "https://lts-access.cn-north-4.myhuaweicloud.com:8102",
-      "ltsEndpoint" : "https://lts.cn-north-4.myhuaweicloud.com",
-      "region" : "cn-north-4",
-      "swr_addr" : "swr.cn-north-4.myhuaweicloud.com",
-      "swr_user" : "%s",
+      "aomEndpoint" : "https://aom.${local.region_name}.myhuaweicloud.com",
+      "iam_url" : "iam.${local.region_name}.myhuaweicloud.com",
+      "ltsAccessEndpoint" : "https://lts-access.${local.region_name}.myhuaweicloud.com:8102",
+      "ltsEndpoint" : "https://lts.${local.region_name}.myhuaweicloud.com",
+      "region" : local.region_name,
+      "swr_addr" : "swr.${local.region_name}.myhuaweicloud.com",
+      "swr_user" : local.swr_user,
       "rbac_enabled" : true,
-      "cluster_version" : "v1.28"
+      "cluster_version" : local.cluster_version
     })
 
     "flavor" = jsonencode({
       "category" : [
         "Autopilot"
       ],
-      "description" : "Recommanded when the number of logs per second does not exceed 5000.",
+      "description" : "Applicable to clusters where the logs of a single pod are less than 10000/s or 5 MB/s.",
       "is_default" : true,
-      "name" : "Autopilot-Low",
-      "replicas" : 2,
+      "name" : "custom-resources",
       "resources" : [
         {
           "name" : "log-operator",
-          "limitsCpu" : "1000m",
-          "requestsCpu" : "1000m",
+          "limitsCpu" : "500m",
+          "requestsCpu" : "500m",
+          "replicas" : 2,
           "limitsMem" : "2048Mi",
           "requestsMem" : "2048Mi"
         },
         {
-          "name" : "otel-collector",
-          "limitsCpu" : "2000m",
-          "requestsCpu" : "2000m",
-          "limitsMem" : "4096Mi",
-          "requestsMem" : "4096Mi"
-        },
-        {
-          "name" : "fluent-bit",
-          "limitsMem" : "400Mi",
-          "requestsMem" : "50Mi"
+          "name" : "otel-collector-event",
+          "limitsCpu" : "500m",
+          "requestsCpu" : "500m",
+          "replicas" : 2,
+          "limitsMem" : "2048Mi",
+          "requestsMem" : "2048Mi"
         }
-      ]
+      ],
+      "size" : "custom"
     })
 
     "custom" = jsonencode({
       "accessKey" : "",
-      "aomEndpoint" : "https://aom.cn-north-4.myhuaweicloud.com",
+      "agency_name" : "",
+      "aomEndpoint" : "https://aom.${local.region_name}.myhuaweicloud.com",
       "aomPrivateEndpointIP" : "",
-      "caCert" : "%s",
-      "clusterID" : "%s",
-      "clusterName" : "%s",
+      "bufferChunkSize" : "128k",
+      "bufferMaxSize" : "512k",
+      "caCert" : "",
+      "clusterID" : local.cluster_id,
+      "clusterName" : local.cluster_name,
       "cluster_category" : "CCE",
       "createAudit" : false,
       "createDefaultEvent" : false,
@@ -156,10 +194,17 @@ resource "huaweicloud_cce_autopilot_addon" "test" {
       "createKubeApiserver" : false,
       "createKubeControllerManager" : false,
       "createKubeScheduler" : false,
-      "enable_autopilot" : true,
-      "ltsAccessEndpoint" : "https://lts-access.cn-north-4.myhuaweicloud.com:8102",
+      "enableEventReport" : true,
+      "enableFullPathCollection" : false,
+      "enableGcrypto" : true,
+      "enableLogOperatorHA" : true,
+      "enableLogReport" : true,
+      "featureGates" : ["sendAOMAllEvent", "outputKafka", "podLabelExclude", "fullPathCollection", "independentEvents"],
+      "host_network" : false,
+      "ltsAccessEndpoint" : "https://lts-access.${local.region_name}.myhuaweicloud.com:8102",
       "ltsAuditStreamID" : "",
-      "ltsEndpoint" : "https://lts.cn-north-4.myhuaweicloud.com",
+      "ltsEndpoint" : "https://lts.${local.region_name}.myhuaweicloud.com",
+      "ltsEnterpriseProjectID" : local.eps_id,
       "ltsEventStreamID" : "",
       "ltsGroupID" : "",
       "ltsKubeApiserverStreamID" : "",
@@ -168,15 +213,125 @@ resource "huaweicloud_cce_autopilot_addon" "test" {
       "ltsLogReportDomain" : "",
       "ltsPrivateEndpointIP" : "",
       "ltsStdoutStreamID" : "",
+      "maxEventAgeSeconds" : "",
+      "memBufLimit" : "40mb",
       "multiAZEnabled" : false,
+      "otelReportLogs" : true,
       "paasakskEnable" : true,
-      "projectID" : "%s",
+      "podDisruptionBudget" : {"create" : true, "maxUnavailable" : 1},
+      "projectID" : "",
       "secretKey" : "",
       "securityToken" : "",
-      "serverCert" : "%s",
-      "serverKey" : "%s"
+      "serverCert" : "",
+      "serverKey" : ""
     })
   }
 }
-`, acceptance.HW_SWR_USER, acceptance.HW_CERTIFICATE_ROOT_CA, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME, acceptance.HW_PROJECT_ID, acceptance.HW_CERTIFICATE_CONTENT, acceptance.HW_CERTIFICATE_PRIVATE_KEY)
+`, testAccAutopilotAddon_base(rName, epsId))
+}
+
+// testAccAutopilotAddon_update changes the log-agent configuration to test the Update flow.
+// The key change is enabling the audit log creation (createAudit: true) and
+// disabling the default event to AOM (createDefaultEventToAOM: false).
+func testAccAutopilotAddon_update(rName, epsId string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cce_autopilot_addon" "test" {
+  cluster_id          = local.cluster_id
+  addon_template_name = "log-agent"
+
+  values = {
+    "basic" = jsonencode({
+      "aomEndpoint" : "https://aom.${local.region_name}.myhuaweicloud.com",
+      "iam_url" : "iam.${local.region_name}.myhuaweicloud.com",
+      "ltsAccessEndpoint" : "https://lts-access.${local.region_name}.myhuaweicloud.com:8102",
+      "ltsEndpoint" : "https://lts.${local.region_name}.myhuaweicloud.com",
+      "region" : local.region_name,
+      "swr_addr" : "swr.${local.region_name}.myhuaweicloud.com",
+      "swr_user" : local.swr_user,
+      "rbac_enabled" : true,
+      "cluster_version" : local.cluster_version
+    })
+
+    "flavor" = jsonencode({
+      "category" : [
+        "Autopilot"
+      ],
+      "description" : "Applicable to clusters where the logs of a single pod are less than 10000/s or 5 MB/s.",
+      "is_default" : true,
+      "name" : "custom-resources",
+      "resources" : [
+        {
+          "name" : "log-operator",
+          "limitsCpu" : "1000m",
+          "requestsCpu" : "1000m",
+          "replicas" : 3,
+          "limitsMem" : "2048Mi",
+          "requestsMem" : "2048Mi"
+        },
+        {
+          "name" : "otel-collector-event",
+          "limitsCpu" : "1000m",
+          "requestsCpu" : "1000m",
+          "replicas" : 3,
+          "limitsMem" : "2048Mi",
+          "requestsMem" : "2048Mi"
+        }
+      ],
+      "size" : "custom"
+    })
+
+    "custom" = jsonencode({
+      "accessKey" : "",
+      "agency_name" : "",
+      "aomEndpoint" : "https://aom.${local.region_name}.myhuaweicloud.com",
+      "aomPrivateEndpointIP" : "",
+      "bufferChunkSize" : "128k",
+      "bufferMaxSize" : "512k",
+      "caCert" : "",
+      "clusterID" : local.cluster_id,
+      "clusterName" : local.cluster_name,
+      "cluster_category" : "CCE",
+      "createAudit" : true,
+      "createDefaultEvent" : false,
+      "createDefaultEventToAOM" : false,
+      "createDefaultStdout" : false,
+      "createKubeApiserver" : false,
+      "createKubeControllerManager" : false,
+      "createKubeScheduler" : false,
+      "enableEventReport" : true,
+      "enableFullPathCollection" : false,
+      "enableGcrypto" : true,
+      "enableLogOperatorHA" : true,
+      "enableLogReport" : true,
+      "featureGates" : ["sendAOMAllEvent", "outputKafka", "podLabelExclude", "fullPathCollection", "independentEvents"],
+      "host_network" : false,
+      "ltsAccessEndpoint" : "https://lts-access.${local.region_name}.myhuaweicloud.com:8102",
+      "ltsAuditStreamID" : "",
+      "ltsEndpoint" : "https://lts.${local.region_name}.myhuaweicloud.com",
+      "ltsEnterpriseProjectID" : local.eps_id,
+      "ltsEventStreamID" : "",
+      "ltsGroupID" : "",
+      "ltsKubeApiserverStreamID" : "",
+      "ltsKubeControllerManagerStreamID" : "",
+      "ltsKubeSchedulerStreamID" : "",
+      "ltsLogReportDomain" : "",
+      "ltsPrivateEndpointIP" : "",
+      "ltsStdoutStreamID" : "",
+      "maxEventAgeSeconds" : "",
+      "memBufLimit" : "40mb",
+      "multiAZEnabled" : false,
+      "otelReportLogs" : true,
+      "paasakskEnable" : true,
+      "podDisruptionBudget" : {"create" : true, "maxUnavailable" : 1},
+      "projectID" : "",
+      "secretKey" : "",
+      "securityToken" : "",
+      "serverCert" : "",
+      "serverKey" : ""
+    })
+  }
+}
+`, testAccAutopilotAddon_base(rName, epsId))
 }

--- a/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_release_test.go
+++ b/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_release_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -75,14 +76,28 @@ func TestAccAutopilotRelease_basic(t *testing.T) {
 						"huaweicloud_cce_autopilot_chart.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "namespace", "default"),
-					resource.TestCheckResourceAttr(resourceName, "version", "4.9.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "chart_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "chart_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DEPLOYED"),
 					resource.TestCheckResourceAttrSet(resourceName, "status_description"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttr(resourceName, "release_version", "1"),
+				),
+			},
+			{
+				Config: testAccAutopilotRelease_upgrade(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "release_version", "2"),
+				),
+			},
+			{
+				Config: testAccAutopilotRelease_rollback(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "release_version", "3"),
 				),
 			},
 			{
@@ -91,7 +106,7 @@ func TestAccAutopilotRelease_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccCCEAutopilotReleaseImportStateIdFunc("default", name),
 				ImportStateVerifyIgnore: []string{
-					"version", "values", "chart_id", "description", "parameters",
+					"action", "version", "values", "chart_id", "description", "parameters",
 				},
 			},
 		},
@@ -122,11 +137,11 @@ resource "huaweicloud_cce_autopilot_release" "test" {
   chart_id   = huaweicloud_cce_autopilot_chart.test.id
   name       = "%[3]s"
   namespace  = "default"
-  version    = "4.9.0"
+  version    = "1.0.0"
 
   values {
-    image_tag         = "v1"
     image_pull_policy = "IfNotPresent"
+    image_tag         = "5.0"
   }
 
   description = "created by terraform"
@@ -135,5 +150,100 @@ resource "huaweicloud_cce_autopilot_release" "test" {
     dry_run = false
   }
 }
-`, testAccCluster_basic(name), testAccAutopilotChart_basic(), name)
+`, testAccAutopilotRelease_base(name), testAccAutopilotChart_basic(), name)
+}
+
+func testAccAutopilotRelease_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cce_autopilot_cluster" "test" {
+  name        = "%[2]s"
+  flavor      = "cce.autopilot.cluster"
+  description = "created by terraform"
+
+  host_network {
+    vpc    = huaweicloud_vpc.test.id
+    subnet = huaweicloud_vpc_subnet.test.id
+  }
+
+  container_network {
+    mode = "eni"
+  }
+
+  eni_network {
+    subnets {
+      subnet_id = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+    }
+  }
+
+  # for pull image from SWR
+  enable_swr_image_access = true
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+`, common.TestVpc(rName), rName)
+}
+
+func testAccAutopilotRelease_upgrade(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_cce_autopilot_release" "test" {
+  cluster_id = huaweicloud_cce_autopilot_cluster.test.id
+  chart_id   = huaweicloud_cce_autopilot_chart.test.id
+  name       = "%[3]s"
+  namespace  = "default"
+  version    = "1.0.0"
+
+  values {
+    image_pull_policy = "IfNotPresent"
+    image_tag         = "5.0.6"
+  }
+
+  description = "created by terraform"
+
+  action = "upgrade"
+
+  parameters {
+    dry_run = false
+  }
+}
+`, testAccAutopilotRelease_base(name), testAccAutopilotChart_basic(), name)
+}
+
+func testAccAutopilotRelease_rollback(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_cce_autopilot_release" "test" {
+  cluster_id = huaweicloud_cce_autopilot_cluster.test.id
+  chart_id   = huaweicloud_cce_autopilot_chart.test.id
+  name       = "%[3]s"
+  namespace  = "default"
+  version    = "1.0.0"
+
+  values {
+    image_pull_policy = "IfNotPresent"
+    image_tag         = "5.0.6"
+  }
+
+  description = "created by terraform"
+
+  action = "rollback"
+
+  parameters {
+    dry_run         = false
+    release_version = 1
+  }
+}
+`, testAccAutopilotRelease_base(name), testAccAutopilotChart_basic(), name)
 }

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_release.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_release.go
@@ -3,10 +3,14 @@ package cce
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -36,6 +40,12 @@ func ResourceRelease() *schema.Resource {
 		},
 
 		CustomizeDiff: config.FlexibleForceNew(releaseNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -171,6 +181,10 @@ func ResourceRelease() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"release_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -232,17 +246,12 @@ func buildReleaseParametersParams(d *schema.ResourceData) map[string]interface{}
 func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		createReleaseHttpUrl = "cce/cam/v3/clusters/{cluster_id}/releases"
-		createReleaseProduct = "cce"
-	)
-	createReleaseClient, err := cfg.NewServiceClient(createReleaseProduct, region)
+	createReleaseClient, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	createReleasePath := createReleaseClient.Endpoint + createReleaseHttpUrl
+	createReleasePath := createReleaseClient.Endpoint + "cce/cam/v3/clusters/{cluster_id}/releases"
 	createReleasePath = strings.ReplaceAll(createReleasePath, "{cluster_id}", d.Get("cluster_id").(string))
 
 	createReleaseOpt := golangsdk.RequestOpts{
@@ -264,61 +273,67 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	d.SetId(d.Get("name").(string))
 
+	err = waitingForReleaseJobCompleted(ctx, createReleaseClient, d, d.Timeout(schema.TimeoutCreate), []string{"DEPLOYED"})
+	if err != nil {
+		return diag.Errorf("error creating CCE release: %s", err)
+	}
+
 	return resourceReleaseRead(ctx, d, meta)
 }
 
 func resourceReleaseRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		getReleaseHttpUrl = "cce/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
-		getReleaseProduct = "cce"
-	)
-	getReleaseClient, err := cfg.NewServiceClient(getReleaseProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE client: %s", err)
 	}
 
-	getReleaseHttpPath := getReleaseClient.Endpoint + getReleaseHttpUrl
-	getReleaseHttpPath = strings.ReplaceAll(getReleaseHttpPath, "{cluster_id}", d.Get("cluster_id").(string))
-	getReleaseHttpPath = strings.ReplaceAll(getReleaseHttpPath, "{namespace}", d.Get("namespace").(string))
-	getReleaseHttpPath = strings.ReplaceAll(getReleaseHttpPath, "{name}", d.Id())
+	getRespBody, err := getCceReleaseDetails(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CCE release")
+	}
 
-	getReleaseOpt := golangsdk.RequestOpts{
+	// values, chart_id, description, parameters, action these set by user are not returned in GET API
+	// version returned in the response is the version of release
+	mErr := multierror.Append(nil,
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("cluster_id", utils.PathSearch("cluster_id", getRespBody, nil)),
+		d.Set("name", utils.PathSearch("name", getRespBody, nil)),
+		d.Set("namespace", utils.PathSearch("namespace", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("status", getRespBody, nil)),
+		d.Set("status_description", utils.PathSearch("status_description", getRespBody, nil)),
+		d.Set("cluster_name", utils.PathSearch("cluster_name", getRespBody, nil)),
+		d.Set("chart_name", utils.PathSearch("chart_name", getRespBody, nil)),
+		d.Set("chart_public", utils.PathSearch("chart_public", getRespBody, nil)),
+		d.Set("chart_version", utils.PathSearch("chart_version", getRespBody, nil)),
+		d.Set("release_version", utils.PathSearch("version", getRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("create_at", getRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("update_at", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getCceReleaseDetails(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getPath := client.Endpoint + "cce/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{namespace}", d.Get("namespace").(string))
+	getPath = strings.ReplaceAll(getPath, "{name}", d.Id())
+
+	getOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders: map[string]string{
 			"Content-Type": "application/json",
 		},
 	}
 
-	getReleaseResp, err := getReleaseClient.Request("GET", getReleaseHttpPath, &getReleaseOpt)
+	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving CCE release")
+		return nil, err
 	}
 
-	getReleaseRespBody, err := utils.FlattenResponse(getReleaseResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	// version, values, chart_id, description, parameters, action are not returned in GET API
-	mErr := multierror.Append(nil,
-		d.Set("region", cfg.GetRegion(d)),
-		d.Set("cluster_id", utils.PathSearch("cluster_id", getReleaseRespBody, nil)),
-		d.Set("name", utils.PathSearch("name", getReleaseRespBody, nil)),
-		d.Set("namespace", utils.PathSearch("namespace", getReleaseRespBody, nil)),
-		d.Set("status", utils.PathSearch("status", getReleaseRespBody, nil)),
-		d.Set("status_description", utils.PathSearch("status_description", getReleaseRespBody, nil)),
-		d.Set("cluster_name", utils.PathSearch("cluster_name", getReleaseRespBody, nil)),
-		d.Set("chart_name", utils.PathSearch("chart_name", getReleaseRespBody, nil)),
-		d.Set("chart_public", utils.PathSearch("chart_public", getReleaseRespBody, nil)),
-		d.Set("chart_version", utils.PathSearch("chart_version", getReleaseRespBody, nil)),
-		d.Set("created_at", utils.PathSearch("create_at", getReleaseRespBody, nil)),
-		d.Set("updated_at", utils.PathSearch("update_at", getReleaseRespBody, nil)),
-	)
-
-	return diag.FromErr(mErr.ErrorOrNil())
+	return utils.FlattenResponse(getResp)
 }
 
 func buildUpdateReleaseBodyParams(d *schema.ResourceData) (map[string]interface{}, error) {
@@ -342,32 +357,54 @@ func buildUpdateReleaseBodyParams(d *schema.ResourceData) (map[string]interface{
 func resourceReleaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		updateReleaseHttpUrl = "cce/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
-		updateReleaseProduct = "cce"
-	)
-	updateReleaseClient, err := cfg.NewServiceClient(updateReleaseProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
 	if d.HasChangeExcept("enable_force_new") {
-		updateReleasePath := updateReleaseClient.Endpoint + updateReleaseHttpUrl
-		updateReleasePath = strings.ReplaceAll(updateReleasePath, "{cluster_id}", d.Get("cluster_id").(string))
-		updateReleasePath = strings.ReplaceAll(updateReleasePath, "{namespace}", d.Get("namespace").(string))
-		updateReleasePath = strings.ReplaceAll(updateReleasePath, "{name}", d.Id())
-
-		updateReleaseOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-		}
+		updatePath := client.Endpoint + "cce/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
+		updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", d.Get("cluster_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{namespace}", d.Get("namespace").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{name}", d.Id())
 
 		bodyParams, err := buildUpdateReleaseBodyParams(d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		updateReleaseOpt.JSONBody = utils.RemoveNil(bodyParams)
-		_, err = updateReleaseClient.Request("PUT", updateReleasePath, &updateReleaseOpt)
+
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(bodyParams),
+		}
+
+		retryFunc := func() (interface{}, bool, error) {
+			res, err := client.Request("PUT", updatePath, &updateOpt)
+			if err == nil {
+				return res, false, nil
+			}
+			shouldRetry := strings.Contains(err.Error(), "Update release is forbidden")
+			return nil, shouldRetry, err
+		}
+
+		_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     refreshReleaseStatus(client, d, []string{"DEPLOYED"}),
+			WaitTarget:   []string{"COMPLETED"},
+			WaitPending:  []string{"PENDING"},
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			DelayTimeout: 10 * time.Second,
+			PollInterval: 5 * time.Second,
+		})
+		if err != nil {
+			return diag.Errorf("error updating CCE release: %s", err)
+		}
+
+		err = waitingForReleaseJobCompleted(ctx, client, d, d.Timeout(schema.TimeoutUpdate), []string{"DEPLOYED"})
 		if err != nil {
 			return diag.Errorf("error updating CCE release: %s", err)
 		}
@@ -376,31 +413,42 @@ func resourceReleaseUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return resourceReleaseRead(ctx, d, meta)
 }
 
-func resourceReleaseDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReleaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		deleteReleaseHttpUrl = "cce/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
-		deleteReleaseProduct = "cce"
-	)
-	deleteReleaseClient, err := cfg.NewServiceClient(deleteReleaseProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE client: %s", err)
 	}
 
-	deleteReleaseHttpPath := deleteReleaseClient.Endpoint + deleteReleaseHttpUrl
-	deleteReleaseHttpPath = strings.ReplaceAll(deleteReleaseHttpPath, "{cluster_id}", d.Get("cluster_id").(string))
-	deleteReleaseHttpPath = strings.ReplaceAll(deleteReleaseHttpPath, "{namespace}", d.Get("namespace").(string))
-	deleteReleaseHttpPath = strings.ReplaceAll(deleteReleaseHttpPath, "{name}", d.Id())
+	deletePath := client.Endpoint + "cce/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", d.Get("cluster_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{namespace}", d.Get("namespace").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{name}", d.Id())
 
 	deleteReleaseOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
-	_, err = deleteReleaseClient.Request("DELETE", deleteReleaseHttpPath, &deleteReleaseOpt)
+	_, err = client.Request("DELETE", deletePath, &deleteReleaseOpt)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error deleting CCE release")
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"DELETED"},
+		Refresh:      refreshReleaseStatus(client, d, []string{"DELETED"}),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error deleting CCE release: %s", err)
 	}
 
 	return nil
@@ -418,9 +466,59 @@ func resourceReleaseImport(_ context.Context, d *schema.ResourceData, _ interfac
 	name := parts[2]
 
 	d.SetId(name)
-	d.Set("name", name)
-	d.Set("cluster_id", clusterID)
-	d.Set("namespace", namespace)
 
-	return []*schema.ResourceData{d}, nil
+	mErr := multierror.Append(nil,
+		d.Set("cluster_id", clusterID),
+		d.Set("namespace", namespace),
+		d.Set("name", name),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}
+
+func waitingForReleaseJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	t time.Duration, targets []string) error {
+	stateConf := &retry.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshReleaseStatus(client, d, targets),
+		Timeout:      t,
+		Delay:        10 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshReleaseStatus(client *golangsdk.ServiceClient, d *schema.ResourceData, targets []string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Expect the status of CCE release to be any one of the status list: %v.", targets)
+		releaseRespBody, err := getCceReleaseDetails(client, d)
+		if err != nil {
+			var errDefault404 golangsdk.ErrDefault404
+			if errors.As(err, &errDefault404) {
+				return "Resource Not Found", "DELETED", nil
+			}
+			return nil, "ERROR", fmt.Errorf("error retrieving CCE release: %s", err)
+		}
+
+		status := utils.PathSearch("status", releaseRespBody, nil)
+		if status == nil {
+			return nil, "ERROR", fmt.Errorf("error parsing status from response body")
+		}
+
+		statusStr := status.(string)
+		invalidStatuses := []string{"FAILED", "UNKNOWN"}
+		if utils.IsStrContainsSliceElement(statusStr, invalidStatuses, true, true) {
+			if statusStr == "UNKNOWN" {
+				return nil, "ERROR", fmt.Errorf("the release status is unknown, please try to delete and reinstall manually")
+			}
+			return nil, "ERROR", fmt.Errorf("the release job failed, status: %s", statusStr)
+		}
+
+		if utils.StrSliceContains(targets, statusStr) {
+			return releaseRespBody, "COMPLETED", nil
+		}
+		return releaseRespBody, "PENDING", nil
+	}
 }

--- a/huaweicloud/services/cceautopilot/resource_huaweicloud_cce_autopilot_addon.go
+++ b/huaweicloud/services/cceautopilot/resource_huaweicloud_cce_autopilot_addon.go
@@ -3,7 +3,9 @@ package cceautopilot
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -40,6 +42,7 @@ func ResourceAutopilotAddon() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -162,44 +165,41 @@ func buildAddonValuesBodyParams(d *schema.ResourceData) (map[string]interface{},
 func resourceAutopilotAddonCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		createAddonHttpUrl = "autopilot/v3/addons"
-		createAddonProduct = "cce"
-	)
-	createAddonClient, err := cfg.NewServiceClient(createAddonProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	createAddonPath := createAddonClient.Endpoint + createAddonHttpUrl
-
+	createPath := client.Endpoint + "autopilot/v3/addons"
+	createParams, err := buildCreateAddonBodyParams(d)
+	if err != nil {
+		return diag.Errorf("error building create options of CCE autopilot addon: %s", err)
+	}
 	createAddonOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(createParams),
 	}
 
-	createOpts, err := buildCreateAddonBodyParams(d)
+	createAddonResp, err := client.Request("POST", createPath, &createAddonOpt)
 	if err != nil {
-		return diag.Errorf("error building create options of CCE autopolit addon: %s", err)
-	}
-	createAddonOpt.JSONBody = utils.RemoveNil(createOpts)
-	createAddonResp, err := createAddonClient.Request("POST", createAddonPath, &createAddonOpt)
-	if err != nil {
-		return diag.Errorf("error creating CCE autopolit add-on: %s", err)
+		return diag.Errorf("error creating CCE autopilot add-on: %s", err)
 	}
 
-	createAddonRespBody, err := utils.FlattenResponse(createAddonResp)
+	createRespBody, err := utils.FlattenResponse(createAddonResp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	id := utils.PathSearch("metadata.uid", createAddonRespBody, "").(string)
+	id := utils.PathSearch("metadata.uid", createRespBody, "").(string)
 	if id == "" {
 		return diag.Errorf("error creating CCE autopilot add-on: ID is not found in API response")
 	}
 	d.SetId(id)
 
-	err = addonWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
+	err = waitingForAddonJobCompleted(ctx, client, d, d.Timeout(schema.TimeoutCreate), []string{"running", "available"})
 	if err != nil {
 		return diag.Errorf("error waiting for creating CCE autopilot add-on (%s) to complete: %s", id, err)
 	}
@@ -211,30 +211,14 @@ func resourceAutopilotAddonRead(_ context.Context, d *schema.ResourceData, meta 
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
-	var (
-		getAddonHttpUrl = "autopilot/v3/addons/{id}"
-		getAddonProduct = "cce"
-	)
-	getAddonClient, err := cfg.NewServiceClient(getAddonProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	getAddonPath := getAddonClient.Endpoint + getAddonHttpUrl
-	getAddonPath = strings.ReplaceAll(getAddonPath, "{id}", d.Id())
-
-	getAddonOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	getAddonResp, err := getAddonClient.Request("GET", getAddonPath, &getAddonOpt)
+	getAddonRespBody, err := getAutopilotAddon(client, d)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving CCE autopolit add-on")
-	}
-
-	getAddonRespBody, err := utils.FlattenResponse(getAddonResp)
-	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error retrieving CCE autopilot add-on")
 	}
 
 	// values not set, because the response if different from the user input
@@ -251,6 +235,25 @@ func resourceAutopilotAddonRead(_ context.Context, d *schema.ResourceData, meta 
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getAutopilotAddon(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getPath := client.Endpoint + "autopilot/v3/addons/{id}"
+	getPath = strings.ReplaceAll(getPath, "{id}", d.Id())
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	getAddonResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getAddonResp)
 }
 
 func buildUpdateAddonBodyParams(d *schema.ResourceData) (map[string]interface{}, error) {
@@ -290,26 +293,36 @@ func resourceAutopilotAddonUpdate(ctx context.Context, d *schema.ResourceData, m
 		updateAddonHttpUrl = "autopilot/v3/addons/{id}"
 	)
 
-	updateAddonClient, err := cfg.NewServiceClient(updateAddonProduct, region)
+	client, err := cfg.NewServiceClient(updateAddonProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	updateAddonPath := updateAddonClient.Endpoint + updateAddonHttpUrl
-	updateAddonPath = strings.ReplaceAll(updateAddonPath, "{id}", d.Id())
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + updateAddonHttpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{id}", d.Id())
 
-	updateOpts, err := buildUpdateAddonBodyParams(d)
-	if err != nil {
-		return diag.Errorf("error building update options of CCE autopolit add-on: %s", err)
-	}
-	updateAddonOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(updateOpts),
-	}
+		updateOpts, err := buildUpdateAddonBodyParams(d)
+		if err != nil {
+			return diag.Errorf("error building update options of CCE autopilot add-on: %s", err)
+		}
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(updateOpts),
+		}
 
-	_, err = updateAddonClient.Request("PUT", updateAddonPath, &updateAddonOpt)
-	if err != nil {
-		return diag.Errorf("error updating CCE autopolit add-on: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating CCE autopilot add-on: %s", err)
+		}
+
+		err = waitingForAddonJobCompleted(ctx, client, d, d.Timeout(schema.TimeoutUpdate), []string{"running", "available"})
+		if err != nil {
+			return diag.Errorf("error waiting for updating CCE autopilot add-on (%s) to complete: %s", d.Id(), err)
+		}
 	}
 
 	return resourceAutopilotAddonRead(ctx, d, meta)
@@ -318,30 +331,28 @@ func resourceAutopilotAddonUpdate(ctx context.Context, d *schema.ResourceData, m
 func resourceAutopilotAddonDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		deleteAddonHttpUrl = "autopilot/v3/addons/{id}"
-		deleteAddonProduct = "cce"
-	)
-	deleteAddonClient, err := cfg.NewServiceClient(deleteAddonProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	deleteAddonPath := deleteAddonClient.Endpoint + deleteAddonHttpUrl
-	deleteAddonPath = strings.ReplaceAll(deleteAddonPath, "{project_id}", deleteAddonClient.ProjectID)
-	deleteAddonPath = strings.ReplaceAll(deleteAddonPath, "{id}", d.Id())
+	deletePath := client.Endpoint + "autopilot/v3/addons/{id}"
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", d.Id())
 
-	deleteAddonOpt := golangsdk.RequestOpts{
+	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
-	_, err = deleteAddonClient.Request("DELETE", deleteAddonPath, &deleteAddonOpt)
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error deleting CCE autopolit add-on")
+		return common.CheckDeletedDiag(d, err, "error deleting CCE autopilot add-on")
 	}
 
-	err = addonWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
+	err = waitingForAddonJobCompleted(ctx, client, d, d.Timeout(schema.TimeoutDelete), nil)
 	if err != nil {
 		return diag.Errorf("error waiting for deleting CCE autopilot add-on (%s) to complete: %s", d.Id(), err)
 	}
@@ -349,65 +360,57 @@ func resourceAutopilotAddonDelete(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func addonWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+func waitingForAddonJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	t time.Duration, targets []string) error {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"COMPLETED"},
-		Refresh: func() (interface{}, string, error) {
-			cfg := meta.(*config.Config)
-			region := cfg.GetRegion(d)
-			var (
-				adonWaitingHttpUrl = "autopilot/v3/addons/{id}"
-				adonWaitingProduct = "cce"
-			)
-			adonWaitingClient, err := cfg.NewServiceClient(adonWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating CCE client: %s", err)
-			}
-
-			adonWaitingPath := adonWaitingClient.Endpoint + adonWaitingHttpUrl
-			adonWaitingPath = strings.ReplaceAll(adonWaitingPath, "{id}", d.Id())
-
-			adonWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-			}
-			adonWaitingResp, err := adonWaitingClient.Request("GET", adonWaitingPath, &adonWaitingOpt)
-			if err != nil {
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return adonWaitingResp, "COMPLETED", nil
-				}
-				return nil, "ERROR", err
-			}
-
-			adonWaitingRespBody, err := utils.FlattenResponse(adonWaitingResp)
-			if err != nil {
-				return nil, "ERROR", err
-			}
-			status := utils.PathSearch(`status.status`, adonWaitingRespBody, nil)
-			if status == nil {
-				return nil, "ERROR", fmt.Errorf("error parsing %s from response body", `status.phase`)
-			}
-
-			targetStatus := []string{
-				"running",
-			}
-			if utils.StrSliceContains(targetStatus, status.(string)) {
-				return adonWaitingRespBody, "COMPLETED", nil
-			}
-
-			unexpectedStatus := []string{
-				"installFailed", "upgradeFailed", "deleteFailed", "rollbackFailed",
-			}
-			if utils.StrSliceContains(unexpectedStatus, status.(string)) {
-				return adonWaitingRespBody, status.(string), nil
-			}
-
-			return adonWaitingRespBody, "PENDING", nil
-		},
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshAddonStatus(client, d, targets),
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+func refreshAddonStatus(client *golangsdk.ServiceClient, d *schema.ResourceData, targets []string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Expect the status of CCE autopilot add-on to be any one of the status list: %v.", targets)
+		addonRespBody, err := getAutopilotAddon(client, d)
+		if err != nil {
+			var errDefault404 golangsdk.ErrDefault404
+			if errors.As(err, &errDefault404) {
+				// On delete (targets is nil), the resource is already gone, which is the expected
+				// outcome. Return a non-nil empty object so the SDK state machine matches "COMPLETED"
+				// against Target=["COMPLETED"] and finishes normally.
+				// On create/update (targets is non-nil), a 404 means the resource does not exist,
+				// return nil so the SDK increments notfoundTick and eventually reports NotFoundError.
+				if len(targets) == 0 {
+					return map[string]interface{}{}, "COMPLETED", nil
+				}
+				return nil, "COMPLETED", nil
+			}
+			return nil, "ERROR", err
+		}
+
+		status := utils.PathSearch("status.status", addonRespBody, nil)
+		if status == nil {
+			return nil, "ERROR", fmt.Errorf("error parsing status from response body")
+		}
+
+		statusStr := status.(string)
+		invalidStatuses := []string{"installFailed", "upgradeFailed", "deleteFailed", "rollbackFailed", "abnormal", "unknown"}
+		if utils.IsStrContainsSliceElement(statusStr, invalidStatuses, true, true) {
+			reason := utils.PathSearch("status.reason", addonRespBody, "")
+			message := utils.PathSearch("status.message", addonRespBody, "")
+			return nil, "ERROR", fmt.Errorf("addon status is %s, reason: %s, message: %s",
+				statusStr, reason, message)
+		}
+
+		if utils.StrSliceContains(targets, statusStr) {
+			return addonRespBody, "COMPLETED", nil
+		}
+		return addonRespBody, "PENDING", nil
+	}
 }

--- a/huaweicloud/services/cceautopilot/resource_huaweicloud_cce_autopilot_release.go
+++ b/huaweicloud/services/cceautopilot/resource_huaweicloud_cce_autopilot_release.go
@@ -3,10 +3,14 @@ package cceautopilot
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -36,6 +40,12 @@ func ResourceAutopilotRelease() *schema.Resource {
 		},
 
 		CustomizeDiff: config.FlexibleForceNew(releaseNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -160,6 +170,10 @@ func ResourceAutopilotRelease() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"release_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -213,30 +227,32 @@ func buildAutopilotReleaseParametersParams(d *schema.ResourceData) map[string]in
 func resourceAutopilotReleaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		createAutopilotReleaseHttpUrl = "autopilot/cam/v3/clusters/{cluster_id}/releases"
-		createAutopilotReleaseProduct = "cce"
-	)
-	createAutopilotReleaseClient, err := cfg.NewServiceClient(createAutopilotReleaseProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	createAutopilotReleasePath := createAutopilotReleaseClient.Endpoint + createAutopilotReleaseHttpUrl
-	createAutopilotReleasePath = strings.ReplaceAll(createAutopilotReleasePath, "{cluster_id}", d.Get("cluster_id").(string))
+	createPath := client.Endpoint + "autopilot/cam/v3/clusters/{cluster_id}/releases"
+	createPath = strings.ReplaceAll(createPath, "{cluster_id}", d.Get("cluster_id").(string))
 
-	createAutopilotReleaseOpt := golangsdk.RequestOpts{
+	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateAutopilotReleaseBodyParams(d)),
 	}
 
-	createAutopilotReleaseOpt.JSONBody = utils.RemoveNil(buildCreateAutopilotReleaseBodyParams(d))
-	_, err = createAutopilotReleaseClient.Request("POST", createAutopilotReleasePath, &createAutopilotReleaseOpt)
+	_, err = client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating CCE autopilot release: %s", err)
 	}
-
 	d.SetId(d.Get("name").(string))
+
+	err = waitingForReleaseJobCompleted(ctx, client, d, d.Timeout(schema.TimeoutCreate), []string{"DEPLOYED"})
+	if err != nil {
+		return diag.Errorf("error creating CCE autopilot release: %s", err)
+	}
 
 	return resourceAutopilotReleaseRead(ctx, d, meta)
 }
@@ -244,36 +260,18 @@ func resourceAutopilotReleaseCreate(ctx context.Context, d *schema.ResourceData,
 func resourceAutopilotReleaseRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		getAutopilotReleaseHttpUrl = "autopilot/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
-		getAutopilotReleaseProduct = "cce"
-	)
-	getAutopilotReleaseClient, err := cfg.NewServiceClient(getAutopilotReleaseProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE client: %s", err)
 	}
 
-	getAutopilotReleaseHttpPath := getAutopilotReleaseClient.Endpoint + getAutopilotReleaseHttpUrl
-	getAutopilotReleaseHttpPath = strings.ReplaceAll(getAutopilotReleaseHttpPath, "{cluster_id}", d.Get("cluster_id").(string))
-	getAutopilotReleaseHttpPath = strings.ReplaceAll(getAutopilotReleaseHttpPath, "{namespace}", d.Get("namespace").(string))
-	getAutopilotReleaseHttpPath = strings.ReplaceAll(getAutopilotReleaseHttpPath, "{name}", d.Id())
-
-	getAutopilotReleaseOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	getAutopilotReleaseResp, err := getAutopilotReleaseClient.Request("GET", getAutopilotReleaseHttpPath, &getAutopilotReleaseOpt)
+	getAutopilotReleaseRespBody, err := getAutopilotRelease(client, d)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error retrieving CCE autopilot release")
 	}
 
-	getAutopilotReleaseRespBody, err := utils.FlattenResponse(getAutopilotReleaseResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	// version, values, chart_id, description, parameters, action are not returned in GET API
+	// values, chart_id, description, parameters, action these set by user are not returned in GET API
+	// version returned in the response is the version of release
 	mErr := multierror.Append(nil,
 		d.Set("region", cfg.GetRegion(d)),
 		d.Set("cluster_id", utils.PathSearch("cluster_id", getAutopilotReleaseRespBody, nil)),
@@ -285,11 +283,33 @@ func resourceAutopilotReleaseRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("chart_name", utils.PathSearch("chart_name", getAutopilotReleaseRespBody, nil)),
 		d.Set("chart_public", utils.PathSearch("chart_public", getAutopilotReleaseRespBody, nil)),
 		d.Set("chart_version", utils.PathSearch("chart_version", getAutopilotReleaseRespBody, nil)),
+		d.Set("release_version", utils.PathSearch("version", getAutopilotReleaseRespBody, nil)),
 		d.Set("created_at", utils.PathSearch("create_at", getAutopilotReleaseRespBody, nil)),
 		d.Set("updated_at", utils.PathSearch("update_at", getAutopilotReleaseRespBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getAutopilotRelease(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getPath := client.Endpoint + "autopilot/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{namespace}", d.Get("namespace").(string))
+	getPath = strings.ReplaceAll(getPath, "{name}", d.Id())
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
 }
 
 func buildUpdateAutopilotReleaseBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -306,59 +326,92 @@ func buildUpdateAutopilotReleaseBodyParams(d *schema.ResourceData) map[string]in
 func resourceAutopilotReleaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		updateAutopilotReleaseHttpUrl = "autopilot/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
-		updateAutopilotReleaseProduct = "cce"
-	)
-	updateAutopilotReleaseClient, err := cfg.NewServiceClient(updateAutopilotReleaseProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE Client: %s", err)
 	}
 
-	updateAutopilotReleasePath := updateAutopilotReleaseClient.Endpoint + updateAutopilotReleaseHttpUrl
-	updateAutopilotReleasePath = strings.ReplaceAll(updateAutopilotReleasePath, "{cluster_id}", d.Get("cluster_id").(string))
-	updateAutopilotReleasePath = strings.ReplaceAll(updateAutopilotReleasePath, "{namespace}", d.Get("namespace").(string))
-	updateAutopilotReleasePath = strings.ReplaceAll(updateAutopilotReleasePath, "{name}", d.Id())
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + "autopilot/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
+		updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", d.Get("cluster_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{namespace}", d.Get("namespace").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{name}", d.Id())
 
-	updateAutopilotReleaseOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildUpdateAutopilotReleaseBodyParams(d)),
+		}
+
+		retryFunc := func() (interface{}, bool, error) {
+			res, err := client.Request("PUT", updatePath, &updateOpt)
+			if err == nil {
+				return res, false, nil
+			}
+			shouldRetry := strings.Contains(err.Error(), "Update release is forbidden")
+			return nil, shouldRetry, err
+		}
+
+		_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     refreshAutoPilotReleaseStatus(client, d, []string{"DEPLOYED"}),
+			WaitTarget:   []string{"COMPLETED"},
+			WaitPending:  []string{"PENDING"},
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			DelayTimeout: 10 * time.Second,
+			PollInterval: 5 * time.Second,
+		})
+		if err != nil {
+			return diag.Errorf("error updating CCE autopilot release: %s", err)
+		}
+
+		err = waitingForReleaseJobCompleted(ctx, client, d, d.Timeout(schema.TimeoutUpdate), []string{"DEPLOYED"})
+		if err != nil {
+			return diag.Errorf("error updating CCE autopilot release: %s", err)
+		}
 	}
-
-	updateAutopilotReleaseOpt.JSONBody = utils.RemoveNil(buildUpdateAutopilotReleaseBodyParams(d))
-	_, err = updateAutopilotReleaseClient.Request("PUT", updateAutopilotReleasePath, &updateAutopilotReleaseOpt)
-	if err != nil {
-		return diag.Errorf("error updating CCE autopilot release: %s", err)
-	}
-
 	return resourceAutopilotReleaseRead(ctx, d, meta)
 }
 
-func resourceAutopilotReleaseDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAutopilotReleaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-
-	var (
-		deleteAutopilotReleaseHttpUrl = "autopilot/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
-		deleteAutopilotReleaseProduct = "cce"
-	)
-	deleteAutopilotReleaseClient, err := cfg.NewServiceClient(deleteAutopilotReleaseProduct, region)
+	client, err := cfg.NewServiceClient("cce", region)
 	if err != nil {
 		return diag.Errorf("error creating CCE client: %s", err)
 	}
 
-	deleteAutopilotReleaseHttpPath := deleteAutopilotReleaseClient.Endpoint + deleteAutopilotReleaseHttpUrl
-	deleteAutopilotReleaseHttpPath = strings.ReplaceAll(deleteAutopilotReleaseHttpPath, "{cluster_id}", d.Get("cluster_id").(string))
-	deleteAutopilotReleaseHttpPath = strings.ReplaceAll(deleteAutopilotReleaseHttpPath, "{namespace}", d.Get("namespace").(string))
-	deleteAutopilotReleaseHttpPath = strings.ReplaceAll(deleteAutopilotReleaseHttpPath, "{name}", d.Id())
+	deletePath := client.Endpoint + "autopilot/cam/v3/clusters/{cluster_id}/namespace/{namespace}/releases/{name}"
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", d.Get("cluster_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{namespace}", d.Get("namespace").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{name}", d.Id())
 
 	deleteAutopilotReleaseOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
-	_, err = deleteAutopilotReleaseClient.Request("DELETE", deleteAutopilotReleaseHttpPath, &deleteAutopilotReleaseOpt)
+	_, err = client.Request("DELETE", deletePath, &deleteAutopilotReleaseOpt)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error deleting CCE autopilot release")
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"DELETED"},
+		Refresh:      refreshAutoPilotReleaseStatus(client, d, []string{"DELETED"}),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error deleting CCE autopilot release: %s", err)
 	}
 
 	return nil
@@ -376,9 +429,58 @@ func resourceAutopilotReleaseImport(_ context.Context, d *schema.ResourceData, _
 	name := parts[2]
 
 	d.SetId(name)
-	d.Set("name", name)
-	d.Set("cluster_id", clusterID)
-	d.Set("namespace", namespace)
+	mErr := multierror.Append(nil,
+		d.Set("name", name),
+		d.Set("cluster_id", clusterID),
+		d.Set("namespace", namespace),
+	)
 
-	return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}
+
+func waitingForReleaseJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	t time.Duration, targets []string) error {
+	stateConf := &retry.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshAutoPilotReleaseStatus(client, d, targets),
+		Timeout:      t,
+		Delay:        10 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshAutoPilotReleaseStatus(client *golangsdk.ServiceClient, d *schema.ResourceData, targets []string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Expect the status of CCE autopilot release to be any one of the status list: %v.", targets)
+		releaseRespBody, err := getAutopilotRelease(client, d)
+		if err != nil {
+			var errDefault404 golangsdk.ErrDefault404
+			if errors.As(err, &errDefault404) {
+				return "Resource Not Found", "DELETED", nil
+			}
+			return nil, "ERROR", fmt.Errorf("error retrieving CCE autopilot release: %s", err)
+		}
+
+		status := utils.PathSearch("status", releaseRespBody, nil)
+		if status == nil {
+			return nil, "ERROR", fmt.Errorf("error parsing status from response body")
+		}
+
+		statusStr := status.(string)
+		invalidStatuses := []string{"FAILED", "UNKNOWN"}
+		if utils.IsStrContainsSliceElement(statusStr, invalidStatuses, true, true) {
+			if statusStr == "UNKNOWN" {
+				return nil, "ERROR", fmt.Errorf("the release status is unknown, please try to delete and reinstall manually")
+			}
+			return nil, "ERROR", fmt.Errorf("the release job failed, status: %s", statusStr)
+		}
+
+		if utils.StrSliceContains(targets, statusStr) {
+			return releaseRespBody, "COMPLETED", nil
+		}
+		return releaseRespBody, "PENDING", nil
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1.Skip update logic when only 'enable_force_new' changes for the following resources:
- huaweicloud_taurusdb_cce_autopilot_addon
- huaweicloud_taurusdb_cce_autopilot_release

2.Add logic waiting for the async job completed in the following resources:
- huaweicloud_taurusdb_cce_autopilot_addon
- huaweicloud_taurusdb_cce_autopilot_release
- huaweicloud_taurusdb_cce_release

3. Add retry logic when update request failed in the following resource:
- huaweicloud_taurusdb_cce_autopilot_release

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Skip update logic when only 'enable_force_new' changes for resources of cceautopilot
2. Add logic waiting for the async job completed
3. Add retry logic when update request failed in `huaweicloud_taurusdb_cce_autopilot_release`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
- huaweicloud_taurusdb_cce_autopilot_addon
```
make testacc TEST='./huaweicloud/services/acceptance/cceautopilot' TESTARGS='-run=TestAccAutopilotAddon'
=== RUN   TestAccAutopilotAddon_basic
=== PAUSE TestAccAutopilotAddon_basic
=== CONT  TestAccAutopilotAddon_basic
--- PASS: TestAccAutopilotAddon_basic (957.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cceautopilot 957.336s
```
**change attributes excpet `enable_force_new`:**
<img width="1816" height="981" alt="image" src="https://github.com/user-attachments/assets/9156cee3-c079-4e4a-b556-f67bd69ea24a" />

**only change `enable_force_new`:**
<img width="1801" height="934" alt="image" src="https://github.com/user-attachments/assets/a75911ca-2d08-48ac-b887-9b8126c5b685" />

- huaweicloud_taurusdb_cce_autopilot_release
```
make testacc TEST='./huaweicloud/services/acceptance/cceautopilot' TESTARGS='-run=TestAccAutopilotRelease'
=== RUN   TestAccAutopilotRelease_basic
=== PAUSE TestAccAutopilotRelease_basic
=== CONT  TestAccAutopilotRelease_basic
--- PASS: TestAccAutopilotRelease_basic (1893.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cceautopilot 957.336s
```

**change attributes excpet `enable_force_new`:**
<img width="1808" height="958" alt="image" src="https://github.com/user-attachments/assets/42fa5af9-1f03-413e-a773-c94caf57ccac" />

**only change `enable_force_new`:**
<img width="1813" height="967" alt="image" src="https://github.com/user-attachments/assets/4ccaad0b-261c-40a7-8182-31235a8bf2ed" />


- huaweicloud_taurusdb_cce_release
```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run=TestAccRelease'
=== RUN   TestAccRelease_basic
=== PAUSE TestAccRelease_basic
=== CONT  TestAccRelease_basic
--- PASS: TestAccRelease_basic (1127.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce 1127.043s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
