### PR TITLE
fix(iam): Ensure resource management via polling and waiting

### DIFF
--- a/docs/resources/identity_agency.md
+++ b/docs/resources/identity_agency.md
@@ -107,9 +107,8 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `read` - Default is 2 minutes.
-* `update` - Default is 1 minute.
-* `delete` - Default is 1 minute.
+* `update` - Default is 20 minutes.
+* `delete` - Default is 20 minutes.
 
 ## Import
 

--- a/docs/resources/identity_group.md
+++ b/docs/resources/identity_group.md
@@ -45,7 +45,7 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 20 seconds.
+* `create` - Default is 20 minutes.
 
 ## Import
 

--- a/docs/resources/identity_role.md
+++ b/docs/resources/identity_role.md
@@ -73,6 +73,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `references` - The number of references.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+
 ## Import
 
 IAM custom policies can be imported using the `id`, e.g.

--- a/docs/resources/identity_user.md
+++ b/docs/resources/identity_user.md
@@ -87,7 +87,7 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 20 seconds.
+* `create` - Default is 20 minutes.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
@@ -19,7 +19,9 @@ func getV3AgencyResourceFunc(c *config.Config, state *terraform.ResourceState) (
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
-	return iam.GetV3AgencyByIdWithRetry(context.Background(), client, state.Primary.ID)
+	return iam.PollRequest(context.Background(), func() (interface{}, error) {
+		return iam.GetV3AgencyById(client, state.Primary.ID)
+	})
 }
 
 func TestAccV3Agency_basic(t *testing.T) {

--- a/huaweicloud/services/iam/common.go
+++ b/huaweicloud/services/iam/common.go
@@ -1,12 +1,53 @@
 package iam
 
 import (
+	"context"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+const (
+	iamPollTimeout      = 20 * time.Second
+	iamPollInitialDelay = 1 * time.Second
+	iamPollInterval     = 1 * time.Second
+)
+
+// PollRequest polls an IAM resource until the request function no longer returns 404.
+func PollRequest(ctx context.Context, requestFunc func() (interface{}, error)) (interface{}, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(iamPollInitialDelay):
+	}
+
+	deadline := time.Now().Add(iamPollTimeout)
+
+	for {
+		resp, err := requestFunc()
+		if err == nil {
+			return resp, nil
+		}
+
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return nil, err
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timeout waiting for IAM resources to become expected status after %s", iamPollTimeout)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(iamPollInterval):
+		}
+	}
+}
 
 func buildV5ResourceTags(tagmap map[string]interface{}) []map[string]interface{} {
 	tags := make([]map[string]interface{}, 0, len(tagmap))

--- a/huaweicloud/services/iam/common_test.go
+++ b/huaweicloud/services/iam/common_test.go
@@ -1,0 +1,248 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// TestPollRequest_successOnFirstRequest verifies the happy path where the request function succeeds
+// on its first invocation after the initial delay.
+//
+// PollRequest always waits iamPollInitialDelay before calling requestFunc for the first time.
+// This test ensures that:
+//   - A successful response is returned without error when requestFunc succeeds immediately.
+//   - The returned value matches exactly what requestFunc produced.
+//   - The total elapsed time is at least iamPollInitialDelay, confirming the initial delay is enforced
+//     even when no retry is required.
+func TestPollRequest_successOnFirstRequest(t *testing.T) {
+	start := time.Now()
+	expected := map[string]interface{}{"id": "test-id"}
+
+	resp, err := PollRequest(context.Background(), func() (interface{}, error) {
+		return expected, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !reflect.DeepEqual(resp, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, resp)
+	}
+
+	// Confirm the initial delay occurred before the first request was made.
+	elapsed := time.Since(start)
+	if elapsed < iamPollInitialDelay {
+		t.Fatalf("expected initial delay of at least %s, elapsed %s", iamPollInitialDelay, elapsed)
+	}
+}
+
+// TestPollRequest_successAfter404Retries verifies that PollRequest keeps polling when requestFunc
+// returns golangsdk.ErrDefault404, and eventually returns the successful response once the resource
+// becomes available.
+//
+// The mock requestFunc returns 404 for the first two attempts and succeeds on the third.
+// This test ensures that:
+//   - PollRequest retries on 404 instead of treating it as a terminal error.
+//   - requestFunc is invoked exactly three times before returning.
+//   - The final successful response is returned to the caller.
+//   - The total elapsed time includes the initial delay plus one interval wait after each 404,
+//     i.e. iamPollInitialDelay + 2*iamPollInterval.
+func TestPollRequest_successAfter404Retries(t *testing.T) {
+	start := time.Now()
+	expected := map[string]interface{}{"id": "test-id"}
+	attempts := 0
+
+	resp, err := PollRequest(context.Background(), func() (interface{}, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, golangsdk.ErrDefault404{}
+		}
+		return expected, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !reflect.DeepEqual(resp, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, resp)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+
+	// Two 404 responses require two interval waits between the three request attempts.
+	minElapsed := iamPollInitialDelay + 2*iamPollInterval
+	if elapsed := time.Since(start); elapsed < minElapsed {
+		t.Fatalf("expected elapsed time of at least %s, got %s", minElapsed, elapsed)
+	}
+}
+
+// TestPollRequest_non404Error verifies that PollRequest stops immediately when requestFunc returns
+// an error other than golangsdk.ErrDefault404.
+//
+// Non-404 errors (e.g. 403, 500, network failures) are considered non-retryable and should be
+// returned directly to the caller without entering the interval retry loop.
+// This test ensures that the original error is preserved and returned unchanged.
+func TestPollRequest_non404Error(t *testing.T) {
+	expectedErr := errors.New("internal error")
+
+	_, err := PollRequest(context.Background(), func() (interface{}, error) {
+		return nil, expectedErr
+	})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+}
+
+// TestPollRequest_contextCanceledDuringInitialDelay verifies that PollRequest respects context
+// cancellation during the initial delay phase, before requestFunc is ever invoked.
+//
+// The context is canceled before PollRequest is called. This test ensures that:
+//   - PollRequest returns immediately with context.Canceled instead of waiting the full initial delay.
+//   - requestFunc is never called when the context is already canceled at entry.
+func TestPollRequest_contextCanceledDuringInitialDelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := PollRequest(ctx, func() (interface{}, error) {
+		t.Fatal("request function should not be called when context is already canceled")
+		return nil, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestPollRequest_contextCanceledDuringInterval verifies that PollRequest respects context
+// cancellation while waiting between retry attempts after a 404 response.
+//
+// The mock requestFunc returns 404 on the first call and triggers context cancellation at that
+// point. PollRequest should detect the canceled context during the subsequent interval wait and
+// return context.Canceled instead of continuing to poll.
+// A goroutine is used because PollRequest blocks until it returns or the test times out.
+func TestPollRequest_contextCanceledDuringInterval(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := PollRequest(ctx, func() (interface{}, error) {
+			attempts++
+			if attempts == 1 {
+				cancel()
+			}
+			return nil, golangsdk.ErrDefault404{}
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for PollRequest to return after context cancellation")
+	}
+}
+
+// TestPollRequest_timeout verifies that PollRequest eventually returns a timeout error when
+// requestFunc keeps returning golangsdk.ErrDefault404 until the polling deadline is exceeded.
+//
+// The polling deadline is iamPollTimeout from the moment PollRequest starts (after the initial
+// delay is set up). This test ensures that:
+//   - A non-nil error is returned when the resource never becomes available within the timeout window.
+//   - requestFunc is called multiple times before giving up, confirming retries did occur.
+//   - The total elapsed time is at least iamPollInitialDelay + iamPollTimeout.
+//
+// This test is skipped when running with -short because it requires approximately 21 seconds to complete.
+func TestPollRequest_timeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timeout test in short mode")
+	}
+
+	start := time.Now()
+	attempts := 0
+
+	_, err := PollRequest(context.Background(), func() (interface{}, error) {
+		attempts++
+		return nil, golangsdk.ErrDefault404{}
+	})
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if attempts < 2 {
+		t.Fatalf("expected multiple polling attempts before timeout, got %d", attempts)
+	}
+
+	minElapsed := iamPollInitialDelay + iamPollTimeout
+	if elapsed := time.Since(start); elapsed < minElapsed {
+		t.Fatalf("expected elapsed time of at least %s, got %s", minElapsed, elapsed)
+	}
+}
+
+// TestPollRequest_longRunningRequestExceedsDeadline verifies that PollRequest does not interrupt
+// an in-flight requestFunc, even when that call blocks longer than iamPollTimeout.
+//
+// This test simulates the SDK 429 backoff scenario by sleeping 25 seconds inside requestFunc
+// (longer than the 20-second polling deadline) and then returning 404.
+//
+// Expected timeline:
+//   - t=0s:  PollRequest starts
+//   - t=1s:  initial delay ends, requestFunc is invoked
+//   - t=1s~26s: requestFunc blocks for 25 seconds (PollRequest cannot check the deadline yet)
+//   - t=26s: requestFunc returns 404, PollRequest then detects that the deadline has already
+//     passed and returns a timeout error
+//
+// Therefore the total elapsed time should fall in the ~26s range
+// (iamPollInitialDelay + 25s), NOT the ~21s range (iamPollInitialDelay + iamPollTimeout).
+// This confirms that requestFunc execution time is not preempted by the PollRequest deadline.
+//
+// This test is skipped when running with -short because it requires approximately 26 seconds.
+func TestPollRequest_longRunningRequestExceedsDeadline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running requestFunc test in short mode")
+	}
+
+	const requestSleep = 25 * time.Second
+	start := time.Now()
+	attempts := 0
+
+	_, err := PollRequest(context.Background(), func() (interface{}, error) {
+		attempts++
+		// Simulate a long-blocking request (e.g. SDK 429 backoff).
+		// lintignore:R018
+		time.Sleep(requestSleep)
+		return nil, golangsdk.ErrDefault404{}
+	})
+
+	elapsed := time.Since(start)
+	t.Logf("PollRequest returned after %s (attempts=%d, err=%v)", elapsed, attempts, err)
+
+	if err == nil {
+		t.Fatal("expected timeout error after the long-running requestFunc returned 404, got nil")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected requestFunc to be called exactly once, got %d", attempts)
+	}
+
+	// ~21s range would mean PollRequest somehow timed out around its own deadline without
+	// waiting for requestFunc. That should not happen.
+	around21s := iamPollInitialDelay + iamPollTimeout // 21s
+	// ~26s range means PollRequest waited for the full requestFunc sleep before returning.
+	around26s := iamPollInitialDelay + requestSleep // 26s
+
+	if elapsed < around26s {
+		t.Fatalf("elapsed %s is closer to the 21s range (%s) than expected; "+
+			"PollRequest should wait for requestFunc to finish (~%s)",
+			elapsed, around21s, around26s)
+	}
+
+	// Allow a small scheduling overhead upper bound.
+	if elapsed > around26s+2*time.Second {
+		t.Fatalf("elapsed %s is unexpectedly larger than ~%s", elapsed, around26s)
+	}
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_acl.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_acl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -320,6 +321,11 @@ func resourceV3AclCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	d.SetId(fmt.Sprintf("%s/%s", domainId, d.Get("type").(string)))
 
+	// sleep 3 seconds to wait for the ACL policy to be updated (during PUT operation, the ACL policy with the
+	// expected result cannot be queried immediately).
+	// lintignore:R018
+	time.Sleep(3 * time.Second)
+
 	if err = d.Set("ip_ciders_order", buildV3AclIpCidersOrder(d)); err != nil {
 		log.Printf("[ERROR] error setting the ip_ciders_order field after creating ACL: %s", err)
 	}
@@ -595,6 +601,11 @@ func resourceV3AclUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			}
 		}
 	}
+
+	// sleep 3 seconds to wait for the ACL policy to be updated (during PUT operation, the ACL policy with the
+	// expected result cannot be queried immediately).
+	// lintignore:R018
+	time.Sleep(3 * time.Second)
 
 	return resourceV3AclRead(ctx, d, meta)
 }

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
@@ -53,7 +53,6 @@ func ResourceV3Agency() *schema.Resource {
 		CustomizeDiff: config.FlexibleForceNew(v3AgencyNonUpdatableParams),
 
 		Timeouts: &schema.ResourceTimeout{
-			Read:   schema.DefaultTimeout(2 * time.Minute),
 			Update: schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
@@ -737,6 +736,14 @@ func resourceV3AgencyCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	d.SetId(agencyId)
 
+	// After creation, the agency may not be immediately queryable (usually 2-3s, up to 10s).
+	_, err = PollRequest(ctx, func() (interface{}, error) {
+		return GetV3AgencyById(iamClient, agencyId)
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	// get all of the role IDs, include system-defined roles and custom roles
 	allRoles, err := listAllRoles(iamClient, domainId)
 	if err != nil {
@@ -799,7 +806,7 @@ func normalizeAgencyDuration(duration interface{}) interface{} {
 	return result
 }
 
-func getV3AgencyById(client *golangsdk.ServiceClient, agencyId string) (interface{}, error) {
+func GetV3AgencyById(client *golangsdk.ServiceClient, agencyId string) (interface{}, error) {
 	httpUrl := "v3.0/OS-AGENCY/agencies/{agency_id}"
 
 	getPath := client.Endpoint + httpUrl
@@ -818,37 +825,6 @@ func getV3AgencyById(client *golangsdk.ServiceClient, agencyId string) (interfac
 	}
 
 	return utils.FlattenResponse(respBody)
-}
-
-func GetV3AgencyByIdWithRetry(ctx context.Context, client *golangsdk.ServiceClient, agencyId string, timeout ...time.Duration) (interface{}, error) {
-	var (
-		respBody   interface{}
-		err        error
-		timeoutVal time.Duration
-	)
-
-	if len(timeout) < 1 || timeout[0] <= time.Duration(0) {
-		return getV3AgencyById(client, agencyId)
-	}
-	timeoutVal = timeout[0]
-
-	// lintignore:R006
-	err = retry.RetryContext(ctx, timeoutVal, func() *retry.RetryError {
-		respBody, err = getV3AgencyById(client, agencyId)
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			// Retrieving agency details may result in a 404 error, requiring appropriate retries.
-			// If the details are not retrieved within the timeout period, an error will be returned.
-			// lintignore:R018
-			time.Sleep(10 * time.Second)
-			return retry.RetryableError(err)
-		}
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-		return nil
-	})
-
-	return respBody, err
 }
 
 func listAttachedProjectRolesForV3AgencyByProjectId(client *golangsdk.ServiceClient, agencyId, projectId string) ([]interface{}, error) {
@@ -947,7 +923,6 @@ func resourceV3AgencyRead(ctx context.Context, d *schema.ResourceData, meta inte
 		cfg      = meta.(*config.Config)
 		region   = cfg.GetRegion(d)
 		agencyId = d.Id()
-		timeout  time.Duration
 	)
 
 	client, err := cfg.NewServiceClient("iam", region)
@@ -955,10 +930,14 @@ func resourceV3AgencyRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
+	var agency interface{}
 	if d.IsNewResource() {
-		timeout = d.Timeout(schema.TimeoutRead)
+		agency, err = PollRequest(ctx, func() (interface{}, error) {
+			return GetV3AgencyById(client, agencyId)
+		})
+	} else {
+		agency, err = GetV3AgencyById(client, agencyId)
 	}
-	agency, err := GetV3AgencyByIdWithRetry(ctx, client, agencyId, timeout)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error retrieving agency")
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
@@ -1457,6 +1457,11 @@ func resourceV3AgencyUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
+	// sleep 3 seconds to wait for the agency to be updated (during each POST/PUT/DELETE operation, the agency with the
+	// expected result cannot be queried immediately).
+	// lintignore:R018
+	time.Sleep(3 * time.Second)
+
 	return resourceV3AgencyRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
@@ -53,8 +53,8 @@ func ResourceV3Agency() *schema.Resource {
 		CustomizeDiff: config.FlexibleForceNew(v3AgencyNonUpdatableParams),
 
 		Timeouts: &schema.ResourceTimeout{
-			Update: schema.DefaultTimeout(1 * time.Minute),
-			Delete: schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Importer: &schema.ResourceImporter{

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
@@ -180,6 +180,11 @@ func resourceV3GroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error updating group (%s): %s", groupId, err)
 	}
 
+	// sleep 3 seconds to wait for the group to be updated (during each PATCH operation, the group with the
+	// expected result cannot be queried immediately).
+	// lintignore:R018
+	time.Sleep(3 * time.Second)
+
 	return resourceV3GroupRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
@@ -29,7 +29,7 @@ func ResourceV3Group() *schema.Resource {
 		DeleteContext: resourceV3GroupDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Second),
+			Create: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Importer: &schema.ResourceImporter{

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
@@ -114,19 +113,6 @@ func GetV3GroupById(client *golangsdk.ServiceClient, groupId string) (interface{
 	return utils.FlattenResponse(requestResp)
 }
 
-func refreshV3Group(client *golangsdk.ServiceClient, groupId string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := GetV3GroupById(client, groupId)
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return "NOT_FOUND", "PENDING", nil
-			}
-			return nil, "ERROR", err
-		}
-		return resp, "COMPLETED", nil
-	}
-}
-
 func resourceV3GroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
@@ -141,14 +127,9 @@ func resourceV3GroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	var group interface{}
 	// After creation, the group may not be immediately queryable (usually 2-3s, up to 10s).
 	if d.IsNewResource() {
-		stateConf := &retry.StateChangeConf{
-			Pending:    []string{"PENDING"},
-			Target:     []string{"COMPLETED"},
-			Refresh:    refreshV3Group(client, groupId),
-			Timeout:    d.Timeout(schema.TimeoutCreate),
-			MinTimeout: 1 * time.Second,
-		}
-		group, err = stateConf.WaitForStateContext(ctx)
+		group, err = PollRequest(ctx, func() (interface{}, error) {
+			return GetV3GroupById(client, groupId)
+		})
 	} else {
 		group, err = GetV3GroupById(client, groupId)
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group_membership.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group_membership.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -128,6 +129,11 @@ func resourceV3GroupMembershipCreate(ctx context.Context, d *schema.ResourceData
 	if err = mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error adding users to group (%s): %s", groupId, err)
 	}
+
+	// sleep 3 seconds to wait for the group membership to be created (during each PUT operation, the group membership
+	// with the expected result cannot be queried immediately).
+	// lintignore:R018
+	time.Sleep(3 * time.Second)
 
 	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
 	// '_origin' attributes for subsequent determination and construction of the request body during next updates.

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_role.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_role.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -27,6 +28,11 @@ func ResourceV3Role() *schema.Resource {
 		ReadContext:   resourceV3IdentityRoleRead,
 		UpdateContext: resourceV3IdentityRoleUpdate,
 		DeleteContext: resourceV3IdentityRoleDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Second),
+		},
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -99,17 +105,29 @@ func resourceV3IdentityRoleCreate(ctx context.Context, d *schema.ResourceData, m
 	return resourceV3IdentityRoleRead(ctx, d, meta)
 }
 
-func resourceV3IdentityRoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3IdentityRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.IAMV3Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	role, err := policies.Get(client, d.Id()).Extract()
+	var (
+		resp   interface{}
+		roleId = d.Id()
+	)
+	// After creation, the role may not be immediately queryable (usually 2-3s, up to 10s).
+	if d.IsNewResource() {
+		resp, err = PollRequest(ctx, func() (interface{}, error) {
+			return policies.Get(client, roleId).Extract()
+		})
+	} else {
+		resp, err = policies.Get(client, roleId).Extract()
+	}
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "IAM custom policy")
 	}
+	role := resp.(*policies.Role)
 
 	log.Printf("[DEBUG] Retrieved IAM custom policy: %#v", role)
 	policy, err := json.Marshal(role.Policy)

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_role.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_role.go
@@ -30,7 +30,7 @@ func ResourceV3Role() *schema.Resource {
 		DeleteContext: resourceV3IdentityRoleDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Second),
+			Create: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Importer: &schema.ResourceImporter{

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
@@ -35,7 +35,7 @@ func ResourceIdentityUser() *schema.Resource {
 		DeleteContext: resourceUserDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Second),
+			Create: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Importer: &schema.ResourceImporter{

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -188,11 +187,20 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("error creating IAM user: %s", err)
 	}
 
-	d.SetId(user.ID)
+	userId := user.ID
+	d.SetId(userId)
+
+	// After creation, the user may not be immediately queryable (usually 2-3s, up to 10s).
+	_, err = PollRequest(ctx, func() (interface{}, error) {
+		return users.Get(iamClient, userId).Extract()
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// if login_protect_verification_method is not empty, update login protect
 	if val, ok := d.GetOk("login_protect_verification_method"); ok {
-		err := updateLoginProtect(iamClient, user.ID, val.(string))
+		err := updateLoginProtect(iamClient, userId, val.(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -217,20 +225,8 @@ func updateLoginProtect(client *golangsdk.ServiceClient, userID, method string) 
 	if err != nil {
 		return fmt.Errorf("error updating IAM user login protect: %s", err)
 	}
-	return nil
-}
 
-func refreshIdentityUser(client *golangsdk.ServiceClient, userId string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := users.Get(client, userId).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return "NOT_FOUND", "PENDING", nil
-			}
-			return nil, "ERROR", err
-		}
-		return resp, "COMPLETED", nil
-	}
+	return nil
 }
 
 func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -241,27 +237,14 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	var (
-		resp   interface{}
 		method string
 		userId = d.Id()
 	)
-	// After creation, the user may not be immediately queryable (usually 2-3s, up to 10s).
-	if d.IsNewResource() {
-		stateConf := &retry.StateChangeConf{
-			Pending:    []string{"PENDING"},
-			Target:     []string{"COMPLETED"},
-			Refresh:    refreshIdentityUser(iamClient, userId),
-			Timeout:    d.Timeout(schema.TimeoutCreate),
-			MinTimeout: 1 * time.Second,
-		}
-		resp, err = stateConf.WaitForStateContext(ctx)
-	} else {
-		resp, err = users.Get(iamClient, userId).Extract()
-	}
+
+	user, err := users.Get(iamClient, userId).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "user")
 	}
-	user := resp.(*users.User)
 
 	loginProtect, err := users.GetLoginProtect(iamClient, userId).ExtractLoginProtect()
 	if err != nil {

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
@@ -225,6 +225,10 @@ func updateLoginProtect(client *golangsdk.ServiceClient, userID, method string) 
 	if err != nil {
 		return fmt.Errorf("error updating IAM user login protect: %s", err)
 	}
+	// sleep 3 seconds to wait for the user to be updated (during each PUT operation, the user with the
+	// expected result cannot be queried immediately).
+	// lintignore:R018
+	time.Sleep(3 * time.Second)
 
 	return nil
 }
@@ -366,6 +370,11 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 			return diag.FromErr(err)
 		}
 	}
+
+	// sleep 3 seconds to wait for the user to be updated (during each PUT operation, the user with the
+	// expected result cannot be queried immediately).
+	// lintignore:R018
+	time.Sleep(3 * time.Second)
 
 	return resourceUserRead(ctx, d, meta)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Immediately after creating resources if their have not update logic between create and read, check if their are already exist.
For the user resource, if `login_protect_verification_method` is configured, an update will occur between creation and query, thus deferred the polling logic.
Based on PR [10416](https://github.com/huaweicloud/terraform-provider-huaweicloud/pull/10416), the following adjustments are made:
- Pre-polling (executed immediately after the creation request is sent)
- Wait 3 seconds after updates and deletions to ensure IAM data synchronization is complete.

For some of IAM resources, the default timeouts for create, update and delete steps are too short.
This excessively short timeout duration will cause the 429 retries to be prematurely interrupted. Therefore, the excessively short timeout duration during the creation phase of IAM resources should be removed.

- The PollRequest method provides a 20-second 404 retry window, which is isolated from the 429 retry window. 429 retries have higher priority than 404 (the 429 retry window is located within the DoRequest window).
- If the 429 retry duration exceeds the maximum timeout (20 seconds) created for the 404 retry, the process terminates prematurely and returns an error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new resource polling method and remove timeout definition
2. wait 3 seconds after update request send
3. increase the timeout time for some resources
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccIdentityUser_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccIdentityUser_basic -timeout 360m -parallel 10
=== RUN   TestAccIdentityUser_basic
=== PAUSE TestAccIdentityUser_basic
=== CONT  TestAccIdentityUser_basic
--- PASS: TestAccIdentityUser_basic (67.05s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       67.191s coverage: 3.1% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
