### PR TITLE
feat(waf): support `waf_pools` data source

### DIFF
--- a/docs/data-sources/waf_pools.md
+++ b/docs/data-sources/waf_pools.md
@@ -1,0 +1,91 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_pools"
+description: |-
+  Use this data source to get the list of WAF pools within HuaweiCloud.
+---
+
+# huaweicloud_waf_pools
+
+Use this data source to get the list of WAF pools within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_waf_pools" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID used for filtering.
+  If you need to query the resources bound to all enterprise projects of the current user, set this parameter to
+  **all_granted_eps**. The default value is **0**, indicating the default enterprise project.
+
+* `name` - (Optional, String) Specifies the pool name used for filtering. The `name` uses fuzzy matching.
+
+* `type` - (Optional, List) Specifies the pool type list used for filtering.  
+  The valid values are as follows:
+  + **elb**: basic ELB type.
+  + **elb-v2**: ELB-v2 type.
+  + **elb-shadow**: SaaS ELB type.
+  + **standard-container**: reverse proxy dedicated engine group (in-cloud, dedicated for tenants).
+  + **standard-cloud**: reverse proxy dedicated engine group (in-cloud).
+  + **standard**: reverse proxy dedicated engine group (out-of-cloud).
+  + **detector-cloud**: bypass detection dedicated engine group (in-cloud).
+  + **detector**: bypass detection dedicated engine group (out-of-cloud).
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID associated with the pool.
+
+* `detail` - (Optional, Bool) Specifies whether to query the detailed information of the pools.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The pool list.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `id` - The pool ID.
+
+* `name` - The pool name.
+
+* `region` - The region where the pool is located.
+
+* `type` - The pool type.
+
+* `vpc_id` - The VPC ID associated with the pool.
+
+* `description` - The description of the pool.
+
+* `hosts` - The list of protected domain names associated with the pool.
+
+  The [hosts](#hosts_instances_struct) structure is documented below.
+
+* `instances` - The list of engine instances associated with the pool.
+
+  The [instances](#hosts_instances_struct) structure is documented below.
+
+* `enterprise_project_id` - The enterprise project ID associated with the pool.
+
+* `create_time` - The creation time of the pool, in milliseconds.
+
+<a name="hosts_instances_struct"></a>
+The `hosts`/`instances` block supports:
+
+* `id` - The resource ID.
+
+* `name` - The resource name.
+
+* `service_ip` - The engine instance IP.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2894,6 +2894,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_overviews_statistics":                 waf.DataSourceWafOverviewsStatistics(),
 			"huaweicloud_waf_policies":                             waf.DataSourceWafPolicies(),
 			"huaweicloud_waf_policy_ip_reputation":                 waf.DataSourcePolicyIpReputation(),
+			"huaweicloud_waf_pools":                                waf.DataSourceWafPools(),
 			"huaweicloud_waf_reference_tables":                     waf.DataSourceWafReferenceTables(),
 			"huaweicloud_waf_rules_anti_crawler":                   waf.DataSourceWafRulesAntiCrawler(),
 			"huaweicloud_waf_rules_blacklist":                      waf.DataSourceWafRulesBlacklist(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_pools_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_pools_test.go
@@ -1,0 +1,135 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceWafPools_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		dataSource = "data.huaweicloud_waf_pools.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceWafPools_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "items.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.region"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.create_time"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("vpc_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceWafPools_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_waf_pool" "test" {
+  name                  = "%[1]s"
+  type                  = "detector-cloud"
+  vpc_id                = huaweicloud_vpc.test.id
+  description           = "created by terraform"
+  enterprise_project_id = "%[2]s"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testDataSourceWafPools_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_waf_pools" "test" {
+  depends_on = [huaweicloud_waf_pool.test]
+
+  enterprise_project_id = "%[2]s"
+  detail                = true
+}
+
+# Filter by name.
+locals {
+  name = data.huaweicloud_waf_pools.test.items[0].name
+}
+
+data "huaweicloud_waf_pools" "filter_by_name" {
+  enterprise_project_id = "%[2]s"
+  name                  = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_waf_pools.filter_by_name.items[*].name : v == local.name
+  ]
+}
+
+output "name_filter_is_useful" {
+  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
+}
+
+# Filter by type.
+locals {
+  type = data.huaweicloud_waf_pools.test.items[0].type
+}
+
+data "huaweicloud_waf_pools" "filter_by_type" {
+  enterprise_project_id = "%[2]s"
+  type                  = [local.type]
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_waf_pools.filter_by_type.items[*].type : v == local.type
+  ]
+}
+
+output "type_filter_is_useful" {
+  value = alltrue(local.type_filter_result) && length(local.type_filter_result) > 0
+}
+
+# Filter by vpc_id.
+locals {
+  vpc_id = data.huaweicloud_waf_pools.test.items[0].vpc_id
+}
+
+data "huaweicloud_waf_pools" "filter_by_vpc_id" {
+  enterprise_project_id = "%[2]s"
+  vpc_id                = local.vpc_id
+}
+
+locals {
+  vpc_id_filter_result = [
+    for v in data.huaweicloud_waf_pools.filter_by_vpc_id.items[*].vpc_id : v == local.vpc_id
+  ]
+}
+
+output "vpc_id_filter_is_useful" {
+  value = alltrue(local.vpc_id_filter_result) && length(local.vpc_id_filter_result) > 0
+}
+`, testDataSourceWafPools_base(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_pools.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_pools.go
@@ -1,0 +1,262 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/premium-waf/pools
+func DataSourceWafPools() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWafPoolsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"detail": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     wafPoolItemSchema(),
+			},
+		},
+	}
+}
+
+func wafPoolItemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hosts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourcePoolIdNameEntrySchema(),
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourcePoolIdNameEntrySchema(),
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePoolIdNameEntrySchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildWafPoolsQueryParams(d *schema.ResourceData, cfg *config.Config, page, pageSize int) string {
+	queryParams := fmt.Sprintf("?page=%d&pagesize=%d", page, pageSize)
+
+	epsId := cfg.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		queryParams = fmt.Sprintf("%s&name=%v", queryParams, v)
+	}
+
+	typeInput := d.Get("type").([]interface{})
+	if len(typeInput) > 0 {
+		for _, v := range utils.ExpandToStringList(typeInput) {
+			queryParams = fmt.Sprintf("%s&type=%v", queryParams, v)
+		}
+	}
+
+	if v, ok := d.GetOk("vpc_id"); ok {
+		queryParams = fmt.Sprintf("%s&vpc_id=%v", queryParams, v)
+	}
+
+	if v := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "detail"); v != nil {
+		queryParams = fmt.Sprintf("%s&detail=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceWafPoolsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v1/{project_id}/premium-waf/pools"
+		product  = "waf"
+		page     = 1
+		pageSize = 100
+		result   = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	for {
+		currentPath := requestPath + buildWafPoolsQueryParams(d, cfg, page, pageSize)
+		resp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving WAF pools: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(items) == 0 {
+			break
+		}
+
+		result = append(result, items...)
+
+		page++
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", flattenWafPoolsItems(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenWafPoolsItems(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"name":        utils.PathSearch("name", v, nil),
+			"region":      utils.PathSearch("region", v, nil),
+			"type":        utils.PathSearch("type", v, nil),
+			"vpc_id":      utils.PathSearch("vpc_id", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+			"hosts": flattenDataSourcePoolIdNameEntries(
+				utils.PathSearch("hosts", v, make([]interface{}, 0))),
+			"instances": flattenDataSourcePoolIdNameEntries(
+				utils.PathSearch("instances", v, make([]interface{}, 0))),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+			"create_time":           utils.PathSearch("create_time", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenDataSourcePoolIdNameEntries(raw interface{}) []map[string]interface{} {
+	entries, ok := raw.([]interface{})
+	if !ok || len(entries) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(entries))
+	for _, v := range entries {
+		rst = append(rst, map[string]interface{}{
+			"id":         utils.PathSearch("id", v, nil),
+			"name":       utils.PathSearch("name", v, nil),
+			"service_ip": utils.PathSearch("service_ip", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_pools` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_pools` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o waf -f TestAccDataSourceWafPools_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceWafPools_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceWafPools_basic
=== PAUSE TestAccDataSourceWafPools_basic
=== CONT  TestAccDataSourceWafPools_basic
--- PASS: TestAccDataSourceWafPools_basic (31.36s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       31.494s coverage: 5.1% of statements in ./huaweicloud/services/waf
```
<img width="796" height="37" alt="image" src="https://github.com/user-attachments/assets/04d0cd87-4a5f-4c43-9c0d-139ea3e7504e" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
