### PR TITLE
feat(waf): support `waf_pool` resource

### DIFF
--- a/docs/resources/waf_pool.md
+++ b/docs/resources/waf_pool.md
@@ -1,0 +1,99 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_pool"
+description: |-
+  Manages a WAF pool resource within HuaweiCloud.
+---
+
+# huaweicloud_waf_pool
+
+Manages a WAF pool resource within HuaweiCloud.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+## Example Usage
+
+```hcl
+variable "pool_name" {}
+variable "type" {}
+variable "vpc_id" {}
+
+resource "huaweicloud_waf_pool" "test" {
+  name   = var.pool_name
+  type   = var.type
+  vpc_id = var.vpc_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the WAF pool resource. If omitted, the
+  provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the pool name. The maximum length is `256` characters. Only digits,
+  letters, underscores (_), hyphens (-) and dots (.) are allowed.
+
+* `type` - (Required, String, NonUpdatable) Specifies the pool type. Valid values are:
+  + **elb**: Basic ELB type.
+  + **elb-v2**: ELB-v2 type.
+  + **elb-shadow**: SaaS ELB type.
+  + **standard-container**: Reverse proxy dedicated engine group (in-cloud, dedicated for tenants).
+  + **standard-cloud**: Reverse proxy dedicated engine group (in-cloud).
+  + **standard**: Reverse proxy dedicated engine group (out-of-cloud).
+  + **detector-cloud**: Bypass detection dedicated engine group (in-cloud).
+  + **detector**: Bypass detection dedicated engine group (out-of-cloud).
+
+* `vpc_id` - (Required, String, NonUpdatable) Specifies the VPC ID associated with the pool.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the pool.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID of WAF pool.
+  This parameter is valid only when the enterprise project is enabled.  
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the pools under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The pool ID.
+
+* `hosts` - The list of protected domain names associated with the pool.
+
+  The [hosts](#pool_Hosts_Instances) structure is documented below.
+
+* `instances` - The list of engine instances associated with the pool.
+
+  The [instances](#pool_Hosts_Instances) structure is documented below.
+
+* `create_time` - The creation time of the pool, in milliseconds.
+
+<a name="pool_Hosts_Instances"></a>
+The `hosts` block supports:
+
+* `id` - The resource ID.
+
+* `name` - The resource name.
+
+* `service_ip` - The engine instance IP.
+
+## Import
+
+The WAF pool resource can be imported using `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+### Import resource under the default enterprise project
+
+```bash
+$ terraform import huaweicloud_waf_pool.test <id>/0
+```
+
+### Import resource from non default enterprise project
+
+```bash
+$ terraform import huaweicloud_waf_pool.test <id>/<enterprise_project_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4922,6 +4922,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_policy_v2":                           waf.ResourceWafPolicyV2(),
 			"huaweicloud_waf_policies_batch_delete":               waf.ResourcePoliciesBatchDelete(),
 			"huaweicloud_waf_policy_copy":                         waf.ResourcePolicyCopy(),
+			"huaweicloud_waf_pool":                                waf.ResourceWafPool(),
 			"huaweicloud_waf_reference_table":                     waf.ResourceWafReferenceTable(),
 			"huaweicloud_waf_rule_anti_crawler":                   waf.ResourceRuleAntiCrawler(),
 			"huaweicloud_waf_rule_blacklist":                      waf.ResourceWafRuleBlackList(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_pool_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_pool_test.go
@@ -1,0 +1,110 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
+)
+
+func getPoolResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("waf", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	return waf.GetWafPool(client, state.Primary.ID, state.Primary.Attributes["enterprise_project_id"])
+}
+
+// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+func TestAccPool_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		randName     = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_waf_pool.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getPoolResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafPool_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "type", "detector-cloud"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "hosts.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "instances.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFPoolImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testAccWafPool_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+`, name)
+}
+
+func testAccWafPool_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_waf_pool" "test" {
+  name                  = "%[2]s"
+  type                  = "detector-cloud"
+  vpc_id                = huaweicloud_vpc.test.id
+  description           = "created by terraform"
+  enterprise_project_id = "%[3]s"
+}
+`, testAccWafPool_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testWAFPoolImportState(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		id := rs.Primary.ID
+		if id == "" || epsId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<id>/<enterprise_project_id>', but got '%s/%s'",
+				id, epsId)
+		}
+
+		return fmt.Sprintf("%s/%s", id, epsId), nil
+	}
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_pool.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_pool.go
@@ -1,0 +1,303 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableParamsPool = []string{
+	"name",
+	"type",
+	"vpc_id",
+	"description",
+	"enterprise_project_id",
+}
+
+// @API WAF POST /v1/{project_id}/premium-waf/pool
+// @API WAF GET /v1/{project_id}/premium-waf/pool/{pool_id}
+// @API WAF DELETE /v1/{project_id}/premium-waf/pool/{pool_id}
+func ResourceWafPool() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafPoolCreate,
+		ReadContext:   resourceWafPoolRead,
+		UpdateContext: resourceWafPoolUpdate,
+		DeleteContext: resourceWafPoolDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceWAFPoolImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableParamsPool),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// The query API does not return, so the `Computed` attribute is not added.
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"hosts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     poolIdNameEntrySchema(),
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     poolIdNameEntrySchema(),
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func poolIdNameEntrySchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildWafPoolQueryParams(epsId string) string {
+	if epsId == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func buildCreatePoolBodyParams(d *schema.ResourceData, region string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"region":      region,
+		"type":        d.Get("type"),
+		"vpc_id":      d.Get("vpc_id"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceWafPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/premium-waf/pool"
+		product = "waf"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += buildWafPoolQueryParams(epsId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildCreatePoolBodyParams(d, region)),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating WAF pool: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating WAF pool: ID is not found in API response")
+	}
+
+	d.SetId(id)
+
+	return resourceWafPoolRead(ctx, d, meta)
+}
+
+func GetWafPool(client *golangsdk.ServiceClient, poolId, epsId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/premium-waf/pool/{pool_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{pool_id}", poolId)
+	getPath += buildWafPoolQueryParams(epsId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceWafPoolRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		product = "waf"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	respBody, err := GetWafPool(client, d.Id(), epsId)
+	if err != nil {
+		// If the pool does not exist, the response HTTP status code of the details API is `404`.
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF pool")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("type", utils.PathSearch("type", respBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("hosts", flattenPoolIdNameEntries(
+			utils.PathSearch("hosts", respBody, make([]interface{}, 0)))),
+		d.Set("instances", flattenPoolIdNameEntries(
+			utils.PathSearch("instances", respBody, make([]interface{}, 0)))),
+		d.Set("create_time", utils.PathSearch("create_time", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPoolIdNameEntries(raw interface{}) []map[string]interface{} {
+	entries, ok := raw.([]interface{})
+	if !ok || len(entries) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(entries))
+	for _, v := range entries {
+		rst = append(rst, map[string]interface{}{
+			"id":         utils.PathSearch("id", v, nil),
+			"name":       utils.PathSearch("name", v, nil),
+			"service_ip": utils.PathSearch("service_ip", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func resourceWafPoolUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceWafPoolDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/premium-waf/pool/{pool_id}"
+		product = "waf"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{pool_id}", d.Id())
+	deletePath += buildWafPoolQueryParams(epsId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		// If the pool does not exist, the response HTTP status code of the deletion API is `404`.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF pool")
+	}
+
+	return nil
+}
+
+func resourceWAFPoolImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format of import ID, must be <id>/<enterprise_project_id>")
+	}
+
+	d.SetId(parts[0])
+
+	return []*schema.ResourceData{d}, d.Set("enterprise_project_id", parts[1])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_pool` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_pool` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o waf -f TestAccPool_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccPool_basic -timeout 360m -parallel 10
=== RUN   TestAccPool_basic
=== PAUSE TestAccPool_basic
=== CONT  TestAccPool_basic
--- PASS: TestAccPool_basic (28.40s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       28.560s coverage: 4.4% of statements in ./huaweicloud/services/waf
```
<img width="795" height="33" alt="image" src="https://github.com/user-attachments/assets/03a4cddb-f2ce-4884-8219-193a512635a0" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="1193" height="897" alt="image" src="https://github.com/user-attachments/assets/0aa4c9af-8874-40ba-8fe0-f684f8c01b12" />


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
