### PR TITLE
feat(cbh): add data source to cbh switch config info

### DIFF
--- a/docs/data-sources/cbh_switch_config_info.md
+++ b/docs/data-sources/cbh_switch_config_info.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbh_switch_config_info"
+description: |-
+  Use this data source to query the CBH switch config info within HuaweiCloud.
+---
+
+# huaweicloud_cbh_switch_config_info
+
+Use this data source to query the CBH switch config info within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+data "huaweicloud_cbh_switch_config_info" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the switch config info.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `switch_info` - The switch information of the CBH service.
+  The [switch_info](#cbh_switch_config_info_switch_info) structure is documented below.
+
+* `version_info` - The version information of the CBH service.
+  The [version_info](#cbh_switch_config_info_version_info) structure is documented below.
+
+<a name="cbh_switch_config_info_switch_info"></a>
+The `switch_info` block supports:
+
+* `is_support_unibuy` - Whether unibuy is supported.
+* `is_support_float_ipv6` - Whether floating IPv6 is supported.
+* `is_support_admin_login` - Whether admin login is supported.
+* `is_support_update_ha` - Whether HA update is supported.
+* `is_support_tms` - Whether TMS is supported.
+* `is_support_eps` - Whether EPS is supported.
+* `is_support_iam_login` - Whether IAM login is supported.
+* `is_support_ipv6` - Whether IPv6 is supported.
+* `is_support_ha` - Whether HA is supported.
+* `is_support_reset` - Whether reset admin password and admin login mode is supported.
+* `is_support_upgrade_instance` - Whether instance upgrade is supported.
+* `is_support_change_security_group` - Whether security group change is supported.
+* `is_support_manually_ip` - Whether manual IP is supported.
+* `is_support_capacity_expantion` - Whether capacity expansion is supported.
+* `is_support_ha_expantion` - Whether HA expansion is supported.
+* `is_support_agency_authorize` - Whether agency authorization is supported.
+* `is_support_change_vpc` - Whether VPC change is supported.
+* `is_support_cluster` - Whether cluster is supported.
+* `is_support_ondemand` - Whether on-demand billing is supported.
+* `is_support_period` - Whether period billing is supported.
+
+<a name="cbh_switch_config_info_version_info"></a>
+The `version_info` block supports:
+
+* `require_eip` - The instance version that supports EIP.
+* `iam_login` - The instance version that supports IAM login.
+* `admin_login` - The instance version that supports admin login.
+* `float_ipv6` - The instance version that supports floating IPv6.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -689,6 +689,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbh_instance_admin_url": cbh.DataSourceInstanceAdminUrl(),
 			"huaweicloud_cbh_instance_login_url": cbh.DataSourceInstanceLoginUrl(),
 			"huaweicloud_cbh_instance_om_url":    cbh.DataSourceInstanceOmUrl(),
+			"huaweicloud_cbh_switch_config_info": cbh.DataSourceSwitchConfigInfo(),
 
 			"huaweicloud_cc_authorizations":                               cc.DataSourceCcAuthorizations(),
 			"huaweicloud_cc_bandwidth_packages":                           cc.DataSourceCcBandwidthPackages(),

--- a/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_switch_config_info_test.go
+++ b/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_switch_config_info_test.go
@@ -1,0 +1,40 @@
+package cbh
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSwitchConfigInfo_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_cbh_switch_config_info.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSwitchConfigInfo_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "switch_info.0.is_support_unibuy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "switch_info.0.is_support_iam_login"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "switch_info.0.is_support_ha"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version_info.0.require_eip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version_info.0.iam_login"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceSwitchConfigInfo_basic string = `
+data "huaweicloud_cbh_switch_config_info" "test" {}
+`

--- a/huaweicloud/services/cbh/data_source_huaweicloud_cbh_switch_config_info.go
+++ b/huaweicloud/services/cbh/data_source_huaweicloud_cbh_switch_config_info.go
@@ -1,0 +1,239 @@
+package cbh
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBH GET /v2/{project_id}/cbs/feature/config
+func DataSourceSwitchConfigInfo() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSwitchConfigInfoRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"switch_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"is_support_unibuy": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_float_ipv6": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_admin_login": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_update_ha": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_tms": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_eps": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_iam_login": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_ipv6": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_ha": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_reset": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_upgrade_instance": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_change_security_group": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_manually_ip": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_capacity_expantion": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_ha_expantion": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_agency_authorize": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_change_vpc": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_cluster": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_ondemand": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_support_period": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"version_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"require_eip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"iam_login": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"admin_login": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"float_ipv6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSwitchConfigInfoRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		mErr       *multierror.Error
+		getHttpUrl = "v2/{project_id}/cbs/feature/config"
+		product    = "cbh"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CBH switch config info: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("switch_info", flattenSwitchInfo(getRespBody)),
+		d.Set("version_info", flattenVersionInfo(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSwitchInfo(resp interface{}) []interface{} {
+	switchInfo := utils.PathSearch("switch_info", resp, nil)
+	if switchInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"is_support_unibuy":                utils.PathSearch("is_support_unibuy", switchInfo, nil),
+			"is_support_float_ipv6":            utils.PathSearch("is_support_float_ipv6", switchInfo, nil),
+			"is_support_admin_login":           utils.PathSearch("is_support_admin_login", switchInfo, nil),
+			"is_support_update_ha":             utils.PathSearch("is_support_update_ha", switchInfo, nil),
+			"is_support_tms":                   utils.PathSearch("is_support_tms", switchInfo, nil),
+			"is_support_eps":                   utils.PathSearch("is_support_eps", switchInfo, nil),
+			"is_support_iam_login":             utils.PathSearch("is_support_iam_login", switchInfo, nil),
+			"is_support_ipv6":                  utils.PathSearch("is_support_ipv6", switchInfo, nil),
+			"is_support_ha":                    utils.PathSearch("is_support_ha", switchInfo, nil),
+			"is_support_reset":                 utils.PathSearch("is_support_reset", switchInfo, nil),
+			"is_support_upgrade_instance":      utils.PathSearch("is_support_upgrade_instance", switchInfo, nil),
+			"is_support_change_security_group": utils.PathSearch("is_support_change_security_group", switchInfo, nil),
+			"is_support_manually_ip":           utils.PathSearch("is_support_manually_ip", switchInfo, nil),
+			"is_support_capacity_expantion":    utils.PathSearch("is_support_capacity_expantion", switchInfo, nil),
+			"is_support_ha_expantion":          utils.PathSearch("is_support_ha_expantion", switchInfo, nil),
+			"is_support_agency_authorize":      utils.PathSearch("is_support_agency_authorize", switchInfo, nil),
+			"is_support_change_vpc":            utils.PathSearch("is_support_change_vpc", switchInfo, nil),
+			"is_support_cluster":               utils.PathSearch("is_support_cluster", switchInfo, nil),
+			"is_support_ondemand":              utils.PathSearch("is_support_ondemand", switchInfo, nil),
+			"is_support_period":                utils.PathSearch("is_support_period", switchInfo, nil),
+		},
+	}
+}
+
+func flattenVersionInfo(resp interface{}) []interface{} {
+	versionInfo := utils.PathSearch("version_info", resp, nil)
+	if versionInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"require_eip": utils.PathSearch("require_eip", versionInfo, nil),
+			"iam_login":   utils.PathSearch("iam_login", versionInfo, nil),
+			"admin_login": utils.PathSearch("admin_login", versionInfo, nil),
+			"float_ipv6":  utils.PathSearch("float_ipv6", versionInfo, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to cbh switch config info
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to cbh switch config info
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbh -f TestAccDataSourceSwitchConfigInfo_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbh" -v -coverprofile="./huaweicloud/services/acceptance/cbh/cbh_coverage.cov" -coverpkg="./huaweicloud/services/cbh" -run TestAccDataSourceSwitchConfigInfo_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSwitchConfigInfo_basic
=== PAUSE TestAccDataSourceSwitchConfigInfo_basic
=== CONT  TestAccDataSourceSwitchConfigInfo_basic
--- PASS: TestAccDataSourceSwitchConfigInfo_basic (9.88s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/cbh
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       12.007s coverage: 3.8% of statements in ./huaweicloud/services/cbh
```
<img width="921" height="28" alt="image" src="https://github.com/user-attachments/assets/0ab3d5f2-ff2a-4537-89dc-dfb27777fafb" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
