### PR TITLE
docs(iam): ipv6 range no longer support API access

### DIFF
--- a/docs/resources/identity_acl.md
+++ b/docs/resources/identity_acl.md
@@ -19,6 +19,8 @@ The ACL policies allowing user access only from specified IP address ranges and 
 
 ## Example Usage
 
+### API Access
+
 ```hcl
 resource "huaweicloud_identity_acl" "acl" {
   type = "api"
@@ -30,6 +32,29 @@ resource "huaweicloud_identity_acl" "acl" {
   ip_ranges {
     range       = "0.0.0.0-255.255.255.0"
     description = "This is a test IP range"
+  }
+}
+```
+
+### Console Access with IPv4 and IPv6 Ranges
+
+The following example restricts console access to specific IPv4 and IPv6 address ranges.
+
+~> When configuring console ACL, please ensure that the IP address of your current machine is included in the access
+   addresses to avoid being locked out of the console.
+
+```hcl
+resource "huaweicloud_identity_acl" "console_acl" {
+  type = "console"
+
+  ip_ranges {
+    range       = "10.212.1.156-10.202.1.157"
+    description = "Office IPv4 address range"
+  }
+
+  ipv6_ranges {
+    range       = "2001:db8:0:0:0:0:0:0-2001:db8:0:0:0:0:FFFF:FFFF"
+    description = "Office IPv6 address range"
   }
 }
 ```
@@ -54,7 +79,7 @@ The following arguments are supported:
 * `ipv6_cidrs` - (Optional, List) Specifies the IPv6 CIDR blocks from which console access or API access is allowed.
   The [ipv6_cidrs](#iam_acl_ipv6_cidrs) structure is documented below.
 
-* `ipv6_ranges` - (Optional, List) Specifies the IPv6 address ranges from which console access or API access is allowed.
+* `ipv6_ranges` - (Optional, List) Specifies the IPv6 address ranges from which console access is allowed.
   The [ipv6_ranges](#iam_acl_ipv6_ranges) structure is documented below.
 
 <a name="iam_acl_ip_cidrs"></a>
@@ -80,14 +105,14 @@ The `ip_ranges` block supports:
 <a name="iam_acl_ipv6_cidrs"></a>
 The `ipv6_cidrs` block supports:
 
-* `cidr` - (Required, String) Specifies the IPv6 CIDR block which allow access through console or API.
+* `cidr` - (Required, String) Specifies the IPv6 CIDR block which allow access through console.
 
 * `description` - (Optional, String) Specifies a description about an IPv6 CIDR block.
 
 <a name="iam_acl_ipv6_ranges"></a>
 The `ipv6_ranges` block supports:
 
-* `range` - (Required, String) Specifies the IPv6 address range which allow access through console or API.
+* `range` - (Required, String) Specifies the IPv6 address range which allow access through console.
 
 * `description` - (Optional, String) Specifies a description about an IP address range.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

IPv6 range settings only support console access, API access does not support yet.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. according to the IAM team's response, Ipv6 range no longer support API access
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
