### PR TITLE
fix(SWR-Enterprise): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_replication_policy_test.go
+++ b/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_replication_policy_test.go
@@ -63,7 +63,6 @@ func TestAccSwrEnterpriseReplicationPolicy_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckSwrSignatureWithImageEnabled(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_repository_update_test.go
+++ b/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_repository_update_test.go
@@ -60,7 +60,6 @@ func TestAccSwrEnterpriseRepositoryUpdate_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckSwrSignatureWithImageEnabled(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_image_signature_policy.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_image_signature_policy.go
@@ -235,7 +235,10 @@ func resourceSwrEnterpriseImageSignaturePolicyCreate(ctx context.Context, d *sch
 	createPath = strings.ReplaceAll(createPath, "{namespace_name}", namespaceName)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseImageSignaturePolicyBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseImageSignaturePolicyBodyParams(d)),
 	}
 
 	createResp, err := client.Request("POST", createPath, &createOpt)
@@ -499,20 +502,25 @@ func resourceSwrEnterpriseImageSignaturePolicyUpdate(ctx context.Context, d *sch
 		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
-	updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/signature/policies/{policy_id}"
-	updatePath := client.Endpoint + updateHttpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", d.Get("namespace_name").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("policy_id").(string))
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseImageSignaturePolicyBodyParams(d)),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/signature/policies/{policy_id}"
+		updatePath := client.Endpoint + updateHttpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", d.Get("namespace_name").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("policy_id").(string))
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseImageSignaturePolicyBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating SWR instance policy: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating SWR instance policy: %s", err)
+		}
 	}
 
 	return resourceSwrEnterpriseImageSignaturePolicyRead(ctx, d, meta)
@@ -534,6 +542,9 @@ func resourceSwrEnterpriseImageSignaturePolicyDelete(_ context.Context, d *schem
 	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", d.Get("policy_id").(string))
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_immutable_tag_rule.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_immutable_tag_rule.go
@@ -168,7 +168,10 @@ func resourceSwrEnterpriseImmutableTagRuleCreate(ctx context.Context, d *schema.
 	createPath = strings.ReplaceAll(createPath, "{namespace_name}", namespaceName)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseImmutableTagRuleBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseImmutableTagRuleBodyParams(d)),
 	}
 
 	createResp, err := client.Request("POST", createPath, &createOpt)
@@ -357,20 +360,25 @@ func resourceSwrEnterpriseImmutableTagRuleUpdate(ctx context.Context, d *schema.
 		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
-	updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/immutabletagrules/{immutable_rule_id}"
-	updatePath := client.Endpoint + updateHttpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", d.Get("namespace_name").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{immutable_rule_id}", d.Get("immutable_rule_id").(string))
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseImmutableTagRuleBodyParams(d)),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/immutabletagrules/{immutable_rule_id}"
+		updatePath := client.Endpoint + updateHttpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", d.Get("namespace_name").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{immutable_rule_id}", d.Get("immutable_rule_id").(string))
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseImmutableTagRuleBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating SWR instance immutable tag rule: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating SWR instance immutable tag rule: %s", err)
+		}
 	}
 
 	return resourceSwrEnterpriseImmutableTagRuleRead(ctx, d, meta)
@@ -392,6 +400,9 @@ func resourceSwrEnterpriseImmutableTagRuleDelete(_ context.Context, d *schema.Re
 	deletePath = strings.ReplaceAll(deletePath, "{immutable_rule_id}", d.Get("immutable_rule_id").(string))
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_replication_policy.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_replication_policy.go
@@ -199,7 +199,10 @@ func resourceSwrEnterpriseReplicationPolicyCreate(ctx context.Context, d *schema
 	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateSwrEnterpriseReplicationPolicyBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateSwrEnterpriseReplicationPolicyBodyParams(d)),
 	}
 
 	createResp, err := client.Request("POST", createPath, &createOpt)
@@ -322,6 +325,9 @@ func resourceSwrEnterpriseReplicationPolicyRead(_ context.Context, d *schema.Res
 	getPath = strings.ReplaceAll(getPath, "{policy_id}", id)
 	getOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
@@ -418,19 +424,24 @@ func resourceSwrEnterpriseReplicationPolicyUpdate(ctx context.Context, d *schema
 		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
-	updateHttpUrl := "v2/{project_id}/instances/{instance_id}/replication/policies/{policy_id}"
-	updatePath := client.Endpoint + updateHttpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", strconv.Itoa(d.Get("policy_id").(int)))
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildUpdateSwrEnterpriseReplicationPolicyBodyParams(d)),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updateHttpUrl := "v2/{project_id}/instances/{instance_id}/replication/policies/{policy_id}"
+		updatePath := client.Endpoint + updateHttpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{policy_id}", strconv.Itoa(d.Get("policy_id").(int)))
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildUpdateSwrEnterpriseReplicationPolicyBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating SWR instance replication policy: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating SWR instance replication policy: %s", err)
+		}
 	}
 
 	return resourceSwrEnterpriseReplicationPolicyRead(ctx, d, meta)
@@ -480,6 +491,9 @@ func resourceSwrEnterpriseReplicationPolicyDelete(_ context.Context, d *schema.R
 	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", strconv.Itoa(d.Get("policy_id").(int)))
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_repository_update.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_repository_update.go
@@ -25,8 +25,8 @@ var enterpriseRepositoryUpdateNonUpdatableParams = []string{
 // @API SWR GET /v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/repositories/{repository_name}
 func ResourceSwrEnterpriseRepositoryUpdate() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSwrEnterpriseRepositoryUpdateCreateOrUpdate,
-		UpdateContext: resourceSwrEnterpriseRepositoryUpdateCreateOrUpdate,
+		CreateContext: resourceSwrEnterpriseRepositoryUpdateCreate,
+		UpdateContext: resourceSwrEnterpriseRepositoryUpdateUpdate,
 		ReadContext:   resourceSwrEnterpriseRepositoryUpdateRead,
 		DeleteContext: resourceSwrEnterpriseRepositoryUpdateDelete,
 
@@ -69,7 +69,7 @@ func ResourceSwrEnterpriseRepositoryUpdate() *schema.Resource {
 	}
 }
 
-func resourceSwrEnterpriseRepositoryUpdateCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSwrEnterpriseRepositoryUpdateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.NewServiceClient("swr", region)
@@ -80,7 +80,42 @@ func resourceSwrEnterpriseRepositoryUpdateCreateOrUpdate(ctx context.Context, d 
 	instanceId := d.Get("instance_id").(string)
 	namespaceName := d.Get("namespace_name").(string)
 	repositoryName := d.Get("repository_name").(string)
+	description := d.Get("description").(string)
 
+	err = updateSwrEnterpriseRepository(client, instanceId, namespaceName, repositoryName, description)
+	if err != nil {
+		return diag.Errorf("error creating SWR enterprise repository: %s", err)
+	}
+
+	d.SetId(instanceId + "/" + namespaceName + "/" + repositoryName)
+
+	return resourceSwrEnterpriseRepositoryUpdateRead(ctx, d, meta)
+}
+
+func resourceSwrEnterpriseRepositoryUpdateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		instanceId := d.Get("instance_id").(string)
+		namespaceName := d.Get("namespace_name").(string)
+		repositoryName := d.Get("repository_name").(string)
+		description := d.Get("description").(string)
+
+		err = updateSwrEnterpriseRepository(client, instanceId, namespaceName, repositoryName, description)
+		if err != nil {
+			return diag.Errorf("error updating SWR enterprise repository: %s", err)
+		}
+	}
+
+	return resourceSwrEnterpriseRepositoryUpdateRead(ctx, d, meta)
+}
+
+func updateSwrEnterpriseRepository(client *golangsdk.ServiceClient, instanceId, namespaceName, repositoryName, description string) error {
 	updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/repositories/{repository_name}"
 	updatePath := client.Endpoint + updateHttpUrl
 	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
@@ -89,21 +124,16 @@ func resourceSwrEnterpriseRepositoryUpdateCreateOrUpdate(ctx context.Context, d 
 	updatePath = strings.ReplaceAll(updatePath, "{repository_name}", url.PathEscape(strings.ReplaceAll(repositoryName, "/", "%2F")))
 	updateOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 		JSONBody: map[string]interface{}{
-			"description": d.Get("description"),
+			"description": description,
 		},
 	}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating SWR enterprise repository: %s", err)
-	}
-
-	if d.IsNewResource() {
-		d.SetId(instanceId + "/" + namespaceName + "/" + repositoryName)
-	}
-
-	return resourceSwrEnterpriseRepositoryUpdateRead(ctx, d, meta)
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
 }
 
 func resourceSwrEnterpriseRepositoryUpdateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -122,6 +152,9 @@ func resourceSwrEnterpriseRepositoryUpdateRead(_ context.Context, d *schema.Reso
 	getPath = strings.ReplaceAll(getPath, "{repository_name}", url.PathEscape(strings.ReplaceAll(d.Get("repository_name").(string), "/", "%2F")))
 	getOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	getResp, err := client.Request("GET", getPath, &getOpt)

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_retention_policy.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_retention_policy.go
@@ -239,7 +239,10 @@ func resourceSwrEnterpriseRetentionPolicyCreate(ctx context.Context, d *schema.R
 	createPath = strings.ReplaceAll(createPath, "{namespace_name}", namespaceName)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseRetentionPolicyBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseRetentionPolicyBodyParams(d)),
 	}
 
 	createResp, err := client.Request("POST", createPath, &createOpt)
@@ -407,6 +410,9 @@ func resourceSwrEnterpriseRetentionPolicyRead(_ context.Context, d *schema.Resou
 	getPath = strings.ReplaceAll(getPath, "{policy_id}", id)
 	getOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
@@ -534,20 +540,25 @@ func resourceSwrEnterpriseRetentionPolicyUpdate(ctx context.Context, d *schema.R
 		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
-	updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/retention/policies/{policy_id}"
-	updatePath := client.Endpoint + updateHttpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", d.Get("namespace_name").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("policy_id").(string))
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseRetentionPolicyBodyParams(d)),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/retention/policies/{policy_id}"
+		updatePath := client.Endpoint + updateHttpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", d.Get("namespace_name").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("policy_id").(string))
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseRetentionPolicyBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating SWR instance retention policy: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating SWR instance retention policy: %s", err)
+		}
 	}
 
 	return resourceSwrEnterpriseRetentionPolicyRead(ctx, d, meta)
@@ -569,6 +580,9 @@ func resourceSwrEnterpriseRetentionPolicyDelete(_ context.Context, d *schema.Res
 	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", d.Get("policy_id").(string))
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_trigger.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_trigger.go
@@ -225,7 +225,10 @@ func resourceSwrEnterpriseTriggerCreate(ctx context.Context, d *schema.ResourceD
 	createPath = strings.ReplaceAll(createPath, "{namespace_name}", namespaceName)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseTriggerBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseTriggerBodyParams(d)),
 	}
 
 	createResp, err := client.Request("POST", createPath, &createOpt)
@@ -361,6 +364,9 @@ func resourceSwrEnterpriseTriggerRead(_ context.Context, d *schema.ResourceData,
 	getPath = strings.ReplaceAll(getPath, "{policy_id}", id)
 	getOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
@@ -473,20 +479,25 @@ func resourceSwrEnterpriseTriggerUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
-	updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/webhook/policies/{policy_id}"
-	updatePath := client.Endpoint + updateHttpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", d.Get("namespace_name").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("trigger_id").(string))
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseTriggerBodyParams(d)),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updateHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/webhook/policies/{policy_id}"
+		updatePath := client.Endpoint + updateHttpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", d.Get("namespace_name").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("trigger_id").(string))
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildCreateOrUpdateSwrEnterpriseTriggerBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating SWR instance trigger: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating SWR instance trigger: %s", err)
+		}
 	}
 
 	return resourceSwrEnterpriseTriggerRead(ctx, d, meta)
@@ -508,6 +519,9 @@ func resourceSwrEnterpriseTriggerDelete(_ context.Context, d *schema.ResourceDat
 	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", d.Get("trigger_id").(string))
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Skip update logic when only 'enable_force_new' changes for the following resources:
- resource_huaweicloud_swr_enterprise_repository_update.go
- resource_huaweicloud_swr_enterprise_trigger.go
- resource_huaweicloud_swr_enterprise_replication_policy.go
-  resource_huaweicloud_swr_enterprise_retention_policy.go
- resource_huaweicloud_swr_enterprise_image_signature_policy.go
- resource_huaweicloud_swr_enterprise_immutable_tag_rule.go

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Skip update logic when only 'enable_force_new' changes for the resources of SWREnterprise
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
- resource_huaweicloud_swr_enterprise_repository_update.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run=TestAccSwrEnterpriseRepositoryUpdate'
    === RUN   TestAccSwrEnterpriseRepositoryUpdate_basic
    === PAUSE TestAccSwrEnterpriseRepositoryUpdate_basic
    === CONT  TestAccSwrEnterpriseRepositoryUpdate_basic
    --- PASS: TestAccSwrEnterpriseRepositoryUpdate_basic (16.45s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise 21.306s
    ```
  change attributes excpet `enable_force_new`:
  <img width="1816" height="943" alt="image" src="https://github.com/user-attachments/assets/b2de1726-5e23-40b3-8ff0-e41ae179d1f1" />

   only change `enable_force_new`:
  <img width="1805" height="946" alt="image" src="https://github.com/user-attachments/assets/df8d5066-8efe-413d-a714-9f2e59c8e6c6" />

- resource_huaweicloud_swr_enterprise_trigger.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run=TestAccSwrEnterpriseTrigger'
    === RUN   TestAccSwrEnterpriseTrigger_basic
    === PAUSE TestAccSwrEnterpriseTrigger_basic
    === CONT  TestAccSwrEnterpriseTrigger_basic
    --- PASS: TestAccSwrEnterpriseTrigger_basic (438.93s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise 438.954s
    ```

   change attributes excpet `enable_force_new`:
  <img width="1819" height="961" alt="image" src="https://github.com/user-attachments/assets/42aa0b84-85ff-4bf1-9b04-9e2499860a07" />

  only change `enable_force_new`:
  <img width="1822" height="951" alt="image" src="https://github.com/user-attachments/assets/405a121d-7732-4895-ab4f-21e2c07b9699" />

- resource_huaweicloud_swr_enterprise_replication_policy.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run=TestAccSwrEnterpriseReplicationPolicy'
    === RUN   TestAccSwrEnterpriseReplicationPolicy_basic
    === PAUSE TestAccSwrEnterpriseReplicationPolicy_basic
    === CONT  TestAccSwrEnterpriseReplicationPolicy_basic
    --- PASS: TestAccSwrEnterpriseReplicationPolicy_basic (21.28s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise 21.306s
    ```

   change attributes excpet `enable_force_new`:
  <img width="1823" height="939" alt="image" src="https://github.com/user-attachments/assets/b7fc03c6-8e43-4102-a1ab-872277cc2a9e" />

   only change `enable_force_new`:
  <img width="1820" height="944" alt="image" src="https://github.com/user-attachments/assets/ee053b63-d7e9-4fa5-9035-e18333751be0" />

-  resource_huaweicloud_swr_enterprise_retention_policy.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run=TestAccSwrEnterpriseRetentionPolicy'
    === RUN   TestAccSwrEnterpriseRetentionPolicy_basic
    === PAUSE TestAccSwrEnterpriseRetentionPolicy_basic
    === CONT  TestAccSwrEnterpriseRetentionPolicy_basic
    --- PASS: TestAccSwrEnterpriseRetentionPolicy_basic (419.15s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise 419.176s
    ```

    change attributes excpet `enable_force_new`:
    <img width="1822" height="940" alt="image" src="https://github.com/user-attachments/assets/02d4ab51-1675-4f6a-82f3-91fd62c10eca" />
    
    only change `enable_force_new`:
    <img width="1789" height="954" alt="image" src="https://github.com/user-attachments/assets/9fefa251-d691-4a3d-8490-7af26d745e2d" />

- resource_huaweicloud_swr_enterprise_image_signature_policy.go

    ```
    make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run=TestAccSwrEnterpriseImageSignaturePolicy'
    === RUN   TestAccSwrEnterpriseImageSignaturePolicy_basic
    === PAUSE TestAccSwrEnterpriseImageSignaturePolicy_basic
    === CONT  TestAccSwrEnterpriseImageSignaturePolicy_basic
    --- PASS: TestAccSwrEnterpriseImageSignaturePolicy_basic (418.83s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise 957.336s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1835" height="970" alt="image" src="https://github.com/user-attachments/assets/7a477c81-39fd-4358-bffd-80079313f82c" />

    only change `enable_force_new`:
    <img width="1826" height="971" alt="image" src="https://github.com/user-attachments/assets/f7d8a4ba-d2a5-4152-acf9-6394a9191695" />

- resource_huaweicloud_swr_enterprise_immutable_tag_rule.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run=TestAccSwrEnterpriseImmutableTagRule'
    === RUN   TestAccSwrEnterpriseImmutableTagRule_basic
    === PAUSE TestAccSwrEnterpriseImmutableTagRule_basic
    === CONT  TestAccSwrEnterpriseImmutableTagRule_basic
    --- PASS: TestAccSwrEnterpriseImmutableTagRule_basic (434.80s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise 434.826s
    ```

   change attributes excpet `enable_force_new`:
  <img width="1826" height="971" alt="image" src="https://github.com/user-attachments/assets/b128e86e-74e4-45fd-8cbe-e4181a2a0b1d" />

   only change `enable_force_new`:
  <img width="1837" height="947" alt="image" src="https://github.com/user-attachments/assets/017fe754-78a5-49e9-8de1-81ce85ea087b" />



* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
