### PR TITLE
fix(AS): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_warm_pool_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_warm_pool_test.go
@@ -55,6 +55,7 @@ func TestAccAsWarmPool_basic(t *testing.T) {
 	var obj interface{}
 
 	rName := "huaweicloud_as_warm_pool.test"
+	name := acceptance.RandomAccResourceName()
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -68,7 +69,7 @@ func TestAccAsWarmPool_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAsWarmPool_basic(),
+				Config: testAsWarmPool_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "min_capacity", "1"),
@@ -78,12 +79,7 @@ func TestAccAsWarmPool_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      rName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAsWarmPool_basic_update(),
+				Config: testAsWarmPool_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "min_capacity", "2"),
@@ -92,28 +88,37 @@ func TestAccAsWarmPool_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
 				),
 			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
-func testAsWarmPool_basic() string {
+func testAsWarmPool_basic(name string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "huaweicloud_as_warm_pool" "test" {
-  scaling_group_id 		  = "%s"
+  scaling_group_id 		  = huaweicloud_as_group.acc_as_group.id
   min_capacity     		  = 1
   max_capacity     		  = 1
   instance_init_wait_time = 30
 }
-`, acceptance.HW_AS_SCALING_GROUP_ID)
+`, testASGroup_basic(name))
 }
 
-func testAsWarmPool_basic_update() string {
+func testAsWarmPool_basic_update(name string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "huaweicloud_as_warm_pool" "test" {
-  scaling_group_id 		  = "%s"
+  scaling_group_id 		  = huaweicloud_as_group.acc_as_group.id
   min_capacity     		  = 2
   max_capacity     		  = 2
   instance_init_wait_time = 60
 }
-`, acceptance.HW_AS_SCALING_GROUP_ID)
+`, testASGroup_basic(name))
 }

--- a/huaweicloud/services/as/resource_huaweicloud_as_warm_pool.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_warm_pool.go
@@ -26,8 +26,8 @@ var warmPoolNonUpdatableParams = []string{"scaling_group_id"}
 // @API AS DELETE /v2/{project_id}/scaling-groups/{scaling_group_id}/warm-pool
 func ResourceAsWarmPool() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAsWarmPoolCreateOrUpdate,
-		UpdateContext: resourceAsWarmPoolCreateOrUpdate,
+		CreateContext: resourceAsWarmPoolCreate,
+		UpdateContext: resourceAsWarmPoolUpdate,
 		ReadContext:   resourceAsWarmPoolRead,
 		DeleteContext: resourceAsWarmPoolDelete,
 		CustomizeDiff: config.FlexibleForceNew(warmPoolNonUpdatableParams),
@@ -82,11 +82,10 @@ func ResourceAsWarmPool() *schema.Resource {
 	}
 }
 
-func resourceAsWarmPoolCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAsWarmPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg            = meta.(*config.Config)
 		region         = cfg.GetRegion(d)
-		httpUrl        = "v2/{project_id}/scaling-groups/{scaling_group_id}/warm-pool"
 		product        = "autoscaling"
 		scalingGroupID = d.Get("scaling_group_id").(string)
 	)
@@ -94,6 +93,42 @@ func resourceAsWarmPoolCreateOrUpdate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.Errorf("error creating AS client: %s", err)
 	}
+
+	err = updateASWarmPool(client, scalingGroupID, d)
+	if err != nil {
+		return diag.Errorf("error creating AS warm pool: %s", err)
+	}
+
+	d.SetId(scalingGroupID)
+	return resourceAsWarmPoolRead(ctx, d, meta)
+}
+
+func resourceAsWarmPoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		product        = "autoscaling"
+		scalingGroupID = d.Get("scaling_group_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AS client: %s", err)
+	}
+
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateASWarmPool(client, scalingGroupID, d)
+		if err != nil {
+			return diag.Errorf("error updating AS warm pool: %s", err)
+		}
+	}
+
+	return resourceAsWarmPoolRead(ctx, d, meta)
+}
+
+func updateASWarmPool(client *golangsdk.ServiceClient, scalingGroupID string, d *schema.ResourceData) error {
+	var (
+		httpUrl = "v2/{project_id}/scaling-groups/{scaling_group_id}/warm-pool"
+	)
 
 	updatePath := client.Endpoint + httpUrl
 	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
@@ -109,13 +144,8 @@ func resourceAsWarmPoolCreateOrUpdate(ctx context.Context, d *schema.ResourceDat
 		JSONBody: utils.RemoveNil(buildCreateOrUpdateASWarmPoolBodyParams(d)),
 	}
 
-	_, err = client.Request("PUT", updatePath, &putOpt)
-	if err != nil {
-		return diag.Errorf("error creating or updating AS warm pool: %s", err)
-	}
-
-	d.SetId(d.Get("scaling_group_id").(string))
-	return resourceAsWarmPoolRead(ctx, d, meta)
+	_, err := client.Request("PUT", updatePath, &putOpt)
+	return err
 }
 
 func buildCreateOrUpdateASWarmPoolBodyParams(d *schema.ResourceData) map[string]interface{} {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Skip update logic when only 'enable_force_new' changes for the following resource of AS service:
- resource_huaweicloud_as_warm_pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Skip update logic when only 'enable_force_new' changes for resources of AS service
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
- resource_huaweicloud_as_warm_pool
    ```
    make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run=TestAccAsWarmPool'
    === RUN   TestAccAsWarmPool_basic
    === PAUSE TestAccAsWarmPool_basic
    === CONT  TestAccAsWarmPool_basic
    --- PASS: TestAccAsWarmPool_basic (146.23s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as 146.254s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1790" height="957" alt="anulE70Iua" src="https://github.com/user-attachments/assets/c2584368-22c1-44c6-ae4f-2be52ecf8145" />
    
    only change attribute`enable_force_new`:
    <img width="1813" height="951" alt="Hcflidjczl" src="https://github.com/user-attachments/assets/b68d5e85-90c9-415f-b7a5-2d8cc31672cb" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
