### PR TITLE
feat(geminidb): add new resource to batch delete backups

### DIFF
--- a/docs/resources/geminidb_backup_batch_delete.md
+++ b/docs/resources/geminidb_backup_batch_delete.md
@@ -1,0 +1,42 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_backup_batch_delete"
+description: |-
+  Manages a resource to batch delete manual backup within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_backup_batch_delete
+
+Manages a resource to batch delete manual backup within HuaweiCloud.
+
+-> This resource is a one-time action resource. Deleting this resource will not clear the corresponding request record,
+  but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "backup_id_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_geminidb_backup_batch_delete" "test" {
+  backup_ids = var.backup_id_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `backup_ids` - (Required, List, NonUpdatable) Specifies the IDs of the backup to be batch delete.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4037,6 +4037,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_account":                     geminidb.ResourceGeminidbAccount(),
 			"huaweicloud_geminidb_sessions_close":              geminidb.ResourceGeminiDBSessionsClose(),
 			"huaweicloud_geminidb_backup":                      geminidb.ResourceGeminiDBBackup(),
+			"huaweicloud_geminidb_backup_batch_delete":         geminidb.ResourceBackupBatchDelete(),
 			"huaweicloud_geminidb_backup_stop":                 geminidb.ResourceGeminiDBBackupStop(),
 			"huaweicloud_geminidb_command_disable":             geminidb.ResourceCommandDisable(),
 			"huaweicloud_geminidb_database_operation":          geminidb.ResourceGeminiDBDatabaseOperation(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_backup_batch_delete_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_backup_batch_delete_test.go
@@ -1,0 +1,34 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBackupBatchDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccCheckGeminidbBackupID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testBackupBatchDelete_basic(),
+			},
+		},
+	})
+}
+
+func testBackupBatchDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_geminidb_backup_batch_delete" "test" {
+  backup_ids = split(",", "%s")
+}
+`, acceptance.HW_GEMINIDB_BACKUP_ID)
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_backup_batch_delete.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_backup_batch_delete.go
@@ -1,0 +1,119 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var backupBatchDeleteNonUpdatableParams = []string{
+	"backup_ids",
+}
+
+// @API GeminiDB DELETE /v3/{project_id}/instances/backups
+func ResourceBackupBatchDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBackupBatchDeleteCreate,
+		ReadContext:   resourceBackupBatchDeleteRead,
+		UpdateContext: resourceBackupBatchDeleteUpdate,
+		DeleteContext: resourceBackupBatchDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(backupBatchDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"backup_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBackupBatchDeleteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"backup_ids": utils.ExpandToStringList(d.Get("backup_ids").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func resourceBackupBatchDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/instances/backups"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildBackupBatchDeleteBodyParams(d),
+	}
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error deleting manual backups: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	return nil
+}
+
+func resourceBackupBatchDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBackupBatchDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBackupBatchDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GeminiDB backup batch delete resource is not supported. The resource is only removed from the " +
+		"state, the resource remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to batch delete backups.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o geminidb -f TestAccBackupBatchDelete_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/geminidb" -v -coverprofile="./huaweicloud/services/acceptance/geminidb/geminidb_coverage.cov" -coverpkg="./huaweicloud/services/geminidb" -run TestAccBackupBatchDelete_basic -timeout 360m -parallel 10
=== RUN   TestAccBackupBatchDelete_basic
=== PAUSE TestAccBackupBatchDelete_basic
=== CONT  TestAccBackupBatchDelete_basic
--- PASS: TestAccBackupBatchDelete_basic (8.00s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/geminidb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  9.520s  coverage: 2.7% of statements in ./huaweicloud/services/geminidb
```
<img width="1013" height="15" alt="image" src="https://github.com/user-attachments/assets/52c08b79-767d-4ae4-849e-70e862a36510" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
