### PR TITLE
feat(apig): resources support enable_force_new param

### DIFF
--- a/docs/data-sources/apig_api.md
+++ b/docs/data-sources/apig_api.md
@@ -148,6 +148,8 @@ The `request_params` block supports:
   + **1**: enable
   + **2**: disable
 
+* `orchestrations` - The list of orchestration rules that parameter used.
+
 <a name="api_backend_params"></a>
 The `backend_params` block supports:
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_publishment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_publishment_test.go
@@ -144,7 +144,7 @@ resource "huaweicloud_apig_api" "web" {
     request_protocol = "HTTP"
     timeout          = 30000
     retry_count      = 1
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   web_policy {
@@ -156,7 +156,7 @@ resource "huaweicloud_apig_api" "web" {
     timeout          = 30000
     retry_count      = 1
     vpc_channel_id   = huaweicloud_apig_channel.test.id
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
 
     backend_params {
       type              = "SYSTEM"
@@ -189,25 +189,25 @@ resource "huaweicloud_apig_api" "func_graph" {
   description             = "Created by script"
 
   func_graph {
-    function_urn     = huaweicloud_fgs_function.test[1].urn
+    function_urn     = trimsuffix(huaweicloud_fgs_function.test[1].urn, ":latest")
     version          = tolist(huaweicloud_fgs_function.test[1].versions)[0].name
     network_type     = "V2"
     request_protocol = "GRPCS"
     timeout          = 5000
     invocation_type  = "sync"
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   func_graph_policy {
     name             = "%[2]s_fgs_policy"
-    function_urn     = huaweicloud_fgs_function.test[1].urn
+    function_urn     = trimsuffix(huaweicloud_fgs_function.test[1].urn, ":latest")
     version          = tolist(huaweicloud_fgs_function.test[1].versions)[0].name
     network_type     = "V2"
     request_protocol = "GRPCS"
     timeout          = 5000
     invocation_type  = "sync"
     effective_mode   = "ANY"
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
 
     conditions {
       source      = "cookie"
@@ -236,14 +236,14 @@ resource "huaweicloud_apig_api" "mock" {
   mock {
     status_code   = 201
     response      = "{'message':'hello world'}"
-    authorizer_id = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   mock_policy {
     name           = "%[2]s_mock_policy"
     status_code    = 201
     response       = "{'message':'hello world'}"
-    authorizer_id  = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id  = huaweicloud_apig_custom_authorizer.backend.id
     effective_mode = "ANY"
 
     conditions {

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_routes_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_routes_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
 )
 
 func getInstanceRoutesFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -20,35 +18,19 @@ func getInstanceRoutesFunc(cfg *config.Config, state *terraform.ResourceState) (
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	opts := instances.ListFeaturesOpts{
-		// Default value of parameter 'limit' is 20, parameter 'offset' is an invalid parameter.
-		// If we omit it, we can only obtain 20 features, other features will be lost.
-		Limit: 500,
-	}
-	resp, err := instances.ListFeatures(client, state.Primary.ID, opts)
-	if err != nil {
-		return nil, fmt.Errorf("error querying feature list: %s", err)
-	}
-
-	for _, val := range resp {
-		if val.Name == "route" {
-			return val, nil
-		}
-	}
-	return nil, fmt.Errorf("error querying feature: route")
+	return apig.ListInstanceRoutes(client, state.Primary.ID)
 }
 
 func TestAccInstanceRoutes_basic(t *testing.T) {
 	var (
-		feature instances.Feature
+		obj interface{}
 
 		rName = "huaweicloud_apig_instance_routes.test"
-		name  = acceptance.RandomAccResourceName()
 	)
 
 	rc := acceptance.InitResourceCheck(
 		rName,
-		&feature,
+		&obj,
 		getInstanceRoutesFunc,
 	)
 
@@ -61,15 +43,15 @@ func TestAccInstanceRoutes_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceRoutes_basic_step1(name),
+				Config: testAccInstanceRoutes_basic_step1(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
 					resource.TestCheckResourceAttr(rName, "nexthops.#", "2"),
 				),
 			},
 			{
-				Config: testAccInstanceRoutes_basic_step2(name),
+				Config: testAccInstanceRoutes_basic_step2(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "nexthops.#", "2"),
@@ -84,43 +66,36 @@ func TestAccInstanceRoutes_basic(t *testing.T) {
 	})
 }
 
-func testAccInstanceRoutes_base(name string) string {
+func testAccInstanceRoutes_base() string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
-
-%[1]s
-
-// Only resource returns parameter 'vpcep_service_address'.
-resource "huaweicloud_apig_instance" "test" {
-  name                  = "%[2]s"
-  edition               = "BASIC"
-  vpc_id                = huaweicloud_vpc.test.id
-  subnet_id             = huaweicloud_vpc_subnet.test.id
-  security_group_id     = huaweicloud_networking_secgroup.test.id
-  enterprise_project_id = "0"
-  availability_zones    = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
-}
-`, common.TestBaseNetwork(name), name)
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[1]s"
 }
 
-func testAccInstanceRoutes_basic_step1(name string) string {
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccInstanceRoutes_basic_step1() string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_apig_instance_routes" "test" {
-  instance_id = huaweicloud_apig_instance.test.id
+  instance_id = local.instance_id
   nexthops    = ["172.16.128.0/20","172.16.0.0/20"]
 }
-`, testAccInstanceRoutes_base(name))
+`, testAccInstanceRoutes_base())
 }
 
-func testAccInstanceRoutes_basic_step2(name string) string {
+func testAccInstanceRoutes_basic_step2() string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_apig_instance_routes" "test" {
-  instance_id = huaweicloud_apig_instance.test.id
+  instance_id = local.instance_id
   nexthops    = ["172.16.64.0/20","172.16.192.0/20"]
 }
-`, testAccInstanceRoutes_base(name))
+`, testAccInstanceRoutes_base())
 }

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_api.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_api.go
@@ -164,6 +164,12 @@ func DataSourceApi() *schema.Resource {
 							Computed:    true,
 							Description: "Whether to enable the parameter validation.",
 						},
+						"orchestrations": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The list of orchestration rules that parameter used.",
+						},
 					},
 				},
 				Description: "The configuration list of the front-end parameters.",

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy.go
@@ -8,14 +8,22 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/acls"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // ResourceAclPolicy is a provider resource of the APIG ACL policy.
+
+var aclPolicyNonUpdatableParams = []string{
+	"instance_id",
+	"entity_type",
+}
+
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/acls/{acl_id}
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/acls/{acl_id}
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/acls/{acl_id}
@@ -31,6 +39,8 @@ func ResourceAclPolicy() *schema.Resource {
 			StateContext: resourceAclPolicyImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(aclPolicyNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -42,7 +52,6 @@ func ResourceAclPolicy() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the ACL policy belongs.",
 			},
 			"name": {
@@ -58,7 +67,6 @@ func ResourceAclPolicy() *schema.Resource {
 			"entity_type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The entity type of the ACL policy.",
 			},
 			"value": {
@@ -70,6 +78,18 @@ func ResourceAclPolicy() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The latest update time of the ACL policy.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -136,20 +156,22 @@ func resourceAclPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		instanceId = d.Get("instance_id").(string)
-		policyId   = d.Id()
-		// Build ACL policy update options according to schema configuration.
-		opts = acls.UpdateOpts{
-			Name:       d.Get("name").(string),
-			Type:       d.Get("type").(string),
-			EntityType: d.Get("entity_type").(string),
-			Value:      d.Get("value").(string),
+	if d.HasChangeExcept("enable_force_new") {
+		var (
+			instanceId = d.Get("instance_id").(string)
+			policyId   = d.Id()
+			// Build ACL policy update options according to schema configuration.
+			opts = acls.UpdateOpts{
+				Name:       d.Get("name").(string),
+				Type:       d.Get("type").(string),
+				EntityType: d.Get("entity_type").(string),
+				Value:      d.Get("value").(string),
+			}
+		)
+		_, err = acls.Update(client, instanceId, policyId, opts)
+		if err != nil {
+			return diag.Errorf("error updating ACL policy: %s", err)
 		}
-	)
-	_, err = acls.Update(client, instanceId, policyId, opts)
-	if err != nil {
-		return diag.Errorf("error updating ACL policy: %s", err)
 	}
 
 	return resourceAclPolicyRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy_associate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/acls"
@@ -19,6 +20,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var aclPolicyAssociateNonUpdatableParams = []string{
+	"instance_id",
+	"policy_id",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/acl-bindings
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/acl-bindings/unbinded-apis
@@ -41,6 +47,8 @@ func ResourceAclPolicyAssociate() *schema.Resource {
 			StateContext: resourceAclPolicyAssociateImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(aclPolicyAssociateNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -52,13 +60,11 @@ func ResourceAclPolicyAssociate() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the APIs and the ACL policy belong.",
 			},
 			"policy_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ACL Policy ID for APIs binding.",
 			},
 			"publish_ids": {
@@ -66,6 +72,18 @@ func ResourceAclPolicyAssociate() *schema.Resource {
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The publish IDs corresponding to the APIs bound by the ACL policy.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -336,31 +354,33 @@ func resourceAclPolicyAssociateUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		instanceId     = d.Get("instance_id").(string)
-		policyId       = d.Get("policy_id").(string)
-		oldRaw, newRaw = d.GetChange("publish_ids")
+	if d.HasChangeExcept("enable_force_new") {
+		var (
+			instanceId     = d.Get("instance_id").(string)
+			policyId       = d.Get("policy_id").(string)
+			oldRaw, newRaw = d.GetChange("publish_ids")
 
-		addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
-		rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
-	)
+			addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
+			rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
+		)
 
-	if rmSet.Len() > 0 {
-		opt := buildAclPolicyListOpts(instanceId, policyId)
-		err = unbindAclPolicy(ctx, client, opt, rmSet, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
+		if rmSet.Len() > 0 {
+			opt := buildAclPolicyListOpts(instanceId, policyId)
+			err = unbindAclPolicy(ctx, client, opt, rmSet, d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
-	if addSet.Len() > 0 {
-		opt := acls.BindOpts{
-			InstanceId: instanceId,
-			PolicyId:   policyId,
-			PublishIds: utils.ExpandToStringListBySet(addSet),
-		}
-		err = bindAclPolicyToApis(ctx, client, opt, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
+		if addSet.Len() > 0 {
+			opt := acls.BindOpts{
+				InstanceId: instanceId,
+				PolicyId:   policyId,
+				PublishIds: utils.ExpandToStringListBySet(addSet),
+			}
+			err = bindAclPolicyToApis(ctx, client, opt, d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_publishment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_publishment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis"
@@ -17,6 +18,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var apigApiPublishmentNonUpdatableParams = []string{
+	"instance_id",
+	"env_id",
+	"api_id",
+}
 
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/apis/action
@@ -33,6 +40,8 @@ func ResourceApigApiPublishment() *schema.Resource {
 			StateContext: resourceApiPublishmentImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(apigApiPublishmentNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -44,20 +53,17 @@ func ResourceApigApiPublishment() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the API and the environment belongs.",
 			},
 			"env_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 				Description: "The ID of the environment to which the current version of the API will be published or " +
 					"has been published.",
 			},
 			"api_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the API to be published or already published.",
 			},
 			"description": {
@@ -104,6 +110,18 @@ func ResourceApigApiPublishment() *schema.Resource {
 					},
 				},
 				Description: "All publish informations of the API.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -331,6 +349,7 @@ func ResourceApiPublishmentRead(_ context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
+// nolint:gocyclo
 func ResourceApiPublishmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
@@ -338,37 +357,39 @@ func ResourceApiPublishmentUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	versionId := d.Get("version_id").(string)
-	instanceId, envId, apiId, err := flattenResourceId(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if versionId == "" {
-		// If the version of the configuration is empty, whether description is changed or not, publish a new version.
-		if err = publishApiToSpecifiedEnv(client, instanceId, envId, apiId, d.Get("description").(string)); err != nil {
-			return diag.Errorf("error publishing API: %s", err)
-		}
-	} else {
-		if !d.HasChange("version_id") && d.HasChange("description") {
-			return diag.Errorf("only for new API publishment, the description can be updated")
-		}
-		description := d.Get("description").(string)
-
-		// Obtain the version history of the API from the specified environment and check whether the current version
-		// has been published.
-		histories, err := GetVersionHistories(client, instanceId, envId, apiId)
+	if d.HasChangeExcept("enable_force_new") {
+		versionId := d.Get("version_id").(string)
+		instanceId, envId, apiId, err := flattenResourceId(d.Id())
 		if err != nil {
-			return diag.Errorf("error getting version histories of the API (%s): %s", apiId, err)
+			return diag.FromErr(err)
 		}
-		if ver, ok := isPublished(histories, versionId); !ok {
-			return diag.Errorf("this version (%s) has not published", versionId)
-		} else if description != "" && ver.Description != description {
-			// If user want to switch an exist version, but the description is not right, throw an error.
-			return diag.Errorf("this description is not belongs to version (%s)", versionId)
-		}
+		if versionId == "" {
+			// If the version of the configuration is empty, whether description is changed or not, publish a new version.
+			if err = publishApiToSpecifiedEnv(client, instanceId, envId, apiId, d.Get("description").(string)); err != nil {
+				return diag.Errorf("error publishing API: %s", err)
+			}
+		} else {
+			if !d.HasChange("version_id") && d.HasChange("description") {
+				return diag.Errorf("only for new API publishment, the description can be updated")
+			}
+			description := d.Get("description").(string)
 
-		if _, err := apis.SwitchSpecVersion(client, instanceId, apiId, versionId).Extract(); err != nil {
-			return diag.Errorf("%s", err)
+			// Obtain the version history of the API from the specified environment and check whether the current version
+			// has been published.
+			histories, err := GetVersionHistories(client, instanceId, envId, apiId)
+			if err != nil {
+				return diag.Errorf("error getting version histories of the API (%s): %s", apiId, err)
+			}
+			if ver, ok := isPublished(histories, versionId); !ok {
+				return diag.Errorf("this version (%s) has not published", versionId)
+			} else if description != "" && ver.Description != description {
+				// If user want to switch an exist version, but the description is not right, throw an error.
+				return diag.Errorf("this description is not belongs to version (%s)", versionId)
+			}
+
+			if _, err := apis.SwitchSpecVersion(client, instanceId, apiId, versionId).Extract(); err != nil {
+				return diag.Errorf("%s", err)
+			}
 		}
 	}
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_acl.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_acl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -16,6 +17,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var applicationAclNonUpdatableParams = []string{
+	"instance_id",
+	"application_id",
+}
 
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-acl
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-acl
@@ -31,6 +37,8 @@ func ResourceApplicationAcl() *schema.Resource {
 			StateContext: resourceApplicationAclImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(applicationAclNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -42,13 +50,11 @@ func ResourceApplicationAcl() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the application belongs.",
 			},
 			"application_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the application to which the ACL rules belong.",
 			},
 			"type": {
@@ -61,6 +67,18 @@ func ResourceApplicationAcl() *schema.Resource {
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The ACL values.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -177,9 +195,11 @@ func resourceApplicationAclUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	err = settingACLsToApplication(client, d)
-	if err != nil {
-		return diag.FromErr(err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = settingACLsToApplication(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceApplicationAclRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_authorization.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_authorization.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -19,6 +20,12 @@ import (
 )
 
 var strSliceParamKeys = []string{"api_ids"}
+
+var applicationAuthorizationNonUpdatableParams = []string{
+	"instance_id",
+	"application_id",
+	"env_id",
+}
 
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/app-auths/{app_auth_id}
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/app-auths
@@ -34,6 +41,8 @@ func ResourceApplicationAuthorization() *schema.Resource {
 			StateContext: resourceApplicationAuthorizationImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(applicationAuthorizationNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -45,19 +54,16 @@ func ResourceApplicationAuthorization() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the application and APIs belong.",
 			},
 			"application_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the application authorized to access the APIs.",
 			},
 			"env_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The environment ID where the APIs were published.",
 			},
 			"api_ids": {
@@ -80,6 +86,18 @@ the new value next time the change is made. The corresponding parameter name is 
 						Internal: true,
 					},
 				),
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -267,6 +285,7 @@ func resourceApplicationAuthorizationRead(_ context.Context, d *schema.ResourceD
 	return nil
 }
 
+// nolint:gocyclo
 func resourceApplicationAuthorizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
@@ -274,50 +293,52 @@ func resourceApplicationAuthorizationUpdate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		resourceId = d.Id()
-		instanceId = d.Get("instance_id").(string)
-		appId      = d.Get("application_id").(string)
-		envId      = d.Get("env_id").(string)
+	if d.HasChangeExcept("enable_force_new") {
+		var (
+			resourceId = d.Id()
+			instanceId = d.Get("instance_id").(string)
+			appId      = d.Get("application_id").(string)
+			envId      = d.Get("env_id").(string)
 
-		consoleApiIds, scriptApiIds = d.GetChange("api_ids")
+			consoleApiIds, scriptApiIds = d.GetChange("api_ids")
 
-		consoleApiIdsList = consoleApiIds.(*schema.Set).List()
-		scriptApiIdsList  = scriptApiIds.(*schema.Set).List()
-		originApiIdsList  = d.Get("api_ids_origin").([]interface{})
-	)
+			consoleApiIdsList = consoleApiIds.(*schema.Set).List()
+			scriptApiIdsList  = scriptApiIds.(*schema.Set).List()
+			originApiIdsList  = d.Get("api_ids_origin").([]interface{})
+		)
 
-	// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
-	// failed)
-	config.MutexKV.Lock(resourceId)
-	defer config.MutexKV.Unlock(resourceId)
+		// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
+		// failed)
+		config.MutexKV.Lock(resourceId)
+		defer config.MutexKV.Unlock(resourceId)
 
-	newApiIds := utils.FindSliceElementsNotInAnother(scriptApiIdsList, consoleApiIdsList)
-	rmApiIds := utils.FindSliceElementsNotInAnother(originApiIdsList, scriptApiIdsList)
+		newApiIds := utils.FindSliceElementsNotInAnother(scriptApiIdsList, consoleApiIdsList)
+		rmApiIds := utils.FindSliceElementsNotInAnother(originApiIdsList, scriptApiIdsList)
 
-	if len(rmApiIds) > 0 {
-		log.Printf("[DEBUG] Prepare to delete the authorization for specified API IDs: %v", rmApiIds)
-		err := deleteApplicationAuthorizationForApis(client, instanceId, envId, appId, rmApiIds)
-		if err != nil {
-			return diag.FromErr(err)
+		if len(rmApiIds) > 0 {
+			log.Printf("[DEBUG] Prepare to delete the authorization for specified API IDs: %v", rmApiIds)
+			err := deleteApplicationAuthorizationForApis(client, instanceId, envId, appId, rmApiIds)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
 
-	if len(newApiIds) > 0 {
-		log.Printf("[DEBUG] Prepare to create the authorization for specified API IDs: %v", newApiIds)
-		err = createApplicationAuthorizationForApis(client, instanceId, envId, appId, newApiIds)
-		if err != nil {
-			return diag.FromErr(err)
+		if len(newApiIds) > 0 {
+			log.Printf("[DEBUG] Prepare to create the authorization for specified API IDs: %v", newApiIds)
+			err = createApplicationAuthorizationForApis(client, instanceId, envId, appId, newApiIds)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
 
-	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
-	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
-	// And whether corresponding parameters are changed, the origin values must be refreshed.
-	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeys)
-	if err != nil {
-		// Don't fail the update if origin refresh fails
-		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
+		// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+		// And whether corresponding parameters are changed, the origin values must be refreshed.
+		err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeys)
+		if err != nil {
+			// Don't fail the update if origin refresh fails
+			log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		}
 	}
 
 	return resourceApplicationAuthorizationRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_quota.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_quota.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -15,6 +16,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var applicationQuotaNonUpdatableParams = []string{
+	"instance_id",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/app-quotas
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}
@@ -31,6 +36,8 @@ func ResourceApplicationQuota() *schema.Resource {
 			StateContext: resourceApplicationQuotaImport,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(applicationQuotaNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -41,7 +48,6 @@ func ResourceApplicationQuota() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specifies the ID of the dedicated instance to which the application quota belongs.",
 			},
 			"name": {
@@ -78,6 +84,18 @@ func ResourceApplicationQuota() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The creation time of the application quota, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -182,19 +200,11 @@ func resourceApplicationQuotaRead(_ context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func resourceApplicationQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+func updateApplicationQuota(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}"
 
-	updateQuotaHttpUrl := "v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}"
-	updateQuotaProduct := "apig"
-
-	updateQuotaClient, err := cfg.NewServiceClient(updateQuotaProduct, region)
-	if err != nil {
-		return diag.Errorf("error creating APIG Client: %s", err)
-	}
-	updateQuotaPath := updateQuotaClient.Endpoint + updateQuotaHttpUrl
-	updateQuotaPath = strings.ReplaceAll(updateQuotaPath, "{project_id}", updateQuotaClient.ProjectID)
+	updateQuotaPath := client.Endpoint + httpUrl
+	updateQuotaPath = strings.ReplaceAll(updateQuotaPath, "{project_id}", client.ProjectID)
 	updateQuotaPath = strings.ReplaceAll(updateQuotaPath, "{instance_id}", d.Get("instance_id").(string))
 	updateQuotaPath = strings.ReplaceAll(updateQuotaPath, "{app_quota_id}", d.Id())
 
@@ -203,10 +213,28 @@ func resourceApplicationQuotaUpdate(ctx context.Context, d *schema.ResourceData,
 		JSONBody:         buildQuotaParams(d),
 	}
 
-	_, err = updateQuotaClient.Request("PUT", updateQuotaPath, &updateQuotaOpt)
+	_, err := client.Request("PUT", updateQuotaPath, &updateQuotaOpt)
 	if err != nil {
-		return diag.Errorf("error updating APIG application quota: %s", err)
+		return fmt.Errorf("error updating APIG application quota: %s", err)
 	}
+	return nil
+}
+
+func resourceApplicationQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG Client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		if err := updateApplicationQuota(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceApplicationQuotaRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_quota_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_quota_associate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -18,6 +19,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var applicationQuotaAssociateNonUpdatableParams = []string{
+	"instance_id",
+	"quota_id",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}/binding-apps
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}/bindable-apps
@@ -40,6 +46,8 @@ func ResourceApplicationQuotaAssociate() *schema.Resource {
 			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(applicationQuotaAssociateNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -51,13 +59,11 @@ func ResourceApplicationQuotaAssociate() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the application quota (policy) belongs.",
 			},
 			"quota_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the application quota (policy).",
 			},
 			"applications": {
@@ -78,6 +84,18 @@ func ResourceApplicationQuotaAssociate() *schema.Resource {
 					},
 				},
 				Description: "The configuration of applications bound to the quota.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -371,6 +389,34 @@ func appsUnbindingRefreshFunc(client *golangsdk.ServiceClient, instanceId, quota
 	}
 }
 
+func updateApplicationQuotaAssociate(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData, timeout time.Duration) error {
+	var (
+		instanceId     = d.Get("instance_id").(string)
+		quotaId        = d.Get("quota_id").(string)
+		oldVal, newVal = d.GetChange("applications")
+		rmRaw          = oldVal.(*schema.Set).Difference(newVal.(*schema.Set))
+		addRaw         = newVal.(*schema.Set).Difference(oldVal.(*schema.Set))
+		err            error
+	)
+
+	if rmRaw.Len() > 0 {
+		if err = disassociateAppsFromQuota(ctx, client, instanceId, quotaId, parseAssociatedAppIds(rmRaw), timeout); err != nil {
+			return err
+		}
+	}
+
+	if addRaw.Len() > 0 {
+		err = precheckAllAppIdsAreAvailable(ctx, client, d, parseAssociatedAppIds(addRaw), timeout)
+		if err != nil {
+			return err
+		}
+		if err = associateAppsToQuota(ctx, client, instanceId, quotaId, parseAssociatedAppIds(addRaw), timeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func resourceApplicationQuotaAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
@@ -382,28 +428,8 @@ func resourceApplicationQuotaAssociateUpdate(ctx context.Context, d *schema.Reso
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	var (
-		instanceId     = d.Get("instance_id").(string)
-		quotaId        = d.Get("quota_id").(string)
-		oldVal, newVal = d.GetChange("applications")
-		rmRaw          = oldVal.(*schema.Set).Difference(newVal.(*schema.Set))
-		addRaw         = newVal.(*schema.Set).Difference(oldVal.(*schema.Set))
-	)
-
-	if rmRaw.Len() > 0 {
-		if err = disassociateAppsFromQuota(ctx, client, instanceId, quotaId, parseAssociatedAppIds(rmRaw),
-			d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if addRaw.Len() > 0 {
-		err = precheckAllAppIdsAreAvailable(ctx, client, d, parseAssociatedAppIds(addRaw), d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		if err = associateAppsToQuota(ctx, client, instanceId, quotaId, parseAssociatedAppIds(addRaw),
-			d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if d.HasChangeExcept("enable_force_new") {
+		if err := updateApplicationQuotaAssociate(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_certificate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_certificate.go
@@ -7,12 +7,19 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/certificates"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var certificateNonUpdatableParams = []string{
+	"type",
+	"instance_id",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/certificates
 // @API APIG DELETE /v2/{project_id}/apigw/certificates/{certificate_id}
@@ -28,6 +35,8 @@ func ResourceCertificate() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		CustomizeDiff: config.FlexibleForceNew(certificateNonUpdatableParams),
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -58,14 +67,12 @@ func ResourceCertificate() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
 				Description: "The certificate type.",
 			},
 			"instance_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
 				Description: "The dedicated instance ID to which the certificate belongs.",
 			},
 			"trusted_root_ca": {
@@ -94,6 +101,18 @@ func ResourceCertificate() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The SAN (Subject Alternative Names) of the certificate.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -163,9 +182,11 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	_, err = certificates.Update(client, d.Id(), buildCertificateModifyOpts(d))
-	if err != nil {
-		return diag.Errorf("error updating APIG SSL certificate: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		_, err = certificates.Update(client, d.Id(), buildCertificateModifyOpts(d))
+		if err != nil {
+			return diag.Errorf("error updating APIG SSL certificate: %s", err)
+		}
 	}
 
 	return resourceCertificateRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels"
 
@@ -17,6 +18,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var channelNonUpdatableParams = []string{
+	"instance_id",
+}
 
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}
@@ -33,6 +38,8 @@ func ResourceChannel() *schema.Resource {
 			StateContext: resourceChannelResourceImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(channelNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -44,7 +51,6 @@ func ResourceChannel() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the channel belongs.",
 			},
 			"name": {
@@ -357,6 +363,18 @@ func ResourceChannel() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: `The current status of the channel.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -697,14 +715,17 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		channelId = d.Id()
-		opts      = buildChannelUpdateOpts(d)
-	)
-	_, err = channels.Update(client, channelId, opts)
-	if err != nil {
-		return diag.Errorf("error updating APIG channel (%s): %s", channelId, err)
+	if d.HasChangeExcept("enable_force_new") {
+		var (
+			channelId = d.Id()
+			opts      = buildChannelUpdateOpts(d)
+		)
+		_, err = channels.Update(client, channelId, opts)
+		if err != nil {
+			return diag.Errorf("error updating APIG channel (%s): %s", channelId, err)
+		}
 	}
+
 	return resourceChannelRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
@@ -25,6 +25,11 @@ const (
 	AuthTypeBackend  AuthType = "BACKEND"
 )
 
+var apigCustomAuthorizerV2NonUpdatableParams = []string{
+	"instance_id",
+	"type",
+}
+
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/authorizers/{authorizer_id}
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/authorizers/{authorizer_id}
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/authorizers/{authorizer_id}
@@ -41,6 +46,8 @@ func ResourceApigCustomAuthorizerV2() *schema.Resource {
 			StateContext: resourceCustomAuthorizerImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(apigCustomAuthorizerV2NonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -52,7 +59,6 @@ func ResourceApigCustomAuthorizerV2() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the custom authorizer belongs.",
 			},
 			"name": {
@@ -95,7 +101,6 @@ func ResourceApigCustomAuthorizerV2() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Default:  string(AuthTypeFrontend),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(AuthTypeFrontend), string(AuthTypeBackend),
@@ -149,6 +154,18 @@ func ResourceApigCustomAuthorizerV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The creation time of the custom authorizer.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -286,13 +303,16 @@ func resourceCustomAuthorizerUpdate(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
-	opt, err := buildCustomAuthorizerOpts(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	_, err = authorizers.Update(client, instanceId, authorizerId, opt).Extract()
-	if err != nil {
-		return diag.Errorf("error updating APIG custom authorizer (%s): %s", authorizerId, err)
+
+	if d.HasChangeExcept("enable_force_new") {
+		opt, err := buildCustomAuthorizerOpts(d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		_, err = authorizers.Update(client, instanceId, authorizerId, opt).Extract()
+		if err != nil {
+			return diag.Errorf("error updating APIG custom authorizer (%s): %s", authorizerId, err)
+		}
 	}
 
 	return resourceCustomAuthorizerRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_endpoint_connection_management.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_endpoint_connection_management.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -17,6 +18,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var endpointConnectionManagementNonUpdatableParams = []string{
+	"instance_id",
+	"endpoint_id",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/vpc-endpoint/connections/action
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/vpc-endpoint/connections
@@ -36,6 +42,8 @@ func ResourceEndpointConnectionManagement() *schema.Resource {
 			Update: schema.DefaultTimeout(5 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(endpointConnectionManagementNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -46,13 +54,11 @@ func ResourceEndpointConnectionManagement() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specifies the ID of the dedicated instance to which the endpoint connection belongs.",
 			},
 			"endpoint_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specifies the ID of the endpoint connection.",
 			},
 			"action": {
@@ -64,6 +70,18 @@ func ResourceEndpointConnectionManagement() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current ststus of the endpoint connection.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_endpoint_whitelist.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_endpoint_whitelist.go
@@ -2,10 +2,12 @@ package apig
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/endpoints"
@@ -14,6 +16,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var endpointWhiteListNonUpdatableParams = []string{
+	"instance_id",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instanceId}/vpc-endpoint/permissions/batch-add
 // @API APIG POST /v2/{project_id}/apigw/instances/{instanceId}/vpc-endpoint/permissions/batch-delete
@@ -29,6 +35,8 @@ func ResourceEndpointWhiteList() *schema.Resource {
 			StateContext: resourceEndpointWhiteListImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(endpointWhiteListNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -40,7 +48,6 @@ func ResourceEndpointWhiteList() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the endpoint service belongs.",
 			},
 			"whitelists": {
@@ -48,6 +55,18 @@ func ResourceEndpointWhiteList() *schema.Resource {
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The whitelist records of the endpoint service.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -139,6 +158,34 @@ func resourceEndpointWhiteListRead(_ context.Context, d *schema.ResourceData, me
 	return nil
 }
 
+func updateEndpointWhiteList(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		instanceId     = d.Get("instance_id").(string)
+		oldRaw, newRaw = d.GetChange("whitelists")
+
+		addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
+		rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
+
+		err error
+	)
+
+	if rmSet.Len() > 0 {
+		whitelists := utils.ExpandToStringListBySet(rmSet)
+		err = deleteEndpointWhiteListFromApis(client, instanceId, whitelists)
+		if err != nil {
+			return fmt.Errorf("error deleting whitelist records: %s", err)
+		}
+	}
+	if addSet.Len() > 0 {
+		whitelists := utils.ExpandToStringListBySet(addSet)
+		err = createEndpointWhiteListForApis(client, instanceId, whitelists)
+		if err != nil {
+			return fmt.Errorf("error creating whitelist records: %s", err)
+		}
+	}
+	return nil
+}
+
 func resourceEndpointWhiteListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
@@ -149,27 +196,9 @@ func resourceEndpointWhiteListUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		instanceId = d.Get("instance_id").(string)
-
-		oldRaw, newRaw = d.GetChange("whitelists")
-
-		addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
-		rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
-	)
-
-	if rmSet.Len() > 0 {
-		whitelists := utils.ExpandToStringListBySet(rmSet)
-		err := deleteEndpointWhiteListFromApis(client, instanceId, whitelists)
-		if err != nil {
-			return diag.Errorf("error deleting whitelist records: %s", err)
-		}
-	}
-	if addSet.Len() > 0 {
-		whitelists := utils.ExpandToStringListBySet(addSet)
-		err = createEndpointWhiteListForApis(client, instanceId, whitelists)
-		if err != nil {
-			return diag.Errorf("error creating whitelist records: %s", err)
+	if d.HasChange("whitelists") {
+		if err := updateEndpointWhiteList(client, d); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
@@ -16,6 +17,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var apigEnvironmentV2NonUpdatableParams = []string{
+	"instance_id",
+}
 
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/envs/{env_id}
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/envs/{env_id}
@@ -32,6 +37,8 @@ func ResourceApigEnvironmentV2() *schema.Resource {
 			StateContext: resourceEnvironmentResourceImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(apigEnvironmentV2NonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -43,7 +50,6 @@ func ResourceApigEnvironmentV2() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the environment belongs.",
 			},
 			"name": {
@@ -66,6 +72,18 @@ func ResourceApigEnvironmentV2() *schema.Resource {
 				Computed:    true,
 				Deprecated:  "Use 'created_at' instead",
 				Description: `schema: Deprecated; The time when the environment was created.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -145,18 +163,20 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		instanceId    = d.Get("instance_id").(string)
-		environmentId = d.Id()
-	)
+	if d.HasChangeExcept("enable_force_new") {
+		var (
+			instanceId    = d.Get("instance_id").(string)
+			environmentId = d.Id()
+		)
 
-	opt := environments.EnvironmentOpts{
-		Name:        d.Get("name").(string), // Due to API restrictions, the name must be provided.
-		Description: utils.String(d.Get("description").(string)),
-	}
-	_, err = environments.Update(client, instanceId, environmentId, opt).Extract()
-	if err != nil {
-		return diag.Errorf("error updating dedicated environment (%s): %s", environmentId, err)
+		opt := environments.EnvironmentOpts{
+			Name:        d.Get("name").(string), // Due to API restrictions, the name must be provided.
+			Description: utils.String(d.Get("description").(string)),
+		}
+		_, err = environments.Update(client, instanceId, environmentId, opt).Extract()
+		if err != nil {
+			return diag.Errorf("error updating dedicated environment (%s): %s", environmentId, err)
+		}
 	}
 
 	return resourceEnvironmentRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_environment_variable.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_environment_variable.go
@@ -8,12 +8,21 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var environmentVariableNonUpdatableParams = []string{
+	"instance_id",
+	"group_id",
+	"env_id",
+	"name",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/env-variables
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/env-variables/{env_variable_id}
@@ -31,6 +40,8 @@ func ResourceEnvironmentVariable() *schema.Resource {
 			StateContext: resourceEnvironmentVariableResourceImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(environmentVariableNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -42,31 +53,39 @@ func ResourceEnvironmentVariable() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specifies the ID of the dedicated instance to which the environment variable belongs.",
 			},
 			"group_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specifies the ID of the group to which the environment variable belongs.",
 			},
 			"env_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specifies the ID of the environment to which the environment variable belongs.",
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specifies the name of the environment variable.",
 			},
 			"value": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Specifies the value of the environment variable.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -129,15 +148,17 @@ func resourceEnvironmentVariableUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	variableId := d.Id()
-	opt := environments.UpdateVariableOpts{
-		InstanceId: d.Get("instance_id").(string),
-		VariableId: variableId,
-		Value:      d.Get("value").(string),
-	}
-	_, err = environments.UpdateVariable(client, opt).Extract()
-	if err != nil {
-		return diag.Errorf("error updating dedicated environment variable (%s): %s", variableId, err)
+	if d.HasChange("value") {
+		variableId := d.Id()
+		opt := environments.UpdateVariableOpts{
+			InstanceId: d.Get("instance_id").(string),
+			VariableId: variableId,
+			Value:      d.Get("value").(string),
+		}
+		_, err = environments.UpdateVariable(client, opt).Extract()
+		if err != nil {
+			return diag.Errorf("error updating dedicated environment variable (%s): %s", variableId, err)
+		}
 	}
 
 	return resourceEnvironmentVariableRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups"
@@ -18,6 +19,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var apigGroupV2NonUpdatableParams = []string{
+	"instance_id",
+}
 
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/env-variables
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/env-variables
@@ -42,6 +47,8 @@ func ResourceApigGroupV2() *schema.Resource {
 			StateContext: resourceGroupResourceImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(apigGroupV2NonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -53,7 +60,6 @@ func ResourceApigGroupV2() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the group belongs.",
 			},
 			"name": {
@@ -201,6 +207,18 @@ func ResourceApigGroupV2() *schema.Resource {
 						Deprecated: true,
 					},
 				),
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -21,6 +22,15 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var apigInstanceV2NonUpdatableParams = []string{
+	"vpc_id",
+	"subnet_id",
+	"availability_zones",
+	"ipv6_enable",
+	"available_zones",
+	"loadbalancer_provider",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}
@@ -58,7 +68,10 @@ func ResourceApigInstanceV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		CustomizeDiff: config.MergeDefaultTags(),
+		CustomizeDiff: customdiff.All(
+			config.FlexibleForceNew(apigInstanceV2NonUpdatableParams),
+			config.MergeDefaultTags(),
+		),
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -81,13 +94,11 @@ func ResourceApigInstanceV2() *schema.Resource {
 			"vpc_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the VPC used to create the dedicated instance.`,
 			},
 			"subnet_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the VPC subnet used to create the dedicated instance.`,
 			},
 			"security_group_id": {
@@ -99,7 +110,6 @@ func ResourceApigInstanceV2() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `schema: Required; The name list of availability zones for the dedicated instance.`,
 			},
@@ -123,7 +133,6 @@ func ResourceApigInstanceV2() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
 				Description: `Whether public access with an IPv6 address is supported.`,
 			},
 			"elb_ids": {
@@ -236,7 +245,6 @@ func ResourceApigInstanceV2() *schema.Resource {
 			"available_zones": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `schema: Deprecated; The name list of availability zones for the dedicated instance.`,
 			},
@@ -263,11 +271,22 @@ func ResourceApigInstanceV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				Description: utils.SchemaDesc(
 					`The type of loadbalancer provider used by the instance.`,
 					utils.SchemaDescInput{
 						Computed: true,
+					}),
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
 					}),
 			},
 		},

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
@@ -20,6 +21,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var instanceFeatureNonUpdatableParams = []string{
+	"instance_id",
+	"name",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/features
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/features
@@ -38,6 +44,8 @@ func ResourceInstanceFeature() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(instanceFeatureNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -48,13 +56,11 @@ func ResourceInstanceFeature() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specified the ID of the dedicated instance to which the feature belongs.",
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Specified the name of the feature.",
 			},
 			"enabled": {
@@ -67,6 +73,18 @@ func ResourceInstanceFeature() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Specified the detailed configuration of the feature.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -234,9 +252,11 @@ func resourceInstanceFeatureUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	_, err = updateFeatureConfiguration(ctx, client, d, instanceId, featureName)
-	if err != nil {
-		return diag.Errorf("error updating feature (%s) under specified instance (%s): %s", featureName, instanceId, err)
+	if d.HasChangeExcept("enable_force_new") {
+		_, err = updateFeatureConfiguration(ctx, client, d, instanceId, featureName)
+		if err != nil {
+			return diag.Errorf("error updating feature (%s) under specified instance (%s): %s", featureName, instanceId, err)
+		}
 	}
 
 	return resourceInstanceFeatureRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances"
@@ -20,6 +21,10 @@ import (
 
 type featureConfig struct {
 	UserRoutes []interface{} `json:"user_routes"`
+}
+
+var instanceRoutesNonUpdatableParams = []string{
+	"instance_id",
 }
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/features
@@ -35,6 +40,8 @@ func ResourceInstanceRoutes() *schema.Resource {
 			StateContext: resourceInstanceRoutesImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(instanceRoutesNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -46,7 +53,6 @@ func ResourceInstanceRoutes() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the routes belong.",
 			},
 			"nexthops": {
@@ -54,6 +60,18 @@ func ResourceInstanceRoutes() *schema.Resource {
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The configuration of the next hop routes.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -99,6 +117,35 @@ func resourceInstanceRoutesCreate(ctx context.Context, d *schema.ResourceData, m
 	return resourceInstanceRoutesRead(ctx, d, meta)
 }
 
+func ListInstanceRoutes(client *golangsdk.ServiceClient, instanceId string) ([]interface{}, error) {
+	opts := instances.ListFeaturesOpts{
+		// Default value of parameter 'limit' is 20, parameter 'offset' is an invalid parameter.
+		// If we omit it, we can only obtain 20 features, other features will be lost.
+		Limit: 500,
+	}
+	resp, err := instances.ListFeatures(client, instanceId, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var routeConfig string
+	for _, val := range resp {
+		if val.Name == "route" {
+			routeConfig = val.Config
+			break
+		}
+	}
+
+	result := utils.StringToJson(routeConfig)
+	userRoutes := utils.PathSearch("user_routes", result, make([]interface{}, 0)).([]interface{})
+	if len(userRoutes) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	// UserRoutes also means nexthops.
+	return userRoutes, nil
+}
+
 func resourceInstanceRoutesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -108,36 +155,14 @@ func resourceInstanceRoutesRead(_ context.Context, d *schema.ResourceData, meta 
 	}
 
 	instanceId := d.Get("instance_id").(string)
-	opts := instances.ListFeaturesOpts{
-		// Default value of parameter 'limit' is 20, parameter 'offset' is an invalid parameter.
-		// If we omit it, we can only obtain 20 features, other features will be lost.
-		Limit: 500,
-	}
-	resp, err := instances.ListFeatures(client, instanceId, opts)
+	nexthops, err := ListInstanceRoutes(client, instanceId)
 	if err != nil {
-		return diag.Errorf("error querying feature list: %s", err)
-	}
-	log.Printf("[DEBUG] The feature list is: %v", resp)
-
-	var routeConfig string
-	for _, val := range resp {
-		if val.Name == "route" {
-			routeConfig = val.Config
-			break
-		}
-	}
-	var result featureConfig
-	err = json.Unmarshal([]byte(routeConfig), &result)
-	if err != nil {
-		return diag.Errorf("error analyzing routes configuration: %s", err)
-	}
-	if len(result.UserRoutes) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "Instance routes")
+		return common.CheckDeletedDiag(d, err, "error getting instance routes")
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("nexthops", result.UserRoutes),
+		d.Set("nexthops", nexthops),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())
 }
@@ -149,12 +174,14 @@ func resourceInstanceRoutesUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating APIG V2 client: %s", err)
 	}
 
-	var (
-		instanceId = d.Get("instance_id").(string)
-		routes     = d.Get("nexthops").(*schema.Set)
-	)
-	if err := modifyInstanceRoutes(client, instanceId, routes.List()); err != nil {
-		return diag.Errorf("error updating instance routes: %v", err)
+	if d.HasChange("nexthops") {
+		var (
+			instanceId = d.Get("instance_id").(string)
+			routes     = d.Get("nexthops").(*schema.Set)
+		)
+		if err := modifyInstanceRoutes(client, instanceId, routes.List()); err != nil {
+			return diag.Errorf("error updating instance routes: %v", err)
+		}
 	}
 
 	return resourceInstanceRoutesRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_orchestration_rule.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_orchestration_rule.go
@@ -17,6 +17,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var orchestrationRuleNonUpdatableParams = []string{
+	"instance_id",
+	"is_preprocessing",
+	"mapped_param",
+}
+
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/orchestrations
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}
@@ -32,6 +38,8 @@ func ResourceOrchestrationRule() *schema.Resource {
 			StateContext: resourceOrchestrationRuleImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(orchestrationRuleNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -43,7 +51,6 @@ func ResourceOrchestrationRule() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the orchestration rule belongs.",
 			},
 			"name": {
@@ -59,13 +66,11 @@ func ResourceOrchestrationRule() *schema.Resource {
 			"is_preprocessing": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Whether rule is a preprocessing rule.",
 			},
 			"mapped_param": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Description:  "The parameter configuration after orchestration, in JSON format.",
 				ValidateFunc: validation.StringIsJSON,
 			},
@@ -87,6 +92,18 @@ func ResourceOrchestrationRule() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The latest update time of the orchestration rule, in RFC3339 format.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -219,18 +236,12 @@ func resourceOrchestrationRuleRead(_ context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceOrchestrationRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateOrchestrationRule(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	var (
-		cfg             = meta.(*config.Config)
-		region          = cfg.GetRegion(d)
 		httpUrl         = "v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}"
 		instanceId      = d.Get("instance_id").(string)
 		orchestrationId = d.Id()
 	)
-	client, err := cfg.NewServiceClient("apig", region)
-	if err != nil {
-		return diag.Errorf("error creating APIG client: %s", err)
-	}
 
 	updatePath := client.Endpoint + httpUrl
 	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
@@ -242,9 +253,27 @@ func resourceOrchestrationRuleUpdate(ctx context.Context, d *schema.ResourceData
 		JSONBody:         utils.RemoveNil(buildOrchestrationRuleModifyBodyParams(d)),
 	}
 
-	_, err = client.Request("PUT", updatePath, &opt)
+	_, err := client.Request("PUT", updatePath, &opt)
 	if err != nil {
-		return diag.Errorf("error updating orchestration rule under dedicated instance (%s): %s", instanceId, err)
+		return fmt.Errorf("error updating orchestration rule under dedicated instance (%s): %s", instanceId, err)
+	}
+	return nil
+}
+
+func resourceOrchestrationRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		if err := updateOrchestrationRule(client, d); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceOrchestrationRuleRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_plugin.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_plugin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins"
 
@@ -17,6 +18,12 @@ import (
 )
 
 // ResourcePlugin defines the provider resource of the APIG plugin.
+
+var pluginNonUpdatableParams = []string{
+	"instance_id",
+	"type",
+}
+
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instanceId}/plugins/{plugin_id}
 // @API APIG GET /v2/{project_id}/apigw/instances/{instanceId}/plugins/{plugin_id}
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instanceId}/plugins/{plugin_id}
@@ -32,6 +39,8 @@ func ResourcePlugin() *schema.Resource {
 			StateContext: resourcePluginImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(pluginNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -43,7 +52,6 @@ func ResourcePlugin() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the plugin belongs.",
 			},
 			"name": {
@@ -54,7 +62,6 @@ func ResourcePlugin() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The plugin type.",
 			},
 			"content": {
@@ -80,6 +87,18 @@ func ResourcePlugin() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The latest update time of the plugin.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -146,22 +165,24 @@ func resourcePluginUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		pluginId = d.Id()
-		opts     = plugins.UpdateOpts{
-			InstanceId:  d.Get("instance_id").(string),
-			ID:          pluginId,
-			Name:        d.Get("name").(string),
-			Type:        d.Get("type").(string),
-			Scope:       "global",
-			Content:     d.Get("content").(string),
-			Description: utils.String(d.Get("description").(string)),
-		}
-	)
+	if d.HasChangeExcept("enable_force_new") {
+		var (
+			pluginId = d.Id()
+			opts     = plugins.UpdateOpts{
+				InstanceId:  d.Get("instance_id").(string),
+				ID:          pluginId,
+				Name:        d.Get("name").(string),
+				Type:        d.Get("type").(string),
+				Scope:       "global",
+				Content:     d.Get("content").(string),
+				Description: utils.String(d.Get("description").(string)),
+			}
+		)
 
-	_, err = plugins.Update(client, opts)
-	if err != nil {
-		return diag.Errorf("error updating the plugin (%s): %s", pluginId, err)
+		_, err = plugins.Update(client, opts)
+		if err != nil {
+			return diag.Errorf("error updating the plugin (%s): %s", pluginId, err)
+		}
 	}
 
 	return resourcePluginRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_plugin_batch_apis_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_plugin_batch_apis_associate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -21,6 +22,13 @@ import (
 var strSliceParamKeysForPluginBatchApisAssociate = []string{"api_ids"}
 
 // ResourcePluginBatchApisAssociate defines the provider resource of the APIG plugin binding.
+
+var pluginBatchApisAssociateNonUpdatableParams = []string{
+	"instance_id",
+	"plugin_id",
+	"env_id",
+}
+
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/detach
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attached-apis
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attach
@@ -35,6 +43,8 @@ func ResourcePluginBatchApisAssociate() *schema.Resource {
 			StateContext: resourcePluginBatchApisAssociateImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(pluginBatchApisAssociateNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -46,19 +56,16 @@ func ResourcePluginBatchApisAssociate() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the plugin belongs.",
 			},
 			"plugin_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The plugin ID.",
 			},
 			"env_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The environment ID where the API was published.",
 			},
 			"api_ids": {
@@ -81,6 +88,18 @@ the new value next time the change is made. The corresponding parameter name is 
 						Internal: true,
 					},
 				),
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -336,6 +355,7 @@ func unbindPluginFromApis(client *golangsdk.ServiceClient, instanceId, pluginId,
 	return mErr.ErrorOrNil()
 }
 
+// nolint:gocyclo
 func resourcePluginBatchApisAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
@@ -343,50 +363,52 @@ func resourcePluginBatchApisAssociateUpdate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		resourceId = d.Id()
-		instanceId = d.Get("instance_id").(string)
-		pluginId   = d.Get("plugin_id").(string)
-		envId      = d.Get("env_id").(string)
+	if d.HasChange("api_ids") {
+		var (
+			resourceId = d.Id()
+			instanceId = d.Get("instance_id").(string)
+			pluginId   = d.Get("plugin_id").(string)
+			envId      = d.Get("env_id").(string)
 
-		consoleApiIds, scriptApiIds = d.GetChange("api_ids")
+			consoleApiIds, scriptApiIds = d.GetChange("api_ids")
 
-		consoleApiIdsList = consoleApiIds.(*schema.Set).List()
-		scriptApiIdsList  = scriptApiIds.(*schema.Set).List()
-		originApiIdsList  = d.Get("api_ids_origin").([]interface{})
-	)
+			consoleApiIdsList = consoleApiIds.(*schema.Set).List()
+			scriptApiIdsList  = scriptApiIds.(*schema.Set).List()
+			originApiIdsList  = d.Get("api_ids_origin").([]interface{})
+		)
 
-	// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
-	// failed)
-	config.MutexKV.Lock(resourceId)
-	defer config.MutexKV.Unlock(resourceId)
+		// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
+		// failed)
+		config.MutexKV.Lock(resourceId)
+		defer config.MutexKV.Unlock(resourceId)
 
-	newApiIds := utils.FindSliceElementsNotInAnother(scriptApiIdsList, consoleApiIdsList)
-	rmApiIds := utils.FindSliceElementsNotInAnother(originApiIdsList, scriptApiIdsList)
+		newApiIds := utils.FindSliceElementsNotInAnother(scriptApiIdsList, consoleApiIdsList)
+		rmApiIds := utils.FindSliceElementsNotInAnother(originApiIdsList, scriptApiIdsList)
 
-	if len(rmApiIds) > 0 {
-		log.Printf("[DEBUG] Prepare to unbind the specified API IDs: %v", rmApiIds)
-		err := unbindPluginFromApis(client, instanceId, pluginId, envId, rmApiIds)
-		if err != nil {
-			return diag.FromErr(err)
+		if len(rmApiIds) > 0 {
+			log.Printf("[DEBUG] Prepare to unbind the specified API IDs: %v", rmApiIds)
+			err := unbindPluginFromApis(client, instanceId, pluginId, envId, rmApiIds)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
 
-	if len(newApiIds) > 0 {
-		log.Printf("[DEBUG] Prepare to bind the specified API IDs: %v", newApiIds)
-		err = bindPluginToApis(client, instanceId, pluginId, envId, newApiIds)
-		if err != nil {
-			return diag.FromErr(err)
+		if len(newApiIds) > 0 {
+			log.Printf("[DEBUG] Prepare to bind the specified API IDs: %v", newApiIds)
+			err = bindPluginToApis(client, instanceId, pluginId, envId, newApiIds)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
 
-	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
-	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
-	// And whether corresponding parameters are changed, the origin values must be refreshed.
-	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForPluginBatchApisAssociate)
-	if err != nil {
-		// Don't fail the update if origin refresh fails
-		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
+		// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+		// And whether corresponding parameters are changed, the origin values must be refreshed.
+		err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForPluginBatchApisAssociate)
+		if err != nil {
+			// Don't fail the update if origin refresh fails
+			log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		}
 	}
 
 	return resourcePluginBatchApisAssociateRead(ctx, d, meta)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/responses"
 
@@ -15,6 +16,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var apigResponseV2NonUpdatableParams = []string{
+	"instance_id",
+	"group_id",
+}
 
 // @API APIG GET /v2/{project_id}/apigw/instances/{instanceId}/api-groups/{group_id}/gateway-responses/{response_id}
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instanceId}/api-groups/{group_id}/gateway-responses/{response_id}
@@ -32,6 +38,8 @@ func ResourceApigResponseV2() *schema.Resource {
 			StateContext: resourceCustomResponseImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(apigResponseV2NonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -43,14 +51,12 @@ func ResourceApigResponseV2() *schema.Resource {
 			"instance_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 				Description: "The ID of the dedicated instance to which the API group and the API custom response " +
 					"belongs.",
 			},
 			"group_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the API group to which the API custom response belongs.",
 			},
 			"name": {
@@ -113,6 +119,18 @@ func ResourceApigResponseV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The latest update time of the API custom response.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -247,18 +265,22 @@ func resourceResponseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
-	// Only updating the name will cause all the response rules that have been set to be reset, so no matter whether
-	// the response rules are updated or not, the response rules must be carried in the update opt.
-	opt := responses.ResponseOpts{
-		InstanceId: d.Get("instance_id").(string),
-		GroupId:    d.Get("group_id").(string),
-		Name:       d.Get("name").(string),
-		Responses:  buildCustomResponses(d.Get("rule").(*schema.Set)),
+
+	if d.HasChangeExcept("enable_force_new") {
+		// Only updating the name will cause all the response rules that have been set to be reset, so no matter whether
+		// the response rules are updated or not, the response rules must be carried in the update opt.
+		opt := responses.ResponseOpts{
+			InstanceId: d.Get("instance_id").(string),
+			GroupId:    d.Get("group_id").(string),
+			Name:       d.Get("name").(string),
+			Responses:  buildCustomResponses(d.Get("rule").(*schema.Set)),
+		}
+		_, err = responses.Update(client, d.Id(), opt).Extract()
+		if err != nil {
+			return diag.Errorf("error updating APIG custom response: %s", err)
+		}
 	}
-	_, err = responses.Update(client, d.Id(), opt).Extract()
-	if err != nil {
-		return diag.Errorf("error updating APIG custom response: %s", err)
-	}
+
 	return resourceResponseRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_signature.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_signature.go
@@ -9,15 +9,22 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/signs"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // ResourceSignature is a provider resource of the APIG signature.
+
+var signatureNonUpdatableParams = []string{
+	"instance_id",
+}
+
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/signs/{sign_id}
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/signs/{sign_id}
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/signs
@@ -33,6 +40,8 @@ func ResourceSignature() *schema.Resource {
 			StateContext: resourceSignatureImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(signatureNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -44,7 +53,6 @@ func ResourceSignature() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the signature belongs.",
 			},
 			"name": {
@@ -85,6 +93,18 @@ func ResourceSignature() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The latest update time of the signature.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -163,22 +183,25 @@ func resourceSignatureUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		signatureId = d.Id()
-		opts        = signs.UpdateOpts{
-			InstanceId:    d.Get("instance_id").(string),
-			SignatureId:   signatureId,
-			Name:          d.Get("name").(string),
-			SignType:      d.Get("type").(string),
-			SignKey:       d.Get("key").(string),
-			SignSecret:    d.Get("secret").(string),
-			SignAlgorithm: d.Get("algorithm").(string),
+	if d.HasChangeExcept("enable_force_new") {
+		var (
+			signatureId = d.Id()
+			opts        = signs.UpdateOpts{
+				InstanceId:    d.Get("instance_id").(string),
+				SignatureId:   signatureId,
+				Name:          d.Get("name").(string),
+				SignType:      d.Get("type").(string),
+				SignKey:       d.Get("key").(string),
+				SignSecret:    d.Get("secret").(string),
+				SignAlgorithm: d.Get("algorithm").(string),
+			}
+		)
+		_, err = signs.Update(client, opts)
+		if err != nil {
+			return diag.Errorf("error updating the signature (%s): %s", signatureId, err)
 		}
-	)
-	_, err = signs.Update(client, opts)
-	if err != nil {
-		return diag.Errorf("error updating the signature (%s): %s", signatureId, err)
 	}
+
 	return resourceSignatureRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_signature_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_signature_associate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/signs"
@@ -21,6 +22,12 @@ import (
 )
 
 // ResourceSignatureAssociate is a provider resource of the API signature.
+
+var signatureAssociateNonUpdatableParams = []string{
+	"instance_id",
+	"signature_id",
+}
+
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/sign-bindings
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/sign-bindings/unbinded-apis
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/sign-bindings/binded-apis
@@ -42,6 +49,8 @@ func ResourceSignatureAssociate() *schema.Resource {
 			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(signatureAssociateNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -53,13 +62,11 @@ func ResourceSignatureAssociate() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the APIs and the signature belong.",
 			},
 			"signature_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The signature ID for APIs binding.",
 			},
 			"publish_ids": {
@@ -67,6 +74,18 @@ func ResourceSignatureAssociate() *schema.Resource {
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The publish IDs corresponding to the APIs bound by the signature.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -298,32 +317,34 @@ func resourceSignatureAssociateUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		instanceId     = d.Get("instance_id").(string)
-		signId         = d.Get("signature_id").(string)
-		oldRaw, newRaw = d.GetChange("publish_ids")
+	if d.HasChange("publish_ids") {
+		var (
+			instanceId     = d.Get("instance_id").(string)
+			signId         = d.Get("signature_id").(string)
+			oldRaw, newRaw = d.GetChange("publish_ids")
 
-		addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
-		rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
-	)
+			addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
+			rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
+		)
 
-	if rmSet.Len() > 0 {
-		err = unbindSignatureFromApis(ctx, client, d, utils.ExpandToStringListBySet(rmSet),
-			d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
+		if rmSet.Len() > 0 {
+			err = unbindSignatureFromApis(ctx, client, d, utils.ExpandToStringListBySet(rmSet),
+				d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
-	if addSet.Len() > 0 {
-		opts := signs.BindOpts{
-			InstanceId:  instanceId,
-			SignatureId: signId,
-			PublishIds:  utils.ExpandToStringListBySet(addSet),
-		}
-		// If the target (published) API already has a signature, this update will replace the signature.
-		err = bindSignatureToApis(ctx, client, opts, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
+		if addSet.Len() > 0 {
+			opts := signs.BindOpts{
+				InstanceId:  instanceId,
+				SignatureId: signId,
+				PublishIds:  utils.ExpandToStringListBySet(addSet),
+			}
+			// If the target (published) API already has a signature, this update will replace the signature.
+			err = bindSignatureToApis(ctx, client, opts, d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/throttles"
@@ -36,6 +37,11 @@ var (
 )
 
 // ResourceApigThrottlingPolicyV2 is a provider resource of the APIG throttling policy.
+
+var apigThrottlingPolicyV2NonUpdatableParams = []string{
+	"instance_id",
+}
+
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/throttles/{throttle_id}/throttle-specials
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/throttles/{throttle_id}/throttle-specials
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/throttles/{throttle_id}
@@ -56,6 +62,8 @@ func ResourceApigThrottlingPolicyV2() *schema.Resource {
 			StateContext: resourceThrottlingPolicyImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(apigThrottlingPolicyV2NonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -67,7 +75,6 @@ func ResourceApigThrottlingPolicyV2() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the throttling policy belongs.",
 			},
 			"name": {
@@ -136,6 +143,18 @@ func ResourceApigThrottlingPolicyV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The creation time of the throttling policy.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -418,7 +437,7 @@ func resourceThrottlingPolicyUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	if d.HasChangesExcept("user_throttles", "app_throttles") {
+	if d.HasChangesExcept("user_throttles", "app_throttles", "enable_force_new") {
 		opt, err := buildThrottlingPolicyOpts(d)
 		if err != nil {
 			return diag.Errorf("unable to get the update option of the throttling policy: %s", err)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/throttles"
@@ -19,6 +20,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var throttlingPolicyAssociateNonUpdatableParams = []string{
+	"instance_id",
+	"policy_id",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/throttle-bindings
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/throttle-bindings/unbinded-apis
@@ -41,6 +47,8 @@ func ResourceThrottlingPolicyAssociate() *schema.Resource {
 			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(throttlingPolicyAssociateNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -52,13 +60,11 @@ func ResourceThrottlingPolicyAssociate() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the APIs and the throttling policy belongs.",
 			},
 			"policy_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "The ID of the throttling policy.",
 			},
 			"publish_ids": {
@@ -66,6 +72,18 @@ func ResourceThrottlingPolicyAssociate() *schema.Resource {
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The publish IDs corresponding to the APIs bound by the throttling policy.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
@@ -332,31 +350,33 @@ func resourceThrottlingPolicyAssociateUpdate(ctx context.Context, d *schema.Reso
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	var (
-		instanceId     = d.Get("instance_id").(string)
-		policyId       = d.Get("policy_id").(string)
-		oldRaw, newRaw = d.GetChange("publish_ids")
+	if d.HasChange("publish_ids") {
+		var (
+			instanceId     = d.Get("instance_id").(string)
+			policyId       = d.Get("policy_id").(string)
+			oldRaw, newRaw = d.GetChange("publish_ids")
 
-		addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
-		rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
-	)
+			addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
+			rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
+		)
 
-	if rmSet.Len() > 0 {
-		opt := buildListOpts(instanceId, policyId)
-		err = unbindPolicy(ctx, client, opt, rmSet, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
+		if rmSet.Len() > 0 {
+			opt := buildListOpts(instanceId, policyId)
+			err = unbindPolicy(ctx, client, opt, rmSet, d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
-	}
-	if addSet.Len() > 0 {
-		opt := throttles.BindOpts{
-			InstanceId: instanceId,
-			ThrottleId: policyId,
-			PublishIds: utils.ExpandToStringListBySet(addSet),
-		}
-		err = bindThrottlingPolicyToApis(ctx, client, opt, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
+		if addSet.Len() > 0 {
+			opt := throttles.BindOpts{
+				InstanceId: instanceId,
+				ThrottleId: policyId,
+				PublishIds: utils.ExpandToStringListBySet(addSet),
+			}
+			err = bindThrottlingPolicyToApis(ctx, client, opt, d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Add the internal `enable_force_new` parameter to APIG resources and switch non-updatable fields from hardcoded `ForceNew` to `config.FlexibleForceNew`.
- Skip Update API calls when only `enable_force_new` changes (`HasChangeExcept("enable_force_new")`).
- Affected resources include ACL policy/associate, API publishment, application ACL/authorization/quota/quota associate, certificate, channel, custom authorizer, endpoint connection management/whitelist, environment/variable, group, instance/feature/routes, orchestration rule, plugin/batch APIs associate, response, signature/associate, and throttling policy/associate.
- Also expose `orchestrations` on `huaweicloud_apig_api` data source `request_params`, and adjust related acceptance tests (API publishment authorizer refs / function URN; instance routes to use dedicated instance env).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
resources support enable_force_new parameter
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccAclPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccAclPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccAclPolicy_basic
=== PAUSE TestAccAclPolicy_basic
=== CONT  TestAccAclPolicy_basic
--- PASS: TestAccAclPolicy_basic (58.96s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      59.104s coverage: 2.7% of statements in ./huaweicloud/services/apig
```
<img width="2228" height="1327" alt="image" src="https://github.com/user-attachments/assets/77999de2-1c37-45a8-98c5-7577ff3858fe" />
<img width="2198" height="1325" alt="image" src="https://github.com/user-attachments/assets/353c6264-56d1-4a11-98e3-52553bb594fa" />

```
./scripts/coverage.sh -o apig -f TestAccAclPolicyAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccAclPolicyAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccAclPolicyAssociate_basic
=== PAUSE TestAccAclPolicyAssociate_basic
=== CONT  TestAccAclPolicyAssociate_basic
--- PASS: TestAccAclPolicyAssociate_basic (231.11s)
PASS
coverage: 11.0% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      231.253s        coverage: 11.0% of statements in ./huaweicloud/services/apig
```
<img width="2247" height="1331" alt="image" src="https://github.com/user-attachments/assets/d303ed4b-b2dd-4de4-90aa-47704050f1e3" />
<img width="2226" height="1325" alt="image" src="https://github.com/user-attachments/assets/5d888171-e160-4e38-86a3-7398637c5a07" />

```
./scripts/coverage.sh -o apig -f TestAccApiPublishment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApiPublishment_basic -timeout 360m -parallel 10
=== RUN   TestAccApiPublishment_basic
=== PAUSE TestAccApiPublishment_basic
=== CONT  TestAccApiPublishment_basic
--- PASS: TestAccApiPublishment_basic (206.26s)
PASS
coverage: 12.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      206.423s        coverage: 12.2% of statements in ./huaweicloud/services/apig
```
<img width="2233" height="1328" alt="image" src="https://github.com/user-attachments/assets/1b069691-3d87-4f85-88a0-039335b1746e" />
<img width="2242" height="1329" alt="image" src="https://github.com/user-attachments/assets/66b88bd4-d197-452b-9151-3eeabc8f91cd" />

```
./scripts/coverage.sh -o apig -f TestAccApplicationAcl_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApplicationAcl_basic -timeout 360m -parallel 10
=== RUN   TestAccApplicationAcl_basic
=== PAUSE TestAccApplicationAcl_basic
=== CONT  TestAccApplicationAcl_basic
--- PASS: TestAccApplicationAcl_basic (124.30s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      124.442s        coverage: 4.0% of statements in ./huaweicloud/services/apig
```
<img width="2250" height="1326" alt="image" src="https://github.com/user-attachments/assets/3960a5e0-7153-45e8-bc8d-8078f224fbbd" />
<img width="2161" height="1324" alt="image" src="https://github.com/user-attachments/assets/31a7b60d-0cfb-4b45-ba71-e05edb8cd39f" />

```
./scripts/coverage.sh -o apig -f TestAccApplicationAuthorization_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApplicationAuthorization_basic -timeout 360m -parallel 10
=== RUN   TestAccApplicationAuthorization_basic
=== PAUSE TestAccApplicationAuthorization_basic
=== CONT  TestAccApplicationAuthorization_basic
--- PASS: TestAccApplicationAuthorization_basic (318.50s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      318.635s        coverage: 9.8% of statements in ./huaweicloud/services/apig
```
<img width="2234" height="1326" alt="image" src="https://github.com/user-attachments/assets/83db4e4e-76a0-4462-8f2a-d5b6a4bd64be" />
<img width="2223" height="1328" alt="image" src="https://github.com/user-attachments/assets/fac2756b-b569-4715-a32d-e664b6bbf7a7" />

```
./scripts/coverage.sh -o apig -f TestAccResourceAppQuota_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccResourceAppQuota_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppQuota_basic
=== PAUSE TestAccResourceAppQuota_basic
=== CONT  TestAccResourceAppQuota_basic
--- PASS: TestAccResourceAppQuota_basic (56.79s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      56.924s coverage: 4.2% of statements in ./huaweicloud/services/apig
```
<img width="2182" height="1318" alt="image" src="https://github.com/user-attachments/assets/5cfc9ab8-19b2-4bf8-a56d-fd2755709029" />
<img width="2197" height="1318" alt="image" src="https://github.com/user-attachments/assets/172a8c99-d87d-4720-b344-0d9d49b6c98b" />

```
./scripts/coverage.sh -o apig -f TestAccApplicationQuotaAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApplicationQuotaAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccApplicationQuotaAssociate_basic
=== PAUSE TestAccApplicationQuotaAssociate_basic
=== CONT  TestAccApplicationQuotaAssociate_basic
--- PASS: TestAccApplicationQuotaAssociate_basic (112.77s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      112.914s        coverage: 5.8% of statements in ./huaweicloud/services/apig
```
<img width="2202" height="1317" alt="image" src="https://github.com/user-attachments/assets/6921b363-31fc-482b-a8df-3f2b213e72b9" />
<img width="2213" height="1324" alt="image" src="https://github.com/user-attachments/assets/57d76216-d8ee-47a2-ae21-a2ad74e4658e" />

```
./scripts/coverage.sh -o apig -f TestAccChannel_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccChannel_basic -timeout 360m -parallel 10
=== RUN   TestAccChannel_basic
=== PAUSE TestAccChannel_basic
=== CONT  TestAccChannel_basic
--- PASS: TestAccChannel_basic (266.98s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      267.112s        coverage: 3.5% of statements in ./huaweicloud/services/apig
```
<img width="2135" height="1324" alt="image" src="https://github.com/user-attachments/assets/2a2c286c-9e3c-43c7-a8b1-cfc9e41861de" />
<img width="2230" height="1329" alt="image" src="https://github.com/user-attachments/assets/a278ea0a-ced8-4e38-94cd-e468a021909d" />

```
./scripts/coverage.sh -o apig -f TestAccCustomAuthorizer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccCustomAuthorizer_basic -timeout 360m -parallel 10
=== RUN   TestAccCustomAuthorizer_basic
=== PAUSE TestAccCustomAuthorizer_basic
=== CONT  TestAccCustomAuthorizer_basic
--- PASS: TestAccCustomAuthorizer_basic (42.85s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      43.002s coverage: 3.1% of statements in ./huaweicloud/services/apig
```
<img width="2234" height="1328" alt="image" src="https://github.com/user-attachments/assets/e2ae256d-bed6-4bbb-baa5-49e9d6afa3ef" />
<img width="2234" height="1325" alt="image" src="https://github.com/user-attachments/assets/488a07ad-c926-462a-bf97-d04bff93e57b" />

```
./scripts/coverage.sh -o apig -f TestAccEndpointWhiteList_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccEndpointWhiteList_basic -timeout 360m -parallel 10
=== RUN   TestAccEndpointWhiteList_basic
=== PAUSE TestAccEndpointWhiteList_basic
=== CONT  TestAccEndpointWhiteList_basic
--- PASS: TestAccEndpointWhiteList_basic (23.49s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      23.618s coverage: 2.3% of statements in ./huaweicloud/services/apig
```
<img width="2165" height="1321" alt="image" src="https://github.com/user-attachments/assets/6cbaf3e6-4770-4201-8252-ac72208b2c40" />
<img width="2198" height="1327" alt="image" src="https://github.com/user-attachments/assets/b48996b9-7456-4371-b0f0-d2fee8631f2e" />

```
./scripts/coverage.sh -o apig -f TestAccEnvironment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccEnvironment_basic -timeout 360m -parallel 10
=== RUN   TestAccEnvironment_basic
=== PAUSE TestAccEnvironment_basic
=== CONT  TestAccEnvironment_basic
--- PASS: TestAccEnvironment_basic (38.45s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      38.610s coverage: 2.3% of statements in ./huaweicloud/services/apig
```
<img width="2247" height="1332" alt="image" src="https://github.com/user-attachments/assets/8e03f0b9-db30-4a1c-a235-10987178aba7" />
<img width="2233" height="1329" alt="image" src="https://github.com/user-attachments/assets/67680323-0c13-40c5-bcf1-69e4fd415baa" />

```
./scripts/coverage.sh -o apig -f TestAccEnvironmentVariable_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccEnvironmentVariable_basic -timeout 360m -parallel 10
=== RUN   TestAccEnvironmentVariable_basic
=== PAUSE TestAccEnvironmentVariable_basic
=== CONT  TestAccEnvironmentVariable_basic
--- PASS: TestAccEnvironmentVariable_basic (52.58s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      52.715s coverage: 4.2% of statements in ./huaweicloud/services/apig
```
<img width="2235" height="1326" alt="image" src="https://github.com/user-attachments/assets/e99e73b3-e19b-4669-8fde-ee60889e039f" />
<img width="2237" height="1327" alt="image" src="https://github.com/user-attachments/assets/4515a1a1-4e10-4fd2-b723-de092af97590" />

```
./scripts/coverage.sh -o apig -f TestAccGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccGroup_basic
=== PAUSE TestAccGroup_basic
=== CONT  TestAccGroup_basic
--- PASS: TestAccGroup_basic (40.50s)
PASS
coverage: 2.4% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      40.633s coverage: 2.4% of statements in ./huaweicloud/services/apig
```
<img width="2228" height="1327" alt="image" src="https://github.com/user-attachments/assets/88b9a061-7785-4604-944d-71fee5d97c9e" />
<img width="2226" height="1324" alt="image" src="https://github.com/user-attachments/assets/8ad00d6a-359d-4f6c-81f4-0980d41f186d" />

```
./scripts/coverage.sh -o apig -f TestAccInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (1209.75s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      1209.883s       coverage: 5.1% of statements in ./huaweicloud/services/apig
```
<img width="2241" height="1319" alt="image" src="https://github.com/user-attachments/assets/200f872f-173e-44d2-8687-efd0e079592c" />
<img width="2237" height="1321" alt="image" src="https://github.com/user-attachments/assets/df5a0d06-8677-4241-8114-11932496e87a" />

```
./scripts/coverage.sh -o apig -f TestAccInstanceFeature_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccInstanceFeature_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceFeature_basic
=== PAUSE TestAccInstanceFeature_basic
=== CONT  TestAccInstanceFeature_basic
--- PASS: TestAccInstanceFeature_basic (29.58s)
PASS
coverage: 2.5% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      29.721s coverage: 2.5% of statements in ./huaweicloud/services/apig
```
<img width="2219" height="1330" alt="image" src="https://github.com/user-attachments/assets/a25a1ba9-7608-4de6-83c7-dceebfc167ef" />
<img width="2249" height="1322" alt="image" src="https://github.com/user-attachments/assets/ddb72081-d574-4e18-991b-905d16d76fff" />

```
./scripts/coverage.sh -o apig -f TestAccInstanceRoutes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccInstanceRoutes_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceRoutes_basic
=== PAUSE TestAccInstanceRoutes_basic
=== CONT  TestAccInstanceRoutes_basic
--- PASS: TestAccInstanceRoutes_basic (63.84s)
PASS
coverage: 2.9% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      63.981s coverage: 2.9% of statements in ./huaweicloud/services/apig
```
<img width="2234" height="1322" alt="image" src="https://github.com/user-attachments/assets/a580e1b8-6199-42b2-bdc6-a69324b1b580" />
<img width="2239" height="1332" alt="image" src="https://github.com/user-attachments/assets/d557dcee-f7a2-4cc5-89c8-96b47d8e5435" />

```
./scripts/coverage.sh -o apig -f TestAccOrchestrationRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccOrchestrationRule_basic -timeout 360m -parallel 10
=== RUN   TestAccOrchestrationRule_basic
=== PAUSE TestAccOrchestrationRule_basic
=== CONT  TestAccOrchestrationRule_basic
--- PASS: TestAccOrchestrationRule_basic (205.45s)
PASS
coverage: 2.6% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      205.580s        coverage: 2.6% of statements in ./huaweicloud/services/apig
```
<img width="2238" height="1317" alt="image" src="https://github.com/user-attachments/assets/323cb139-377d-43a4-b54c-92b422bc3854" />
<img width="2237" height="1332" alt="image" src="https://github.com/user-attachments/assets/85d8167c-4549-4d17-a727-eea5322d4963" />

```
./scripts/coverage.sh -o apig -f TestAccPlugin_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccPlugin_basic -timeout 360m -parallel 10
=== RUN   TestAccPlugin_basic
=== PAUSE TestAccPlugin_basic
=== CONT  TestAccPlugin_basic
--- PASS: TestAccPlugin_basic (53.87s)
PASS
coverage: 2.1% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      54.015s coverage: 2.1% of statements in ./huaweicloud/services/apig
```
<img width="2224" height="1267" alt="image" src="https://github.com/user-attachments/assets/f46bf764-d248-45e2-b525-89cfb3381ad7" />
<img width="2223" height="1323" alt="image" src="https://github.com/user-attachments/assets/38b83fb2-dc06-468f-b99f-d69a4e5a0309" />

```
./scripts/coverage.sh -o apig -f TestAccPluginBatchApisAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccPluginBatchApisAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccPluginBatchApisAssociate_basic
=== PAUSE TestAccPluginBatchApisAssociate_basic
=== CONT  TestAccPluginBatchApisAssociate_basic
--- PASS: TestAccPluginBatchApisAssociate_basic (371.94s)
PASS
coverage: 9.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      372.079s        coverage: 9.2% of statements in ./huaweicloud/services/apig
```
<img width="2244" height="1324" alt="image" src="https://github.com/user-attachments/assets/61d2a8ec-6eda-4bda-b24c-8ae2e47e13c0" />
<img width="2234" height="1322" alt="image" src="https://github.com/user-attachments/assets/96d99d3a-b7c4-4459-8ffd-7035698df917" />

```
./scripts/coverage.sh -o apig -f TestAccResponse_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccResponse_basic -timeout 360m -parallel 10
=== RUN   TestAccResponse_basic
=== PAUSE TestAccResponse_basic
=== CONT  TestAccResponse_basic
--- PASS: TestAccResponse_basic (90.08s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      90.217s coverage: 3.3% of statements in ./huaweicloud/services/apig
```
<img width="2230" height="1329" alt="image" src="https://github.com/user-attachments/assets/c7b80421-9a7e-482b-a3a9-27ed8947ef6e" />
<img width="2232" height="1325" alt="image" src="https://github.com/user-attachments/assets/7d6579ab-92cd-4e8c-85ff-a6618db82e5d" />

```
./scripts/coverage.sh -o apig -f TestAccSignature_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccSignature_basic -timeout 360m -parallel 10
=== RUN   TestAccSignature_basic
=== PAUSE TestAccSignature_basic
=== CONT  TestAccSignature_basic
--- PASS: TestAccSignature_basic (84.06s)
PASS
coverage: 2.1% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      84.222s coverage: 2.1% of statements in ./huaweicloud/services/apig
```
<img width="2220" height="1326" alt="image" src="https://github.com/user-attachments/assets/681e75ef-6dbd-4cd8-a7f7-815f29bb2e07" />
<img width="2232" height="1332" alt="image" src="https://github.com/user-attachments/assets/eca159a1-00a5-4343-8b31-7d478ef2a7b5" />

```
./scripts/coverage.sh -o apig -f TestAccSignatureAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccSignatureAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccSignatureAssociate_basic
=== PAUSE TestAccSignatureAssociate_basic
=== CONT  TestAccSignatureAssociate_basic
--- PASS: TestAccSignatureAssociate_basic (306.43s)
PASS
coverage: 10.8% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      306.579s        coverage: 10.8% of statements in ./huaweicloud/services/apig
```
<img width="2232" height="1324" alt="image" src="https://github.com/user-attachments/assets/bb9c401c-c858-4f00-a9e9-5b80af7e54e7" />
<img width="2224" height="1320" alt="image" src="https://github.com/user-attachments/assets/252e10cd-10d2-4bf7-949d-0a8669a9c107" />

```
./scripts/coverage.sh -o apig -f TestAccThrottlingPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccThrottlingPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccThrottlingPolicy_basic
=== PAUSE TestAccThrottlingPolicy_basic
=== CONT  TestAccThrottlingPolicy_basic
--- PASS: TestAccThrottlingPolicy_basic (188.53s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      188.661s        coverage: 5.1% of statements in ./huaweicloud/services/apig
```
<img width="2241" height="1326" alt="image" src="https://github.com/user-attachments/assets/ef1f1b3f-26c1-427a-adc5-3901000d7944" />
<img width="2236" height="1325" alt="image" src="https://github.com/user-attachments/assets/70f62df0-b9f8-47bd-bfea-d933ff2fa3f7" />

```
./scripts/coverage.sh -o apig -f TestAccThrottlingPolicyAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccThrottlingPolicyAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccThrottlingPolicyAssociate_basic
=== PAUSE TestAccThrottlingPolicyAssociate_basic
=== CONT  TestAccThrottlingPolicyAssociate_basic
--- PASS: TestAccThrottlingPolicyAssociate_basic (239.82s)
PASS
coverage: 11.1% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      239.986s        coverage: 11.1% of statements in ./huaweicloud/services/apig
```
<img width="2247" height="1325" alt="image" src="https://github.com/user-attachments/assets/8b62cbf8-6cbd-4523-8ad4-533912ae7d24" />
<img width="2228" height="1325" alt="image" src="https://github.com/user-attachments/assets/936dc78a-7758-4fb5-b690-8f451aaa77e8" />

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
