### PR TITLE
feat(dcs): the DCS instance data source supports new fields

### DIFF
--- a/docs/data-sources/dcs_instances.md
+++ b/docs/data-sources/dcs_instances.md
@@ -2,7 +2,8 @@
 subcategory: "Distributed Cache Service (DCS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_dcs_instances"
-description: ""
+description: |-
+  Use this data source to get the list of DCS instances.
 ---
 
 # huaweicloud_dcs_instances
@@ -11,10 +12,19 @@ Use this data source to get the list of DCS instances.
 
 ## Example Usage
 
+### Query all instances
+
 ```hcl
+data "huaweicloud_dcs_instances" "test" {}
+```
+
+### Filter by name
+
+```hcl
+variable "instance_name" {}
+
 data "huaweicloud_dcs_instances" "test" {
-  name   = "test_name"
-  status = "RUNNING"
+  name = var.instance_name
 }
 ```
 
@@ -27,12 +37,18 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specifies the name of an instance.
 
-* `status` - (Optional, String) Specifies the cache instance status. The valid values are **RUNNING**, **ERROR**,
-  **RESTARTING**, **FROZEN**, **EXTENDING**, **RESTORING**, **FLUSHING**.
+* `status` - (Optional, String) Specifies the cache instance status.
+  The valid values are **RUNNING**, **ERROR**, **RESTARTING**, **FROZEN**, **EXTENDING**, **RESTORING**, **FLUSHING**.
 
 * `private_ip` - (Optional, String) Specifies the subnet Network ID.
 
 * `capacity` - (Optional, Float) Specifies the cache capacity. Unit: GB.
+
+* `instance_id` - (Optional, String) Specifies the instance ID.
+
+* `tags` - (Optional, String) Specifies the tags of the instance.
+  If multiple tag key-value pairs are used for the query at the same time, they should be separated by commas(,),
+  indicating that the query includes instances that have the specified tag key-value pairs.
 
 ## Attribute Reference
 
@@ -41,10 +57,10 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The data source ID.
 
 * `instances` - Indicates the list of DCS instances.
-  The [Instance](#DcsInstance_Instance) structure is documented below.
+  The [instances](#instances_struct) structure is documented below.
 
-<a name="DcsInstance_Instance"></a>
-The `Instance` block supports:
+<a name="instances_struct"></a>
+The `instances` block supports:
 
 * `id` - Indicates the ID of the instance.
 
@@ -99,3 +115,29 @@ The `Instance` block supports:
 * `order_id` - Indicates the ID of the order that created the instance.
 
 * `tags` - Indicates The key/value pairs to associate with the DCS instance.
+
+* `publicip_id` - Indicates the EIP ID associated with the instance.
+
+* `created_at` - Indicates the creation time of the instance.
+
+* `updated_at` - Indicates the update time of the instance.
+
+* `enable_ssl` - Whether SSL is enabled for the instance.
+
+* `publicip_address` - Indicates the public IP address associate with the instance.
+
+* `service_upgrade` - Whether an upgrade task has been created for the instance.
+
+* `no_password_access` - Whether password-protected access is enabled for the instance.
+
+* `service_task_id` - Indicates the ID of the upgrade task.
+
+* `user_id` - Indicates the ID of the user to which the instance belongs.
+
+* `user_name` - Indicates the username of the instance.
+
+* `readonly_domain_name` - Indicates the read-only domain name of the instance.
+
+* `cpu_type` - Indicates the CPU type of the instance.
+
+* `az_codes` - Indicates the availability zones where there are available resources.

--- a/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_instances_test.go
+++ b/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_instances_test.go
@@ -1,7 +1,6 @@
 package dcs
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -10,37 +9,112 @@ import (
 )
 
 func TestAccDatasourceDcsInstance_basic(t *testing.T) {
-	rName := "data.huaweicloud_dcs_instances.test"
-	name := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(rName)
+	var (
+		dataSource = "data.huaweicloud_dcs_instances.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDCSInstanceID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceDcsInstance_basic(name),
+				Config: testAccDatasourceDcsInstance_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "instances.0.name", name),
-					resource.TestCheckResourceAttr(rName, "instances.0.port", "6388"),
-					resource.TestCheckResourceAttr(rName, "instances.0.flavor", "redis.ha.xu1.tiny.r2.128"),
-					resource.TestCheckResourceAttrPair(rName, "instances.0.flavor",
-						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.engine"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.engine_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.private_ip"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.port"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.updated_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.vpc_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.maintain_begin"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.maintain_end"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.max_memory"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.used_memory"),
+
+					resource.TestCheckOutput("is_instance_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					resource.TestCheckOutput("is_private_ip_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatasourceDcsInstance_basic(name string) string {
-	return fmt.Sprintf(`
-%s
+func testAccDatasourceDcsInstance_basic() string {
+	return `
+data "huaweicloud_dcs_instances" "test" {}
 
-data "huaweicloud_dcs_instances" "test" {
-  name     = huaweicloud_dcs_instance.instance_1.name
-  status   = "RUNNING"
-  capacity = 0.125
+// filter by instance_id
+locals {
+  instance_id = data.huaweicloud_dcs_instances.test.instances[0].id
 }
-`, testAccDcsV1Instance_basic(name))
+
+data "huaweicloud_dcs_instances" "filter_by_instance_id" {
+  instance_id = local.instance_id
+}
+
+output "is_instance_id_filter_useful" {
+  value = length(data.huaweicloud_dcs_instances.filter_by_instance_id.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_dcs_instances.filter_by_instance_id.instances[*].id : v == local.instance_id]
+  )
+}
+
+// filter by name
+locals {
+  name = data.huaweicloud_dcs_instances.test.instances[0].name
+}
+
+data "huaweicloud_dcs_instances" "filter_by_name" {
+  name = local.name
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_dcs_instances.filter_by_name.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_dcs_instances.filter_by_name.instances[*].name : v == local.name]
+  )
+}
+
+// filter by status
+locals {
+  status = data.huaweicloud_dcs_instances.test.instances[0].status
+}
+
+data "huaweicloud_dcs_instances" "filter_by_status" {
+  status = local.status
+}
+
+output "is_status_filter_useful" {
+  value = length(data.huaweicloud_dcs_instances.filter_by_status.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_dcs_instances.filter_by_status.instances[*].status : v == local.status]
+  )
+}
+
+// filter by private_ip
+locals {
+  private_ip = data.huaweicloud_dcs_instances.test.instances[0].private_ip
+}
+
+data "huaweicloud_dcs_instances" "filter_by_private_ip" {
+  private_ip = local.private_ip
+}
+
+output "is_private_ip_filter_useful" {
+  value = length(data.huaweicloud_dcs_instances.filter_by_private_ip.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_dcs_instances.filter_by_private_ip.instances[*].private_ip : v == local.private_ip]
+  )
+}
+`
 }

--- a/huaweicloud/services/dcs/data_source_huaweicloud_dcs_instances.go
+++ b/huaweicloud/services/dcs/data_source_huaweicloud_dcs_instances.go
@@ -1,8 +1,3 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product DCS
-// ---------------------------------------------------------------
-
 package dcs
 
 import (
@@ -13,14 +8,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/pagination"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -60,6 +53,16 @@ func DataSourceDcsInstance() *schema.Resource {
 				Type:        schema.TypeFloat,
 				Optional:    true,
 				Description: `Specifies the cache capacity. Unit: GB.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the instance ID.`,
+			},
+			"tags": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the tags of the instance.`,
 			},
 			"instances": {
 				Type:        schema.TypeList,
@@ -206,6 +209,72 @@ func InstanceInstanceSchema() *schema.Resource {
 				Description: `Indicates the ID of the order that created the instance.`,
 			},
 			"tags": common.TagsComputedSchema(),
+			"publicip_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the EIP ID associated with the instance.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creation time of the instance.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the update time of the instance.`,
+			},
+			"enable_ssl": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether SSL is enabled for the instance.`,
+			},
+			"publicip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the public IP address associate with the instance.`,
+			},
+			"service_upgrade": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether an upgrade task has been created for the instance.`,
+			},
+			"no_password_access": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates whether password-protected access is enabled for the instance.`,
+			},
+			"service_task_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the ID of the upgrade task.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the ID of the user to which the instance belongs.`,
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the username of the instance.`,
+			},
+			"readonly_domain_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the read-only domain name of the instance.`,
+			},
+			"cpu_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the CPU type of the instance.`,
+			},
+			"az_codes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Indicates the availability zones where there are available resources.`,
+			},
 		},
 	}
 	return &sc
@@ -253,22 +322,23 @@ func resourceDcsInstanceRead(_ context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	dataSourceId, err := uuid.GenerateUUID()
+	randomUUID, err := uuid.NewRandom()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(dataSourceId)
+
+	d.SetId(randomUUID.String())
 
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
-		d.Set("instances", flattenGetDCSInstancesResponseBodyInstance(getDCSInstancesRespBody, getDCSInstancesClient)),
+		d.Set("instances", flattenGetDCSInstancesResponseBodyInstance(getDCSInstancesRespBody)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func flattenGetDCSInstancesResponseBodyInstance(resp interface{}, client *golangsdk.ServiceClient) []interface{} {
+func flattenGetDCSInstancesResponseBodyInstance(resp interface{}) []interface{} {
 	if resp == nil {
 		return nil
 	}
@@ -293,16 +363,9 @@ func flattenGetDCSInstancesResponseBodyInstance(resp interface{}, client *golang
 		if securityGroupID == "securityGroupId" {
 			securityGroupID = ""
 		}
-		id := utils.PathSearch("instance_id", v, "")
-		// save tags
-		var tagMap interface{}
-		if resourceTags, err := tags.Get(client, "instances", id.(string)).Extract(); err == nil {
-			tagMap = utils.TagsToMap(resourceTags.Tags)
-		} else {
-			log.Printf("[WARN] Error fetching tags of DCS instance (%s): %s", id.(string), err)
-		}
+
 		rst = append(rst, map[string]interface{}{
-			"id":                    id,
+			"id":                    utils.PathSearch("instance_id", v, nil),
 			"name":                  utils.PathSearch("name", v, nil),
 			"engine":                utils.PathSearch("engine", v, nil),
 			"engine_version":        utils.PathSearch("engine_version", v, nil),
@@ -328,7 +391,20 @@ func flattenGetDCSInstancesResponseBodyInstance(resp interface{}, client *golang
 			"domain_name":           utils.PathSearch("domain_name", v, nil),
 			"access_user":           utils.PathSearch("access_user", v, nil),
 			"order_id":              utils.PathSearch("order_id", v, nil),
-			"tags":                  tagMap,
+			"tags":                  utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+			"publicip_id":           utils.PathSearch("publicip_id", v, nil),
+			"created_at":            utils.PathSearch("created_at", v, nil),
+			"updated_at":            utils.PathSearch("updated_at", v, nil),
+			"enable_ssl":            utils.PathSearch("enable_ssl", v, nil),
+			"publicip_address":      utils.PathSearch("publicip_address", v, nil),
+			"service_upgrade":       utils.PathSearch("service_upgrade", v, nil),
+			"no_password_access":    utils.PathSearch("no_password_access", v, nil),
+			"service_task_id":       utils.PathSearch("service_task_id", v, nil),
+			"user_id":               utils.PathSearch("user_id", v, nil),
+			"user_name":             utils.PathSearch("user_name", v, nil),
+			"readonly_domain_name":  utils.PathSearch("readonly_domain_name", v, nil),
+			"cpu_type":              utils.PathSearch("cpu_type", v, nil),
+			"az_codes":              utils.PathSearch("az_codes", v, nil),
 		})
 	}
 	return rst
@@ -350,6 +426,14 @@ func buildGetDCSInstancesQueryParams(d *schema.ResourceData) string {
 
 	if v, ok := d.GetOk("capacity"); ok {
 		res = fmt.Sprintf("%s&capacity=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("instance_id"); ok {
+		res = fmt.Sprintf("%s&instance_id=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		res = fmt.Sprintf("%s&tags=%v", res, v)
 	}
 
 	if res != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The DCS instance data source supports new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o dcs -f TestAccDatasourceDcsInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dcs" -v -coverprofile="./huaweicloud/services/acceptance/dcs/dcs_coverage.cov" -coverpkg="./huaweicloud/services/dcs" -run TestAccDatasourceDcsInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceDcsInstance_basic
=== PAUSE TestAccDatasourceDcsInstance_basic
=== CONT  TestAccDatasourceDcsInstance_basic
--- PASS: TestAccDatasourceDcsInstance_basic (13.13s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/dcs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       14.681s coverage: 3.9% of statements in ./huaweicloud/services/dcs
```
<img width="987" height="18" alt="image" src="https://github.com/user-attachments/assets/2b82bb2d-ff3c-4bd7-ad05-51c1a50fd4be" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
