### PR TITLE
feat(rds): add data source to rds slow log statistics

### DIFF
--- a/docs/data-sources/rds_slow_log_statistics.md
+++ b/docs/data-sources/rds_slow_log_statistics.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_slow_log_statistics"
+description: |-
+  Use this data source to get the statistics of RDS slow logs within HuaweiCloud.
+---
+
+# huaweicloud_rds_slow_log_statistics
+
+Use this data source to get the statistics of RDS slow logs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_rds_slow_log_statistics" "test" {
+  instance_id = var.instance_id
+  start_time  = var.start_time
+  end_time    = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS instance.
+
+* `start_time` - (Required, String) Specifies the start time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `end_time` - (Required, String) Specifies the end time in the **yyyy-mm-ddThh:mm:ssZ** format.
+  Only slow logs within one month before the current time can be queried.
+
+* `type` - (Optional, String) Specifies the type of SQL statements.
+  Value options: **INSERT**, **UPDATE**, **SELECT**, **DELETE**, **CREATE** and **ALL**, defaults to **ALL**.
+
+* `database` - (Optional, String) Specifies the name of the database.
+  The database name does not support searching with special characters: **<**, **>** and **&**.
+
+* `sort` - (Optional, String) Specifies the sort field. If the value is **executeTime**, the results are sorted
+  by the average execution time. Other values or an empty value sort the results by the number of executions.
+
+* `order` - (Optional, String) Specifies the sort order. Value options: **desc** (descending) and
+  **asc** (ascending), defaults to **desc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `slow_log_list` - The statistics list of the slow logs.
+
+  The [slow_log_list](#slow_log_list_struct) structure is documented below.
+
+<a name="slow_log_list_struct"></a>
+The `slow_log_list` block supports:
+
+* `count` - The number of executions.
+
+* `time` - The average execution time.
+
+* `lock_time` - The average lock wait time, valid only for MySQL.
+
+* `rows_sent` - The average number of result rows, valid only for MySQL.
+
+* `rows_examined` - The average number of scanned rows, valid only for MySQL.
+
+* `database` - The database name.
+
+* `users` - The account name.
+
+* `query_sample` - The SQL execution syntax.
+
+* `client_ip` - The IP address of the client.
+
+* `type` - The type of SQL statements.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2278,6 +2278,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_instance_no_index_tables":           rds.DataSourceRdsInstanceNoIndexTables(),
 			"huaweicloud_rds_backups":                            rds.DataSourceRdsBackups(),
 			"huaweicloud_rds_backup_files":                       rds.DataSourceRdsBackupFiles(),
+			"huaweicloud_rds_slow_log_statistics":                rds.DataSourceRdsSlowLogStatistics(),
 			"huaweicloud_rds_storage_types":                      rds.DataSourceStoragetype(),
 			"huaweicloud_rds_sqlserver_collations":               rds.DataSourceSQLServerCollations(),
 			"huaweicloud_rds_sqlserver_databases":                rds.DataSourceSQLServerDatabases(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_slow_log_statistics_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_slow_log_statistics_test.go
@@ -1,0 +1,45 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRdsSlowLogStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rds_slow_log_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRdsInstanceId(t)
+			acceptance.TestAccPreCheckRdsTimeRange(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRdsSlowLogStatistics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "slow_log_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRdsSlowLogStatistics_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_rds_slow_log_statistics" "test" {
+  instance_id = "%[1]s"
+  start_time  = "%[2]s"
+  end_time    = "%[3]s"
+}
+`, acceptance.HW_RDS_INSTANCE_ID, acceptance.HW_RDS_START_TIME, acceptance.HW_RDS_END_TIME)
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_slow_log_statistics.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_slow_log_statistics.go
@@ -1,0 +1,225 @@
+package rds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS POST /v3.1/{project_id}/instances/{instance_id}/slow-logs/statistics
+func DataSourceRdsSlowLogStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsSlowLogStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"database": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"slow_log_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     rdsSlowLogSchema(),
+			},
+		},
+	}
+}
+
+func rdsSlowLogSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"count": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"lock_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rows_sent": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"rows_examined": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"database": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"users": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"query_sample": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildRdsSlowLogStatisticsBodyParams(d *schema.ResourceData, limit, offset int) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"start_time": d.Get("start_time").(string),
+		"end_time":   d.Get("end_time").(string),
+		"limit":      limit,
+		"offset":     offset,
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		bodyParams["type"] = v
+	}
+
+	if v, ok := d.GetOk("database"); ok {
+		bodyParams["database"] = v
+	}
+
+	if v, ok := d.GetOk("sort"); ok {
+		bodyParams["sort"] = v
+	}
+
+	if v, ok := d.GetOk("order"); ok {
+		bodyParams["order"] = v
+	}
+
+	return bodyParams
+}
+
+func dataSourceRdsSlowLogStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3.1/{project_id}/instances/{instance_id}/slow-logs/statistics"
+		product = "rds"
+		offset  = 0
+		limit   = 100
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", d.Get("instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	for {
+		requestOpt.JSONBody = buildRdsSlowLogStatisticsBodyParams(d, limit, offset)
+
+		resp, err := client.Request("POST", requestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RDS slow log statistics: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		slowLogList := utils.PathSearch("slow_log_list", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, slowLogList...)
+
+		if len(slowLogList) < limit {
+			break
+		}
+
+		offset += len(slowLogList)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("slow_log_list", flattenRdsSlowLogList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRdsSlowLogList(slowLogList []interface{}) []interface{} {
+	if len(slowLogList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(slowLogList))
+	for _, v := range slowLogList {
+		rst = append(rst, map[string]interface{}{
+			"count":         utils.PathSearch("count", v, nil),
+			"time":          utils.PathSearch("time", v, nil),
+			"lock_time":     utils.PathSearch("lock_time", v, nil),
+			"rows_sent":     utils.PathSearch("rows_sent", v, nil),
+			"rows_examined": utils.PathSearch("rows_examined", v, nil),
+			"database":      utils.PathSearch("database", v, nil),
+			"users":         utils.PathSearch("users", v, nil),
+			"query_sample":  utils.PathSearch("query_sample", v, nil),
+			"client_ip":     utils.PathSearch("client_ip", v, nil),
+			"type":          utils.PathSearch("type", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(rds): add data source to rds slow log statistics
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
feat(rds): add data source to rds slow log statistics
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o rds -f TestAccDataSourceRdsSlowLogStatistics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rds" -v -coverprofile="./huaweicloud/services/acceptance/rds/rds_coverage.cov" -coverpkg="./huaweicloud/services/rds" -run TestAccDataSourceRdsSlowLogStatistics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceRdsSlowLogStatistics_basic
=== PAUSE TestAccDataSourceRdsSlowLogStatistics_basic
=== CONT  TestAccDataSourceRdsSlowLogStatistics_basic
--- PASS: TestAccDataSourceRdsSlowLogStatistics_basic (10.53s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/rds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       14.217s coverage: 3.5% of statements in ./huaweicloud/services/rds

```
<img width="1038" height="62" alt="Snipaste_2026-08-27_18-55-13" src="https://github.com/user-attachments/assets/e68f0671-6f68-4400-b09b-cd768da61824" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
