### PR TITLE
feat(drs): support `az_code` field for `drs_job` resource

### DIFF
--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -361,12 +361,14 @@ func ResourceDrsJob() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
 				RequiredWith: []string{"slave_az"},
 			},
 			"slave_az": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
 				RequiredWith: []string{"master_az"},
 			},
 
@@ -509,6 +511,12 @@ func dbInfoSchemaResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"az_code": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "schema: Internal",
 			},
 			"port": {
 				Type:     schema.TypeInt,
@@ -1797,6 +1805,7 @@ func buildDbConfigParamter(d *schema.ResourceData, dbType, projectId string) (*j
 	configRaw := d.Get(dbType).([]interface{})[0].(map[string]interface{})
 	configs := jobs.Endpoint{
 		DbType:              configRaw["engine_type"].(string),
+		AzCode:              configRaw["az_code"].(string),
 		Ip:                  configRaw["ip"].(string),
 		DbName:              configRaw["name"].(string),
 		DbUser:              configRaw["user"].(string),
@@ -1845,10 +1854,12 @@ func buildKafkaSecurityConfigParamter(kafkaSecurityConfig []interface{}) *jobs.K
 
 func setDbInfoToState(d *schema.ResourceData, endpoint jobs.Endpoint, fieldName string) error {
 	result := make([]interface{}, 1)
-	// IP sometimes will not same as input, if input 1, will return 2
+	// IP sometimes will not same as input, if input 1, will return 2.
+	// Query API does not return endpoint `az_code`, keep the configured value to avoid ForceNew drift.
 	item := map[string]interface{}{
 		"engine_type":           endpoint.DbType,
 		"ip":                    d.Get(fieldName + ".0.ip"),
+		"az_code":               d.Get(fieldName + ".0.az_code"),
 		"port":                  endpoint.DbPort,
 		"password":              endpoint.DbPassword,
 		"user":                  endpoint.DbUser,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Added the internal parameter `az_code` to the `dbInfoSchema` struct to support job scenarios where `engine_type` is `mysql-to-gaussdbv5ha` or `gaussdbv1-to-gaussdbv5ha`.
2. The API query might return values ​​for `master_az` and `slave_az` if `az_code` is specified. If `master_az` and `slave_az` are not configured in the Terraform script, this would trigger a `ForceNew` operation. Therefore, the `Computed` attribute has been added to `master_az` and `slave_az`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `az_code` field for `drs_job` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.


### Test cases where `master_az` and `slave_az` are not configured
```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccResourceDrsJob_sync"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_sync -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_sync
=== PAUSE TestAccResourceDrsJob_sync
=== CONT  TestAccResourceDrsJob_sync
--- PASS: TestAccResourceDrsJob_sync (1421.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1421.512s
```

### Test cases configured with `master_az` and `slave_az`
```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccResourceDrsJob_dualAZ"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_dualAZ -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_dualAZ
=== PAUSE TestAccResourceDrsJob_dualAZ
=== CONT  TestAccResourceDrsJob_dualAZ
--- PASS: TestAccResourceDrsJob_dualAZ (1034.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1034.282s
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
