### PR TITLE
feat(drs): support `drs_batch_select_objects` resource

### DIFF
--- a/docs/resources/drs_batch_select_objects.md
+++ b/docs/resources/drs_batch_select_objects.md
@@ -1,0 +1,119 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_batch_select_objects"
+description: |-
+  Manages a resource to batch select DRS job objects within HuaweiCloud.
+---
+
+# huaweicloud_drs_batch_select_objects
+
+Manages a resource to batch select DRS job objects within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to batch select DRS job objects. Deleting this resource will not
+  clear the corresponding request record, but will only remove the resource information from the tf state file.
+  <br/>2. Only real-time migration and real-time synchronization jobs support object selection.
+  The job status must be **CONFIGURATION**. The connection tests to the source and destination databases must succeed,
+  and the job modification API must be called successfully before using this resource.
+  <br/>3. The execution result of this operation is based on the `status` field in the `results` block.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+resource "huaweicloud_drs_batch_select_objects" "test" {
+  jobs {
+    job_id   = var.job_id
+    selected = false
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `jobs` - (Required, List, NonUpdatable) Specifies the list of jobs for batch object selection.
+  To ensure the API calling performance, the number of jobs in a batch call is recommended not to exceed `10`.
+
+  The [jobs](#jobs_struct) structure is documented below.
+
+<a name="jobs_struct"></a>
+The `jobs` block supports:
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the job ID.
+
+* `selected` - (Optional, Bool, NonUpdatable) Specifies whether to select objects customarily.  
+  The valid values are as follows:
+  + **true**: Custom objects. The `job` parameter is required to specify the objects.
+  + **false**: Migrate all objects from the source database.
+
+* `sync_database` - (Optional, Bool, NonUpdatable) Specifies whether to synchronize objects at the database level.  
+  The valid values are as follows:
+  + **true**: Database-level synchronization.
+  + **false**: Non-database-level synchronization.
+
+* `job` - (Optional, List, NonUpdatable) Specifies the database objects to migrate or synchronize.
+  This parameter is required when `selected` is **true**.
+
+  The [job](#job_struct) structure is documented below.
+
+<a name="job_struct"></a>
+The `job` block supports:
+
+* `id` - (Optional, String, NonUpdatable) Specifies the object ID.
+  + When `object_type` is **database**, this is the database name.
+  + When `object_type` is **table** or **view**, refer to the API example for the field value. Please refer to
+    the [document](https://support.huaweicloud.com/intl/en-us/api-drs/drs_03_0109.html).
+
+* `parent_id` - (Optional, String, NonUpdatable) Specifies the parent object ID.
+  This parameter is required when `object_type` is **table** or **view**, and the value is the database name.
+
+* `object_type` - (Optional, String, NonUpdatable) Specifies the object type.  
+  The valid values are as follows:
+  + **database**: Database.
+  + **table**: Table.
+  + **schema**: Schema.
+  + **view**: View.
+
+* `object_name` - (Optional, String, NonUpdatable) Specifies the object name, which can be a database name, table name,
+  or view name.
+
+* `select` - (Optional, String, NonUpdatable) Specifies whether the object is selected for migration.  
+  The valid values are as follows:
+  + **true**: The object will be migrated.
+  + **false**: The object will not be migrated.
+  + **partial**: Partially selected. Migrate some tables under the database.
+
+  Defaults to **false**.
+
+* `object_alias_name` - (Optional, String, NonUpdatable) Specifies the alias of the object after mapping.
+  This parameter is supported only for synchronization tasks.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `all_counts` - The total number of object selection tasks in this request.
+
+* `results` - The results of the batch object selection.
+
+  The [results](#results_struct) structure is documented below.
+
+<a name="results_struct"></a>
+The `results` block supports:
+
+* `job_id` - The job ID.
+
+* `status` - Whether the object selection task succeeded.
+  The value can be **true** or **false**.
+
+* `error_code` - The error code when the task fails.
+
+* `error_msg` - The error message when the task fails.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3883,6 +3883,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_backup_migration":               drs.ResourceBackupMigration(),
 			"huaweicloud_drs_batch_pause_task":               drs.ResourceBatchPauseTask(),
 			"huaweicloud_drs_batch_retry_task":               drs.ResourceBatchRetryTask(),
+			"huaweicloud_drs_batch_select_objects":           drs.ResourceDrsBatchSelectObjects(),
 			"huaweicloud_drs_batch_set_definer":              drs.ResourceBatchSetDefiner(),
 			"huaweicloud_drs_check_data_filter":              drs.ResourceDrsCheckDataFilter(),
 			"huaweicloud_drs_update_data_progress_rules":     drs.ResourceDrsUpdateDataProgressRules(),

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_batch_select_objects_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_batch_select_objects_test.go
@@ -1,0 +1,46 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchSelectObjects_basic(t *testing.T) {
+	resourceName := "huaweicloud_drs_batch_select_objects.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchSelectObjects_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "all_counts"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.job_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testBatchSelectObjects_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_drs_batch_select_objects" "test" {
+  jobs {
+    job_id   = "%s"
+    selected = false
+  }
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_batch_select_objects.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_batch_select_objects.go
@@ -1,0 +1,299 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchSelectObjectsNonUpdatableParams = []string{
+	"jobs",
+	"jobs.*.job_id",
+	"jobs.*.selected",
+	"jobs.*.sync_database",
+	"jobs.*.job",
+	"jobs.*.job.*.id",
+	"jobs.*.job.*.parent_id",
+	"jobs.*.job.*.object_type",
+	"jobs.*.job.*.object_name",
+	"jobs.*.job.*.select",
+	"jobs.*.job.*.object_alias_name",
+}
+
+// @API DRS PUT /v3/{project_id}/jobs/batch-select-objects
+func ResourceDrsBatchSelectObjects() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchSelectObjectsCreate,
+		ReadContext:   resourceBatchSelectObjectsRead,
+		UpdateContext: resourceBatchSelectObjectsUpdate,
+		DeleteContext: resourceBatchSelectObjectsDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchSelectObjectsNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     batchSelectObjectsJobsSchema(),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"all_counts": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     batchSelectObjectsResultsSchema(),
+			},
+		},
+	}
+}
+
+func batchSelectObjectsJobsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"selected": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"sync_database": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"job": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     batchSelectObjectsJobSchema(),
+			},
+		},
+	}
+}
+
+func batchSelectObjectsJobSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parent_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"object_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"object_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"select": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"object_alias_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func batchSelectObjectsResultsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"job_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"error_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildBatchSelectObjectsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"jobs": buildBatchSelectObjectsJobsParams(d),
+	}
+}
+
+func buildBatchSelectObjectsJobsParams(d *schema.ResourceData) []map[string]interface{} {
+	rawArray := d.Get("jobs").([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawConfig := d.GetRawConfig()
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for i, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"job_id":   rawMap["job_id"],
+			"selected": utils.GetNestedObjectFromRawConfig(rawConfig, fmt.Sprintf("jobs.%d.selected", i)),
+			"sync_database": utils.GetNestedObjectFromRawConfig(
+				rawConfig, fmt.Sprintf("jobs.%d.sync_database", i)),
+			"job": buildBatchSelectObjectsJobParams(rawMap["job"].([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func buildBatchSelectObjectsJobParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"id":                utils.ValueIgnoreEmpty(rawMap["id"]),
+			"parent_id":         utils.ValueIgnoreEmpty(rawMap["parent_id"]),
+			"object_type":       utils.ValueIgnoreEmpty(rawMap["object_type"]),
+			"object_name":       utils.ValueIgnoreEmpty(rawMap["object_name"]),
+			"select":            utils.ValueIgnoreEmpty(rawMap["select"]),
+			"object_alias_name": utils.ValueIgnoreEmpty(rawMap["object_alias_name"]),
+		})
+	}
+
+	return rst
+}
+
+func resourceBatchSelectObjectsCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v3/{project_id}/jobs/batch-select-objects"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildBatchSelectObjectsBodyParams(d)),
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch selecting DRS job objects: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(resourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("all_counts", utils.PathSearch("all_counts", respBody, nil)),
+		d.Set("results", flattenBatchSelectObjectsResults(
+			utils.PathSearch("results", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting DRS batch select objects fields: %s", mErr)
+	}
+
+	return nil
+}
+
+func flattenBatchSelectObjectsResults(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(results))
+	for _, result := range results {
+		rst = append(rst, map[string]interface{}{
+			"job_id":     utils.PathSearch("job_id", result, nil),
+			"status":     utils.PathSearch("status", result, nil),
+			"error_code": utils.PathSearch("error_code", result, nil),
+			"error_msg":  utils.PathSearch("error_msg", result, nil),
+		})
+	}
+
+	return rst
+}
+
+func resourceBatchSelectObjectsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceBatchSelectObjectsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceBatchSelectObjectsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch select DRS job objects. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information
+    from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_batch_select_objects` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_batch_select_objects` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccBatchSelectObjects_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccBatchSelectObjects_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchSelectObjects_basic
=== PAUSE TestAccBatchSelectObjects_basic
=== CONT  TestAccBatchSelectObjects_basic
--- PASS: TestAccBatchSelectObjects_basic (29.03s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       29.163s coverage: 5.4% of statements in ./huaweicloud/services/drs
```
<img width="894" height="41" alt="image" src="https://github.com/user-attachments/assets/86e1e8ec-5646-40e3-b237-8d1eaffc9074" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
