### PR TITLE
feat(dcs): add new data source to get list of offline key analysis nodes

### DIFF
--- a/docs/data-sources/dcs_offline_key_analysis_nodes.md
+++ b/docs/data-sources/dcs_offline_key_analysis_nodes.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Distributed Cache Service (DCS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dcs_offline_key_analysis_nodes"
+description: |-
+  Use this data source to query the offline key analyses.
+---
+
+# huaweicloud_dcs_offline_key_analysis_nodes
+
+Use this data source to query the offline key analyses
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "task_id" {}
+
+data "huaweicloud_dcs_offline_key_analysis_nodes" "test" {
+  instance_id = var.instance_id
+  task_id     = var.task_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the DCS instance.
+
+* `task_id` - (Required, String) Specifies the ID of the task.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `nodes` - The list of offline key analysis nodes.
+  The [nodes](#nodes_struct) structure is documented below.
+
+<a name="nodes_struct"></a>
+The `nodes` block supports:
+
+* `id` - The node ID.
+
+* `name` - The node name.
+
+* `group_name` - The group name.
+
+* `node_ipv6` - The node IP address.
+  Return the IPv6 address preferentially, if IPv6 is not configured for the node, will return the IPv4 address.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1208,6 +1208,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_instance_engine_version":             dcs.DataSourceDcsInstanceEngineVersion(),
 			"huaweicloud_dcs_bigkey_analyses":                     dcs.DataSourceDcsBigkeyAnalyses(),
 			"huaweicloud_dcs_offline_key_analyses":                dcs.DataSourceOfflineKeyAnalyses(),
+			"huaweicloud_dcs_offline_key_analysis_nodes":          dcs.DataSourceOfflineKeyAnalysisNodes(),
 			"huaweicloud_dcs_primary_dim_monitored_objects":       dcs.DataSourceDcsPrimaryDimMonitoredObjects(),
 			"huaweicloud_dcs_accounts":                            dcs.DataSourceDcsAccounts(),
 			"huaweicloud_dcs_clients":                             dcs.DataSourceDcsClients(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -826,6 +826,7 @@ var (
 	HW_DCS_BACKUP_ID          = os.Getenv("HW_DCS_BACKUP_ID")
 	HW_DCS_BACKGROUND_TASK_ID = os.Getenv("HW_DCS_BACKGROUND_TASK_ID")
 	HW_DCS_CENTER_TASK_ID     = os.Getenv("HW_DCS_CENTER_TASK_ID")
+	HW_DCS_TASK_ID            = os.Getenv("HW_DCS_TASK_ID")
 
 	HW_ELB_GATEWAY_TYPE = os.Getenv("HW_ELB_GATEWAY_TYPE")
 
@@ -4644,6 +4645,13 @@ func TestAccPreCheckDcsCenterTaskId(t *testing.T) {
 func TestAccPreCheckDcsBackupId(t *testing.T) {
 	if HW_DCS_BACKUP_ID == "" {
 		t.Skip("HW_DCS_BACKUP_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDCSTaskId(t *testing.T) {
+	if HW_DCS_TASK_ID == "" {
+		t.Skip("HW_DCS_TASK_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_offline_key_analysis_nodes_test.go
+++ b/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_offline_key_analysis_nodes_test.go
@@ -1,0 +1,48 @@
+package dcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOfflineKeyAnalysisNodes_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dcs_offline_key_analysis_nodes.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDCSInstanceID(t)
+			acceptance.TestAccPreCheckDCSTaskId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceOfflineKeyAnalysisNodes_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "nodes.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "nodes.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "nodes.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "nodes.0.group_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "nodes.0.node_ipv6"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceOfflineKeyAnalysisNodes_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dcs_offline_key_analysis_nodes" "test" {
+  instance_id = "%[1]s"
+  task_id     = "%[2]s"
+}
+`, acceptance.HW_DCS_INSTANCE_ID, acceptance.HW_DCS_TASK_ID)
+}

--- a/huaweicloud/services/dcs/data_source_huaweicloud_dcs_offline_key_analysis_nodes.go
+++ b/huaweicloud/services/dcs/data_source_huaweicloud_dcs_offline_key_analysis_nodes.go
@@ -1,0 +1,141 @@
+package dcs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DCS GET /v2/{project_id}/instances/{instance_id}/offline/key-analysis/{task_id}/nodes
+func DataSourceOfflineKeyAnalysisNodes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOfflineKeyAnalysisNodesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the DCS instance.`,
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the task.`,
+			},
+			"nodes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the offline key analysis nodes.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The node ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The node name.`,
+						},
+						"group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The group name.`,
+						},
+						"node_ipv6": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The node IP address.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOfflineKeyAnalysisNodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/instances/{instance_id}/offline/key-analysis/{task_id}/nodes"
+		instanceId = d.Get("instance_id").(string)
+		taskId     = d.Get("task_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dcs", region)
+	if err != nil {
+		return diag.Errorf("error creating DCS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{task_id}", taskId)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the DCS offline key analysis nodes: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nodeInfos := utils.PathSearch("nodes", getRespBody, make([]interface{}, 0)).([]interface{})
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("nodes", flattenOfflineKeyAnalysisNodes(nodeInfos)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOfflineKeyAnalysisNodes(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"id":         utils.PathSearch("id", v, nil),
+			"name":       utils.PathSearch("name", v, nil),
+			"group_name": utils.PathSearch("group_name", v, nil),
+			"node_ipv6":  utils.PathSearch("node_ipv6", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of offline key analysis nodes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get the list of offline key analysis nodes.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o dcs -f TestAccDataSourceOfflineKeyAnalysisNodes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dcs" -v -coverprofile="./huaweicloud/services/acceptance/dcs/dcs_coverage.cov" -coverpkg="./huaweicloud/services/dcs" -run TestAccDataSourceOfflineKeyAnalysisNodes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceOfflineKeyAnalysisNodes_basic
=== PAUSE TestAccDataSourceOfflineKeyAnalysisNodes_basic
=== CONT  TestAccDataSourceOfflineKeyAnalysisNodes_basic
--- PASS: TestAccDataSourceOfflineKeyAnalysisNodes_basic (10.26s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/dcs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       11.781s coverage: 3.3% of statements in ./huaweicloud/services/dcs
```
<img width="985" height="19" alt="image" src="https://github.com/user-attachments/assets/fc28871b-65f5-4c00-8637-13a19e3a3af7" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
