### PR TITLE
feat(coc): the script execute resource supports new fields

### DIFF
--- a/docs/resources/coc_script_batch_execute.md
+++ b/docs/resources/coc_script_batch_execute.md
@@ -3,16 +3,19 @@ subcategory: "Cloud Operations Center (COC)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_coc_script_batch_execute"
 description: |-
-  Manages a COC script execution on multiple ECS instances within HuaweiCloud.
+  Manages a COC script execution on multiple instances of specified resource within HuaweiCloud.
 ---
 
 # huaweicloud_coc_script_batch_execute
 
-Manages a COC script execution on multiple ECS instances within HuaweiCloud.
+Manages a COC script execution on multiple instances of specified resource within HuaweiCloud.
 
--> Please make sure each ECS instance has installed the [UniAgent](https://support.huaweicloud.com/intl/en-us/usermanual-aom2/agent_01_0005.html).
+-> If the specified resource is ECS instance, please make sure each ECS instance has installed
+the [UniAgent](https://support.huaweicloud.com/intl/en-us/usermanual-aom2/agent_01_0005.html).
 
 ## Example Usage
+
+### Script execution on multiple ECS instances
 
 ```hcl
 variable "script_id" {}
@@ -75,13 +78,20 @@ The following arguments are supported:
 * `is_sync` - (Optional, Bool, NonUpdatable) Specifies whether to sync data before executing the script.  
   Defaults to **true**.
 
+* `resource_provider` - (Optional, String, NonUpdatable) Specifies the resource provider.
+  The default value is **ecs**.
+
+* `type` - (Optional, String, NonUpdatable) Specifies the resource type of the resource provider.
+  The default value is **cloudservers**.
+
 <a name="coc_script_batch_execute_execute_batches"></a>
 The `execute_batches` block supports:
 
 * `batch_index` - (Required, Int, NonUpdatable) Specifies the batch index.  
   The minimum value is `1`.
 
-* `instance_ids` - (Required, List, NonUpdatable) Specifies the ID list of the ECS instances in this batch.  
+* `instance_ids` - (Required, List, NonUpdatable) Specifies the ID list of the specified resource instances
+  in this batch.  
   A maximum of `10` instances can be operated in batches.
 
 <a name="coc_script_batch_execute_parameters"></a>
@@ -120,7 +130,8 @@ $ terraform import huaweicloud_coc_script_batch_execute.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `execute_batches`, `parameters`, `is_sync`.
+API response, security or some other reason. The missing attributes include: `execute_batches`, `parameters`,
+`is_sync`, `resource_provider` and `type`.
 
 It is generally recommended running `terraform plan` after importing the resource.
 You can then decide if changes should be applied to the resource, or the resource definition should be updated to
@@ -132,7 +143,7 @@ resource "huaweicloud_coc_script_batch_execute" "test" {
 
   lifecycle {
     ignore_changes = [
-      execute_batches, parameters, is_sync,
+      execute_batches, parameters, is_sync, resource_provider, type,
     ]
   }
 }

--- a/docs/resources/coc_script_execute.md
+++ b/docs/resources/coc_script_execute.md
@@ -2,24 +2,28 @@
 subcategory: "Cloud Operations Center (COC)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_coc_script_execute"
-description: ""
+description: |-
+  Manages a COC script execution on a specified resource within HuaweiCloud.
 ---
 
 # huaweicloud_coc_script_execute
 
-Execute a COC script on a specified ECS instance within HuaweiCloud.
+Manages a COC script execution on a specified resource within HuaweiCloud.
 
--> Please make sure the ECS instance has installed the [UniAgent](https://support.huaweicloud.com/intl/en-us/usermanual-aom2/agent_01_0005.html).
+-> If the specified resource is ECS instance, please make sure the resource has installed
+the [UniAgent](https://support.huaweicloud.com/intl/en-us/usermanual-aom2/agent_01_0005.html).
 
 ## Example Usage
 
+### Script execution on a specified ECS instance
+
 ```hcl
 variable "script_id" {}
-variable "instance_id" {}
+variable "ecs_instance_id" {}
 
 resource "huaweicloud_coc_script_execute" "test" {
   script_id    = var.script_id
-  instance_id  = var.instance_id
+  instance_id  = var.ecs_instance_id
   timeout      = 600
   execute_user = "root"
 
@@ -40,7 +44,7 @@ The following arguments are supported:
 
 * `script_id` - (Required, String, NonUpdatable) Specifies the COC script ID.
 
-* `instance_id` - (Required, String, NonUpdatable) Specifies the ECS instance ID.
+* `instance_id` - (Required, String, NonUpdatable) Specifies the resource ID.
 
 * `timeout` - (Required, Int, NonUpdatable) Specifies the maximum time to execute the script in seconds.
 
@@ -51,6 +55,12 @@ The following arguments are supported:
   The [parameters](#block--parameters) structure is documented below.
 
 * `is_sync` - (Optional, Bool, NonUpdatable) Specifies whether sync data before execute the script. Defaults to **true**.
+
+* `resource_provider` - (Optional, String, NonUpdatable) Specifies the resource provider.
+  The default value is **ecs**.
+
+* `type` - (Optional, String, NonUpdatable) Specifies the resource type of the resource provider.
+  The default value is **cloudservers**.
 
 <a name="block--parameters"></a>
 The `parameters` block supports:
@@ -89,7 +99,8 @@ $ terraform import huaweicloud_coc_script_execute.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include `instance_id`, `parameters` and `is_sync`.
+API response, security or some other reason. The missing attributes include `instance_id`, `parameters`, `is_sync`,
+`resource_provider` and `type`.
 
 It is generally recommended running `terraform plan` after importing the resource.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated to
@@ -101,7 +112,7 @@ resource "huaweicloud_coc_script_execute" "test" {
 
   lifecycle {
     ignore_changes = [
-      instance_id, parameters, is_sync
+      instance_id, parameters, is_sync, resource_provider, type,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/coc/resource_huaweicloud_coc_script_batch_execute_test.go
+++ b/huaweicloud/services/acceptance/coc/resource_huaweicloud_coc_script_batch_execute_test.go
@@ -78,7 +78,7 @@ func TestAccScriptBatchExecute_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"execute_batches", "parameters", "is_sync",
+					"execute_batches", "parameters", "is_sync", "resource_provider", "type",
 				},
 			},
 			{
@@ -86,7 +86,7 @@ func TestAccScriptBatchExecute_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"execute_batches", "parameters", "is_sync",
+					"execute_batches", "parameters", "is_sync", "resource_provider", "type",
 				},
 			},
 		},

--- a/huaweicloud/services/acceptance/coc/resource_huaweicloud_coc_script_execute_test.go
+++ b/huaweicloud/services/acceptance/coc/resource_huaweicloud_coc_script_execute_test.go
@@ -80,7 +80,7 @@ func TestAccScriptExecute_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_id", "parameters", "is_sync"},
+				ImportStateVerifyIgnore: []string{"instance_id", "parameters", "is_sync", "resource_provider", "type"},
 			},
 		},
 	})
@@ -123,7 +123,7 @@ func TestAccScriptExecute_no_sync(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_id", "parameters", "is_sync"},
+				ImportStateVerifyIgnore: []string{"instance_id", "parameters", "is_sync", "resource_provider", "type"},
 			},
 		},
 	})

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script_batch_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script_batch_execute.go
@@ -30,6 +30,8 @@ var scriptBatchExecuteNonUpdatableParams = []string{
 	"parameters.*.name",
 	"parameters.*.value",
 	"is_sync",
+	"resource_provider",
+	"type",
 }
 
 // @API COC POST /v1/external/resources/sync
@@ -91,6 +93,18 @@ func ResourceScriptBatchExecute() *schema.Resource {
 				Default:     true,
 				Description: `Whether to sync data before executing the script.`,
 			},
+			"resource_provider": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "ecs",
+				Description: `The resource provider.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "cloudservers",
+				Description: `The resource type of the resource provider.`,
+			},
 
 			// Attributes.
 			"status": {
@@ -142,7 +156,7 @@ func scriptBatchExecuteBatchesSchema() *schema.Resource {
 				Type:        schema.TypeList,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: `The ID list of the ECS instances in this batch.`,
+				Description: `The ID list of the specified resource instances in this batch.`,
 			},
 		},
 	}
@@ -224,7 +238,7 @@ func buildScriptBatchExecuteBatchesTargetInstances(instanceIds []string, instanc
 	return results
 }
 
-func listResources(client *golangsdk.ServiceClient, instanceId string) ([]interface{}, error) {
+func listResources(client *golangsdk.ServiceClient, resourceProvider, resourceType, instanceId string) ([]interface{}, error) {
 	var (
 		httpUrl = "v1/resources"
 		limit   = 100
@@ -232,7 +246,8 @@ func listResources(client *golangsdk.ServiceClient, instanceId string) ([]interf
 		result  = make([]interface{}, 0)
 	)
 
-	listPath := client.Endpoint + fmt.Sprintf("%s?provider=ecs&type=cloudservers&limit=%v&resource_id_list=%s", httpUrl, limit, instanceId)
+	pathParams := fmt.Sprintf("%s?provider=%s&type=%s&limit=%v&resource_id_list=%s", httpUrl, resourceProvider, resourceType, limit, instanceId)
+	listPath := client.Endpoint + pathParams
 	listOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
@@ -262,9 +277,9 @@ func listResources(client *golangsdk.ServiceClient, instanceId string) ([]interf
 	return result, nil
 }
 
-func refreshResourcesAgentStatus(client *golangsdk.ServiceClient, instanceId string) retry.StateRefreshFunc {
+func refreshResourcesAgentStatus(client *golangsdk.ServiceClient, resourceProvider, resourceType, instanceId string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resources, err := listResources(client, instanceId)
+		resources, err := listResources(client, resourceProvider, resourceType, instanceId)
 		if err != nil {
 			return nil, "ERROR", err
 		}
@@ -321,18 +336,21 @@ func resourceScriptBatchExecuteCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating COC client: %s", err)
 	}
 
+	resourceProvider := d.Get("resource_provider").(string)
+	resourceType := d.Get("type").(string)
 	// Synchronize the ECS instances to get information about UniAgent.
 	if d.Get("is_sync").(bool) {
-		if err = syncResourceInfo(client); err != nil {
+		if err = syncResourceInfo(client, resourceProvider, resourceType); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	instanceIds := utils.PathSearch("[*].instance_ids[]", d.Get("execute_batches").([]interface{}), make([]interface{}, 0))
 	stateConf := &retry.StateChangeConf{
-		Pending:      []string{"PENDING"},
-		Target:       []string{"COMPLETE"},
-		Refresh:      refreshResourcesAgentStatus(client, strings.Join(utils.ExpandToStringList(instanceIds.([]interface{})), ",")),
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETE"},
+		Refresh: refreshResourcesAgentStatus(client, resourceProvider, resourceType,
+			strings.Join(utils.ExpandToStringList(instanceIds.([]interface{})), ",")),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        5 * time.Second,
 		PollInterval: 15 * time.Second,

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
@@ -25,6 +25,7 @@ var scriptOrderNotFoundErrCodes = []string{
 
 var scriptExecuteNonUpdatableParams = []string{
 	"script_id", "instance_id", "timeout", "execute_user", "parameters", "parameters.*.name", "parameters.*.value", "is_sync",
+	"resource_provider", "type",
 }
 
 // @API COC POST /v1/job/scripts/{script_uuid}
@@ -89,6 +90,16 @@ func ResourceScriptExecute() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+			"resource_provider": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "ecs",
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "cloudservers",
 			},
 			"enable_force_new": {
 				Type:         schema.TypeString,
@@ -186,9 +197,11 @@ func resourceScriptExecuteCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	instanceID := d.Get("instance_id").(string)
+	resourceProvider := d.Get("resource_provider").(string)
+	resourceType := d.Get("type").(string)
 	// sync the ECS instance to get information about UniAgent
 	if d.Get("is_sync").(bool) {
-		if err = syncResourceInfo(client); err != nil {
+		if err = syncResourceInfo(client, resourceProvider, resourceType); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -196,7 +209,7 @@ func resourceScriptExecuteCreate(ctx context.Context, d *schema.ResourceData, me
 	stateConf := &retry.StateChangeConf{
 		Pending:      []string{"pending"},
 		Target:       []string{"online"},
-		Refresh:      doGetResources(client, instanceID),
+		Refresh:      doGetResources(client, resourceProvider, resourceType, instanceID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        5 * time.Second,
 		PollInterval: 15 * time.Second,
@@ -359,7 +372,7 @@ func resourceScriptExecuteDelete(_ context.Context, d *schema.ResourceData, meta
 	return nil
 }
 
-func syncResourceInfo(client *golangsdk.ServiceClient) error {
+func syncResourceInfo(client *golangsdk.ServiceClient, resourceProvider, resourceType string) error {
 	syncResourceHttpUrl := "v1/external/resources/sync"
 	syncResourcePath := client.Endpoint + syncResourceHttpUrl
 
@@ -367,8 +380,8 @@ func syncResourceInfo(client *golangsdk.ServiceClient) error {
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 		JSONBody: map[string]string{
-			"provider": "ecs",
-			"type":     "cloudservers",
+			"provider": resourceProvider,
+			"type":     resourceType,
 		},
 	}
 
@@ -380,10 +393,10 @@ func syncResourceInfo(client *golangsdk.ServiceClient) error {
 	return nil
 }
 
-func doGetResources(client *golangsdk.ServiceClient, instanceID string) retry.StateRefreshFunc {
+func doGetResources(client *golangsdk.ServiceClient, resourceProvider, resourceType, instanceID string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		listResourceInfoHttpUrl := fmt.Sprintf("v1/external/resources?provider=%s&type=%s&limit=10&resource_id_list=%s",
-			"ecs", "cloudservers", instanceID)
+			resourceProvider, resourceType, instanceID)
 		listResourceInfoPath := client.Endpoint + listResourceInfoHttpUrl
 
 		listResourceInfoOpt := golangsdk.RequestOpts{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The script execute resource supports new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
The follow resources support new parameter:
1.huaweicloud_coc_script_execute
2.huaweicloud_coc_script_batch_execute
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o coc -f TestAccScriptBatchExecute_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/coc" -v -coverprofile="./huaweicloud/services/acceptance/coc/coc_coverage.cov" -coverpkg="./huaweicloud/services/coc" -run TestAccScriptBatchExecute_basic -timeout 360m -parallel 10
=== RUN   TestAccScriptBatchExecute_basic
=== PAUSE TestAccScriptBatchExecute_basic
=== CONT  TestAccScriptBatchExecute_basic
--- PASS: TestAccScriptBatchExecute_basic (301.07s)
PASS
coverage: 7.7% of statements in ./huaweicloud/services/coc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/coc       302.588s        coverage: 7.7% of statements in ./huaweicloud/services/coc
```
```
$ ./scripts/coverage.sh -o coc -f TestAccScriptExecute_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/coc" -v -coverprofile="./huaweicloud/services/acceptance/coc/coc_coverage.cov" -coverpkg="./huaweicloud/services/coc" -run TestAccScriptExecute_basic -timeout 360m -parallel 10
=== RUN   TestAccScriptExecute_basic
=== PAUSE TestAccScriptExecute_basic
=== CONT  TestAccScriptExecute_basic
--- PASS: TestAccScriptExecute_basic (29.97s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/coc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/coc       31.481s coverage: 7.6% of statements in ./huaweicloud/services/coc
```
```
$ ./scripts/coverage.sh -o coc -f TestAccScriptExecute_no_sync
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/coc" -v -coverprofile="./huaweicloud/services/acceptance/coc/coc_coverage.cov" -coverpkg="./huaweicloud/services/coc" -run TestAccScriptExecute_no_sync -timeout 360m -parallel 10
=== RUN   TestAccScriptExecute_no_sync
=== PAUSE TestAccScriptExecute_no_sync
=== CONT  TestAccScriptExecute_no_sync
--- PASS: TestAccScriptExecute_no_sync (29.24s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/coc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/coc       30.753s coverage: 7.4% of statements in ./huaweicloud/services/coc
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
