### PR TITLE
fix(HSS): skip update logic when only 'enable_force_new' changes

### DIFF
--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_kubernetes_cluster_daemonset_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_kubernetes_cluster_daemonset_test.go
@@ -72,7 +72,6 @@ func TestAccContainerKubernetesClusterDaemonset_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			// This test case requires the preparation of a CCE cluster under the default enterprise project.
 			acceptance.TestAccPreCheckHSSCCEProtection(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -112,9 +111,14 @@ func TestAccContainerKubernetesClusterDaemonset_basic(t *testing.T) {
 
 func testContainerKubernetesClusterDaemonset_basic() string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 resource "huaweicloud_hss_container_kubernetes_cluster_daemonset" "test" {
-  cluster_id   = "%[1]s"
-  cluster_name = "%[2]s"
+  cluster_id   = "%[2]s"
+  cluster_name = "%[3]s"
   auto_upgrade = true
 
   runtime_info {
@@ -126,16 +130,21 @@ resource "huaweicloud_hss_container_kubernetes_cluster_daemonset" "test" {
     node_selector = ["test=test"]
   }
 
-  enterprise_project_id = "0"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
-`, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
 }
 
 func testContainerKubernetesClusterDaemonset_update() string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 resource "huaweicloud_hss_container_kubernetes_cluster_daemonset" "test" {
-  cluster_id   = "%[1]s"
-  cluster_name = "%[2]s"
+  cluster_id   = "%[2]s"
+  cluster_name = "%[3]s"
   auto_upgrade = true
 
   runtime_info {
@@ -147,7 +156,7 @@ resource "huaweicloud_hss_container_kubernetes_cluster_daemonset" "test" {
     node_selector = ["test_update=test_update"]
   }
 
-  enterprise_project_id = "0"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
-`, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
 }

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_login_common_location_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_login_common_location_test.go
@@ -2,6 +2,7 @@ package hss
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -12,12 +13,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss"
 )
 
-func getLoginCommonLocationResourceFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+func getLoginCommonLocationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	var (
-		region       = acceptance.HW_REGION_NAME
-		epsId        = "all_granted_eps"
-		testAreaCode = 110109
-		product      = "hss"
+		region  = acceptance.HW_REGION_NAME
+		product = "hss"
 	)
 
 	client, err := cfg.NewServiceClient(product, region)
@@ -25,7 +24,21 @@ func getLoginCommonLocationResourceFunc(cfg *config.Config, _ *terraform.Resourc
 		return nil, fmt.Errorf("error creating HSS client: %s", err)
 	}
 
-	return hss.QueryLoginCommonLocation(client, testAreaCode, epsId)
+	areaCodeStr, ok := state.Primary.Attributes["area_code"]
+	if !ok || areaCodeStr == "" {
+		return nil, fmt.Errorf("area_code not found in resource state attributes")
+	}
+	areaCode, err := strconv.Atoi(areaCodeStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid area_code value (%s) in resource state: %s", areaCodeStr, err)
+	}
+
+	epsId := state.Primary.Attributes["enterprise_project_id"]
+	if epsId == "" {
+		epsId = hss.QueryAllEpsValue
+	}
+
+	return hss.QueryLoginCommonLocation(client, areaCode, epsId)
 }
 
 func TestAccLoginCommonLocation_basic(t *testing.T) {
@@ -74,7 +87,7 @@ func TestAccLoginCommonLocation_basic(t *testing.T) {
 func testAccLoginCommonLocation_basic() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_hss_login_common_location" "test" {
-  area_code             = 110109
+  area_code             = 215  # BeiJing
   host_id_list          = ["%s"]
   enterprise_project_id = "all_granted_eps"
 }
@@ -84,7 +97,7 @@ resource "huaweicloud_hss_login_common_location" "test" {
 func testAccLoginCommonLocation_update() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_hss_login_common_location" "test" {
-  area_code             = 110109
+  area_code             = 215
   host_id_list          = ["%s"]
   enterprise_project_id = "all_granted_eps"
 }

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_policy_group_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_policy_group_test.go
@@ -95,26 +95,36 @@ func TestAccPolicyGroup_basic(t *testing.T) {
 
 func testAccPolicyGroup_basic(name string) string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 resource "huaweicloud_hss_policy_group" "test" {
-  group_id              = "%s"
-  name                  = "%s"
+  group_id              = "%[2]s"
+  name                  = "%[3]s"
   description           = "test description"
-  enterprise_project_id = "all_granted_eps"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
   protect_mode          = "high_detection"
 }
-`, acceptance.HW_HSS_POLICY_GROUP_ID, name)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_HSS_POLICY_GROUP_ID, name)
 }
 
 func testAccPolicyGroup_update(name string) string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 resource "huaweicloud_hss_policy_group" "test" {
-  group_id              = "%s"
-  name                  = "%s"
+  group_id              = "%[2]s"
+  name                  = "%[3]s"
   description           = "test description"
-  enterprise_project_id = "all_granted_eps"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
   protect_mode          = "equalization"
 }
-`, acceptance.HW_HSS_POLICY_GROUP_ID, name)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_HSS_POLICY_GROUP_ID, name)
 }
 
 func testAccPolicyGroupImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_cicd_configuration.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_cicd_configuration.go
@@ -124,7 +124,10 @@ func resourceCiCdConfigurationCreate(ctx context.Context, d *schema.ResourceData
 	requestPath += buildCiCdConfigurationQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateCiCdConfigurationBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateCiCdConfigurationBodyParams(d)),
 	}
 
 	resp, err := client.Request("POST", requestPath, &requestOpt)
@@ -196,6 +199,9 @@ func resourceCiCdConfigurationRead(_ context.Context, d *schema.ResourceData, me
 	requestPath += buildCiCdConfigurationQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	resp, err := client.Request("GET", requestPath, &requestOpt)
@@ -259,18 +265,23 @@ func resourceCiCdConfigurationUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	requestPath := client.Endpoint + "v5/{project_id}/image/cicd/configurations/{cicd_id}"
-	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
-	requestPath = strings.ReplaceAll(requestPath, "{cicd_id}", d.Id())
-	requestPath += buildCiCdConfigurationQueryParams(epsId)
-	requestOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         buildUpdateCiCdConfigurationBodyParams(d),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		requestPath := client.Endpoint + "v5/{project_id}/image/cicd/configurations/{cicd_id}"
+		requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+		requestPath = strings.ReplaceAll(requestPath, "{cicd_id}", d.Id())
+		requestPath += buildCiCdConfigurationQueryParams(epsId)
+		requestOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: buildUpdateCiCdConfigurationBodyParams(d),
+		}
 
-	_, err = client.Request("PUT", requestPath, &requestOpt)
-	if err != nil {
-		return diag.Errorf("error updating HSS CiCd configuration: %s", err)
+		_, err = client.Request("PUT", requestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error updating HSS CiCd configuration: %s", err)
+		}
 	}
 
 	return resourceCiCdConfigurationRead(ctx, d, meta)
@@ -300,7 +311,10 @@ func resourceCiCdConfigurationDelete(_ context.Context, d *schema.ResourceData, 
 	deletePath += buildCiCdConfigurationQueryParams(epsId)
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         buildDeleteCiCdConfigurationBodyParams(d),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildDeleteCiCdConfigurationBodyParams(d),
 	}
 
 	_, err = client.Request("POST", deletePath, &deleteOpt)

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_container_kubernetes_cluster_daemonset.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_container_kubernetes_cluster_daemonset.go
@@ -249,7 +249,10 @@ func resourceContainerKubernetesClusterDaemonsetCreate(ctx context.Context, d *s
 	requestPath += buildContainerKubernetesClusterDaemonsetQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateContainerKubernetesClusterDaemonsetBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateContainerKubernetesClusterDaemonsetBodyParams(d)),
 	}
 
 	_, err = client.Request("POST", requestPath, &requestOpt)
@@ -277,7 +280,7 @@ func resourceContainerKubernetesClusterDaemonsetRead(_ context.Context, d *schem
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
 		product = "hss"
-		epsId   = cfg.GetEnterpriseProjectID(d)
+		epsId   = cfg.GetEnterpriseProjectID(d, QueryAllEpsValue)
 	)
 
 	client, err := cfg.NewServiceClient(product, region)
@@ -381,8 +384,11 @@ func updateContainerKubernetesClusterDaemonset(client *golangsdk.ServiceClient, 
 	requestPath += buildContainerKubernetesClusterDaemonsetQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"region": region},
-		JSONBody:         utils.RemoveNil(buildUpdateContainerKubernetesClusterDaemonsetBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       region,
+		},
+		JSONBody: utils.RemoveNil(buildUpdateContainerKubernetesClusterDaemonsetBodyParams(d)),
 	}
 
 	_, err := client.Request("PUT", requestPath, &requestOpt)
@@ -395,7 +401,7 @@ func resourceContainerKubernetesClusterDaemonsetUpdate(ctx context.Context, d *s
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
 		product = "hss"
-		epsId   = cfg.GetEnterpriseProjectID(d)
+		epsId   = cfg.GetEnterpriseProjectID(d, QueryAllEpsValue)
 	)
 
 	client, err := cfg.NewServiceClient(product, region)
@@ -435,7 +441,7 @@ func resourceContainerKubernetesClusterDaemonsetDelete(ctx context.Context, d *s
 		region  = cfg.GetRegion(d)
 		product = "hss"
 		id      = d.Id()
-		epsId   = cfg.GetEnterpriseProjectID(d)
+		epsId   = cfg.GetEnterpriseProjectID(d, QueryAllEpsValue)
 	)
 
 	client, err := cfg.NewServiceClient(product, region)
@@ -449,7 +455,10 @@ func resourceContainerKubernetesClusterDaemonsetDelete(ctx context.Context, d *s
 	deletePath += buildDeleteContainerKubernetesClusterDaemonsetQueryParams(d, epsId)
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"region": region},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       region,
+		},
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
@@ -473,6 +482,9 @@ func getClusterDaemonset(client *golangsdk.ServiceClient, clusterId, epsId strin
 	queryPath += buildContainerKubernetesClusterDaemonsetQueryParams(epsId)
 	queryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	resp, err := client.Request("GET", queryPath, &queryOpt)

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_container_kubernetes_cluster_daemonset.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_container_kubernetes_cluster_daemonset.go
@@ -409,9 +409,11 @@ func resourceContainerKubernetesClusterDaemonsetUpdate(ctx context.Context, d *s
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	err = updateContainerKubernetesClusterDaemonset(client, d, epsId, region)
-	if err != nil {
-		return diag.Errorf("error updating HSS container kubernetes cluster daemonset: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		err = updateContainerKubernetesClusterDaemonset(client, d, epsId, region)
+		if err != nil {
+			return diag.Errorf("error updating HSS container kubernetes cluster daemonset: %s", err)
+		}
 	}
 
 	return resourceContainerKubernetesClusterDaemonsetRead(ctx, d, meta)

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_event_system_user_white_list.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_event_system_user_white_list.go
@@ -131,7 +131,10 @@ func resourceEventSystemUserWhiteListCreate(ctx context.Context, d *schema.Resou
 	createPath += buildEventSystemUserWhiteListQueryParams(epsId)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateEventSystemUserWhiteListBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateOrUpdateEventSystemUserWhiteListBodyParams(d)),
 	}
 
 	_, err = client.Request("POST", createPath, &createOpt)
@@ -172,6 +175,9 @@ func resourceEventSystemUserWhiteListRead(_ context.Context, d *schema.ResourceD
 	queryPath += buildReadEventSystemUserWhiteListQueryParams(hostID, epsId)
 	queryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	resp, err := client.Request("GET", queryPath, &queryOpt)
@@ -219,17 +225,22 @@ func resourceEventSystemUserWhiteListUpdate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	updatePath := client.Endpoint + "v5/{project_id}/event/white-list/userlist"
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath += buildEventSystemUserWhiteListQueryParams(epsId)
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateOrUpdateEventSystemUserWhiteListBodyParams(d)),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + "v5/{project_id}/event/white-list/userlist"
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath += buildEventSystemUserWhiteListQueryParams(epsId)
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildCreateOrUpdateEventSystemUserWhiteListBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating HSS event system user white list: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating HSS event system user white list: %s", err)
+		}
 	}
 
 	return resourceEventSystemUserWhiteListRead(ctx, d, meta)
@@ -272,7 +283,10 @@ func resourceEventSystemUserWhiteListDelete(_ context.Context, d *schema.Resourc
 	deletePath += buildEventSystemUserWhiteListQueryParams(epsId)
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         buildDeleteEventSystemUserWhiteListBodyParams(d),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildDeleteEventSystemUserWhiteListBodyParams(d),
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_honeypot_port_policy.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_honeypot_port_policy.go
@@ -181,7 +181,10 @@ func resourceHoneypotPortPolicyCreate(ctx context.Context, d *schema.ResourceDat
 	createPath += buildHoneypotPortPolicyQueryParams(epsId)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildHoneypotPortPolicyBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildHoneypotPortPolicyBodyParams(d)),
 	}
 
 	_, err = client.Request("POST", createPath, &createOpt)
@@ -218,6 +221,9 @@ func getHoneypotPortPolicyId(client *golangsdk.ServiceClient, policyName, epsId 
 
 	listOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	for {
@@ -256,6 +262,9 @@ func GetHoneypotPortPolicy(client *golangsdk.ServiceClient, policyId, epsId stri
 	getPath += buildHoneypotPortPolicyQueryParams(epsId)
 	getOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	resp, err := client.Request("GET", getPath, &getOpts)
@@ -323,18 +332,23 @@ func resourceHoneypotPortPolicyUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Id())
-	updatePath += buildHoneypotPortPolicyQueryParams(epsId)
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildHoneypotPortPolicyBodyParams(d)),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Id())
+		updatePath += buildHoneypotPortPolicyQueryParams(epsId)
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(buildHoneypotPortPolicyBodyParams(d)),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating dynamic port honeypot policy: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating dynamic port honeypot policy: %s", err)
+		}
 	}
 
 	return resourceHoneypotPortPolicyRead(ctx, d, meta)
@@ -359,6 +373,9 @@ func resourceHoneypotPortPolicyDelete(_ context.Context, d *schema.ResourceData,
 	deletePath += buildHoneypotPortPolicyQueryParams(epsId)
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_login_common_location.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_login_common_location.go
@@ -82,6 +82,9 @@ func updateLoginCommonLocation(client *golangsdk.ServiceClient, d *schema.Resour
 	requestPath += buildLoginCommonLocationModifyQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 		JSONBody: map[string]interface{}{
 			"area_code":    d.Get("area_code"),
 			"host_id_list": d.Get("host_id_list"),
@@ -135,6 +138,9 @@ func QueryLoginCommonLocation(client *golangsdk.ServiceClient, areaCode int, eps
 	requestPath += buildLoginCommonLocationQueryParams(epsId, areaCode)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	resp, err := client.Request("GET", requestPath, &requestOpt)
@@ -195,8 +201,10 @@ func resourceLoginCommonLocationUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	if err := updateLoginCommonLocation(client, d, epsId); err != nil {
-		return diag.Errorf("error updating HSS login common location in update operation: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		if err := updateLoginCommonLocation(client, d, epsId); err != nil {
+			return diag.Errorf("error updating HSS login common location in update operation: %s", err)
+		}
 	}
 
 	return resourceLoginCommonLocationRead(ctx, d, meta)
@@ -220,6 +228,9 @@ func resourceLoginCommonLocationDelete(_ context.Context, d *schema.ResourceData
 	requestPath += buildLoginCommonLocationModifyQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 		JSONBody: map[string]interface{}{
 			"area_code":    d.Get("area_code"),
 			"host_id_list": make([]string, 0),

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_policy_group.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_policy_group.go
@@ -142,6 +142,9 @@ func queryPolicyGroupByName(client *golangsdk.ServiceClient, name, epsId string)
 	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	var (
@@ -191,6 +194,9 @@ func updatePolicyGroup(client *golangsdk.ServiceClient, d *schema.ResourceData, 
 	requestPath += buildUpdateGroupQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 		JSONBody: map[string]interface{}{
 			"group_id":     d.Id(),
 			"protect_mode": d.Get("protect_mode"),
@@ -220,7 +226,10 @@ func resourcePolicyGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	createPath += buildCreateGroupQueryParams(epsId)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateGroupBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateGroupBodyParams(d)),
 	}
 
 	_, err = client.Request("PUT", createPath, &createOpt)
@@ -264,6 +273,9 @@ func QueryPolicyGroupById(client *golangsdk.ServiceClient, policyGroupId, epsId 
 	requestPath += buildQueryGroupByIdQueryParams(policyGroupId, epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	resp, err := client.Request("GET", requestPath, &requestOpt)
@@ -328,8 +340,10 @@ func resourcePolicyGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	if err := updatePolicyGroup(client, d, epsId); err != nil {
-		return diag.Errorf("error updating HSS policy group in update operation: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		if err := updatePolicyGroup(client, d, epsId); err != nil {
+			return diag.Errorf("error updating HSS policy group in update operation: %s", err)
+		}
 	}
 
 	return resourcePolicyGroupRead(ctx, d, meta)
@@ -360,6 +374,9 @@ func resourcePolicyGroupDelete(_ context.Context, d *schema.ResourceData, meta i
 	requestPath += buildDeleteGroupQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 		JSONBody: map[string]interface{}{
 			"id_list": []string{d.Id()},
 		},

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_policy_switch_status.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_policy_switch_status.go
@@ -64,6 +64,9 @@ func updatePolicySwitchStatus(client *golangsdk.ServiceClient, d *schema.Resourc
 	requestPath += fmt.Sprintf("?enterprise_project_id=%s", epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 		JSONBody: map[string]interface{}{
 			"policy_name": d.Get("policy_name"),
 			"enable":      d.Get("enable"),
@@ -119,8 +122,10 @@ func resourcePolicySwitchStatusUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	if err := updatePolicySwitchStatus(client, d, epsId); err != nil {
-		return diag.Errorf("error changing HSS policy status in update operation: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		if err := updatePolicySwitchStatus(client, d, epsId); err != nil {
+			return diag.Errorf("error changing HSS policy status in update operation: %s", err)
+		}
 	}
 
 	return resourcePolicySwitchStatusRead(ctx, d, meta)

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_ransomware_protection_policy.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_ransomware_protection_policy.go
@@ -231,7 +231,10 @@ func QueryProtectionPolicyByPolicyName(client *golangsdk.ServiceClient, policyNa
 	requestPath += buildProtectionPolicyByPolicyNameQueryParams(policyName, epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"region": region},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       region,
+		},
 	}
 
 	var (
@@ -289,8 +292,11 @@ func resourceRansomwareProtectionPolicyCreate(ctx context.Context, d *schema.Res
 	requestPath += buildRansomwareProtectionPolicyQueryParams(epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"region": region},
-		JSONBody:         utils.RemoveNil(buildCreateRansomwareProtectionPolicyRequestOpt(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       region,
+		},
+		JSONBody: utils.RemoveNil(buildCreateRansomwareProtectionPolicyRequestOpt(d)),
 	}
 
 	_, err = client.Request("POST", requestPath, &requestOpt)
@@ -336,7 +342,10 @@ func QueryProtectionPolicyByPolicyId(client *golangsdk.ServiceClient, policyId, 
 	requestPath += buildProtectionPolicyByPolicyIdQueryParams(policyId, epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"region": region},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       region,
+		},
 	}
 
 	resp, err := client.Request("GET", requestPath, &requestOpt)
@@ -436,8 +445,11 @@ func updateRansomwareProtectionPolicy(client *golangsdk.ServiceClient, d *schema
 	requestPath += buildRansomwareProtectionPolicyQueryParams(cfg.GetEnterpriseProjectID(d, QueryAllEpsValue))
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"region": cfg.GetRegion(d)},
-		JSONBody:         utils.RemoveNil(buildUpdateRansomwareProtectionPolicyRequestOpt(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       cfg.GetRegion(d),
+		},
+		JSONBody: utils.RemoveNil(buildUpdateRansomwareProtectionPolicyRequestOpt(d)),
 	}
 
 	_, err := client.Request("PUT", requestPath, &requestOpt)
@@ -456,8 +468,10 @@ func resourceRansomwareProtectionPolicyUpdate(ctx context.Context, d *schema.Res
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	if err = updateRansomwareProtectionPolicy(client, d, cfg); err != nil {
-		return diag.Errorf("error updating HSS ransomware protection policy in update operation: %s", err)
+	if d.HasChangeExcept("enable_force_new") {
+		if err = updateRansomwareProtectionPolicy(client, d, cfg); err != nil {
+			return diag.Errorf("error updating HSS ransomware protection policy in update operation: %s", err)
+		}
 	}
 
 	return resourceRansomwareProtectionPolicyRead(ctx, d, meta)
@@ -491,7 +505,10 @@ func resourceRansomwareProtectionPolicyDelete(_ context.Context, d *schema.Resou
 	requestPath += buildDeleteRansomwareProtectionPolicyQueryParams(d.Id(), epsId)
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"region": region},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       region,
+		},
 	}
 
 	_, err = client.Request("DELETE", requestPath, &requestOpt)

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_rasp_protection_policy.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_rasp_protection_policy.go
@@ -367,17 +367,19 @@ func resourceRaspProtectionPolicyUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error creating HSS client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath += buildRaspProtectionPolicyUpdateQueryParams(d.Id(), policyName, epsId)
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         buildRaspProtectionPolicyBodyParams(d),
-	}
+	if d.HasChangeExcept("enable_force_new") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath += buildRaspProtectionPolicyUpdateQueryParams(d.Id(), policyName, epsId)
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         buildRaspProtectionPolicyBodyParams(d),
+		}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating protection policy: %s", err)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating protection policy: %s", err)
+		}
 	}
 
 	return resourceRaspProtectionPolicyRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Fix error: Import resource `huaweicloud_hss_container_kubernetes_cluster_daemonset` failed when the EnterpriseId of CCE cluster is not `0`

2.  Skip update logic when only 'enable_force_new' changes  for the following resources of HSS service:
    - resource_huaweicloud_hss_cicd_configuration.go
    - resource_huaweicloud_hss_event_system_user_white_list.go
    - resource_huaweicloud_hss_rasp_protection_policy.go
    - resource_huaweicloud_hss_honeypot_port_policy.go
    - resource_huaweicloud_hss_container_kubernetes_cluster_daemonset.go
    - resource_huaweicloud_hss_ransomware_protection_policy.go
    - resource_huaweicloud_hss_login_common_location.go
    - resource_huaweicloud_hss_policy_group.go
    - resource_huaweicloud_hss_policy_switch_status.go

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Skip update logic when only 'enable_force_new' changes  for the following resources of HSS service
2. Fix error: Import resource `huaweicloud_hss_container_kubernetes_cluster_daemonset` failed when the EnterpriseId of CCE cluster is not `0` 
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

- resource_huaweicloud_hss_cicd_configuration.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccCiCdConfiguration'
    === RUN   TestAccCiCdConfiguration_basic
    === PAUSE TestAccCiCdConfiguration_basic
    === CONT  TestAccCiCdConfiguration_basic
    --- PASS: TestAccCiCdConfiguration_basic (17.03s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 17.056s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1816" height="943" alt="Image" src="https://github.com/user-attachments/assets/63470ad1-2bdf-4beb-93f7-f8b243f75e15" />

    only change attribute`enable_force_new`:
    <img width="1788" height="943" alt="Image" src="https://github.com/user-attachments/assets/580e48d3-762a-469d-aac6-0b73b6429ff1" />

- resource_huaweicloud_hss_event_system_user_white_list.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccEventSystemUserWhiteList'
    === RUN   TestAccEventSystemUserWhiteList_basic
    === PAUSE TestAccEventSystemUserWhiteList_basic
    === CONT  TestAccEventSystemUserWhiteList_basic
    --- PASS: TestAccEventSystemUserWhiteList_basic (16.89s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 16.914s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1838" height="945" alt="Image" src="https://github.com/user-attachments/assets/2f2a599d-4c2d-461a-a61e-735a132ba33f" />

    only change attribute`enable_force_new`:
    <img width="1835" height="945" alt="Image" src="https://github.com/user-attachments/assets/2f9528d3-092a-448d-af06-6660d0610e69" />

- resource_huaweicloud_hss_rasp_protection_policy.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccResourceRaspProtectionPolicy'
    === RUN   TestAccResourceRaspProtectionPolicy_basic
    === PAUSE TestAccResourceRaspProtectionPolicy_basic
    === CONT  TestAccResourceRaspProtectionPolicy_basic
    --- PASS: TestAccResourceRaspProtectionPolicy_basic (20.46s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 20.485s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1833" height="937" alt="Image" src="https://github.com/user-attachments/assets/f883ab4f-4b2d-4ddc-be19-b31ab78b6908" />

    only change attribute`enable_force_new`:
    <img width="1845" height="950" alt="Image" src="https://github.com/user-attachments/assets/ce7c974c-dc51-4851-ae71-c677009cd44c" />

- resource_huaweicloud_hss_honeypot_port_policy.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccResourceHoneypotPortPolicy'
    === RUN   TestAccResourceHoneypotPortPolicy_basic
    === PAUSE TestAccResourceHoneypotPortPolicy_basic
    === CONT  TestAccResourceHoneypotPortPolicy_basic
    --- PASS: TestAccResourceHoneypotPortPolicy_basic (49.35s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 49.378s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1844" height="921" alt="Image" src="https://github.com/user-attachments/assets/203186b3-97b0-4c4b-ac51-8ba1f9d6501a" />

    only change attribute`enable_force_new`:
    <img width="1849" height="945" alt="Image" src="https://github.com/user-attachments/assets/7e8bd9d4-3b99-4797-aa86-ad2d4012c5d4" />

- resource_huaweicloud_hss_container_kubernetes_cluster_daemonset.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccContainerKubernetesClusterDaemonset'
    === RUN   TestAccContainerKubernetesClusterDaemonset_basic
    === PAUSE TestAccContainerKubernetesClusterDaemonset_basic
    === CONT  TestAccContainerKubernetesClusterDaemonset_basic
    --- PASS: TestAccContainerKubernetesClusterDaemonset_basic (20.09s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 20.116s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1849" height="946" alt="Image" src="https://github.com/user-attachments/assets/ae73eeb0-5bcb-41f8-949e-7ce95766c873" />

    only change attribute`enable_force_new`:
    <img width="1850" height="948" alt="Image" src="https://github.com/user-attachments/assets/672e0e7a-aca4-4eb9-81a2-0403475e8394" />

- resource_huaweicloud_hss_ransomware_protection_policy.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccRansomwareProtectionPolicy'
    === RUN   TestAccRansomwareProtectionPolicy_basic
    === PAUSE TestAccRansomwareProtectionPolicy_basic
    === CONT  TestAccRansomwareProtectionPolicy_basic
    --- PASS: TestAccRansomwareProtectionPolicy_basic (34.51s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 34.537s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1802" height="923" alt="image" src="https://github.com/user-attachments/assets/b38c25aa-d726-4bff-a415-f0469195bcc0" />

    only change attribute`enable_force_new`:
    <img width="1830" height="941" alt="image" src="https://github.com/user-attachments/assets/d7a83d40-b745-496c-aa4e-604e217bc79b" />

- resource_huaweicloud_hss_login_common_location.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccLoginCommonLocation'
    === RUN   TestAccLoginCommonLocation_basic
    === PAUSE TestAccLoginCommonLocation_basic
    === CONT  TestAccLoginCommonLocation_basic
    --- PASS: TestAccLoginCommonLocation_basic (19.88s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 20.026s
   ``` 
    change attributes excpet `enable_force_new`:
    <img width="1855" height="950" alt="image" src="https://github.com/user-attachments/assets/ac029645-a2b6-4bd7-8788-60d49e018235" />

    only change attribute`enable_force_new`:
    <img width="1855" height="944" alt="image" src="https://github.com/user-attachments/assets/7285523e-d1cf-4e59-a50d-086472125a01" />

- resource_huaweicloud_hss_policy_group.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccLoginCommonLocation'
    === RUN   TestAccPolicyGroup_basic
    === PAUSE TestAccPolicyGroup_basic
    === CONT  TestAccPolicyGroup_basic
    --- PASS: TestAccPolicyGroup_basic (48.26s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 48.285s
    ```
    change attributes excpet `enable_force_new`:
    <img width="1845" height="939" alt="image" src="https://github.com/user-attachments/assets/a59e4008-66e8-429a-8fdb-eebf1a33c070" />

    only change attribute`enable_force_new`:
    <img width="1797" height="954" alt="image" src="https://github.com/user-attachments/assets/c485c376-03bf-4ea9-999e-548226ea5184" />


- resource_huaweicloud_hss_policy_switch_status.go
    ```
    make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccPolicySwitchStatus'
    === RUN   TestAccPolicySwitchStatus_basic
    === PAUSE TestAccPolicySwitchStatus_basic
    === CONT  TestAccPolicySwitchStatus_basic
    --- PASS: TestAccPolicySwitchStatus_basic (18.07s)
    PASS
    ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss 18.094s
    ```

    change attributes excpet `enable_force_new`:
    <img width="1824" height="943" alt="image" src="https://github.com/user-attachments/assets/5f36bd1e-5603-4a37-9977-64878a42e6b1" />

    only change attribute`enable_force_new`:
    <img width="1827" height="921" alt="image" src="https://github.com/user-attachments/assets/e95042d9-405d-46bd-b76e-421f90590a95" />


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
