### PR TITLE
feat(iam): v5 resources support poll interval after create completed

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_test.go
@@ -1,10 +1,8 @@
 package iam
 
 import (
-	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -20,7 +18,7 @@ func getV5PolicyResourceFunc(cfg *config.Config, state *terraform.ResourceState)
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
 
-	return iam.GetV5PolicyById(context.Background(), client, state.Primary.ID, 10*time.Second, false)
+	return iam.GetV5PolicyById(client, state.Primary.ID)
 }
 
 func TestAccV5Policy_basic(t *testing.T) {

--- a/huaweicloud/services/iam/common.go
+++ b/huaweicloud/services/iam/common.go
@@ -17,7 +17,7 @@ const (
 	iamPollInterval     = 1 * time.Second
 )
 
-// PollRequest polls an IAM resource until the request function no longer returns 404.
+// PollRequest polls an IAM resource until the request function no longer returns 404 or 409.
 func PollRequest(ctx context.Context, requestFunc func() (interface{}, error)) (interface{}, error) {
 	select {
 	case <-ctx.Done():
@@ -33,7 +33,11 @@ func PollRequest(ctx context.Context, requestFunc func() (interface{}, error)) (
 			return resp, nil
 		}
 
-		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+		// Retry on 404 (resource not yet available) and 409 (temporary conflict during creation).
+		switch err.(type) {
+		case golangsdk.ErrDefault404, golangsdk.ErrDefault409:
+			// continue polling
+		default:
 			return nil, err
 		}
 

--- a/huaweicloud/services/iam/common_test.go
+++ b/huaweicloud/services/iam/common_test.go
@@ -40,28 +40,32 @@ func TestPollRequest_successOnFirstRequest(t *testing.T) {
 	}
 }
 
-// TestPollRequest_successAfter404Retries verifies that PollRequest keeps polling when requestFunc
-// returns golangsdk.ErrDefault404, and eventually returns the successful response once the resource
-// becomes available.
+// TestPollRequest_successAfterRetryableErrors verifies that PollRequest keeps polling when
+// requestFunc returns retryable errors (404 or 409), and eventually returns the successful
+// response once the resource becomes available.
 //
-// The mock requestFunc returns 404 for the first two attempts and succeeds on the third.
+// The mock requestFunc returns 404 on the first attempt, 409 on the second, and succeeds on the third.
 // This test ensures that:
-//   - PollRequest retries on 404 instead of treating it as a terminal error.
+//   - PollRequest retries on both 404 and 409 instead of treating them as terminal errors.
 //   - requestFunc is invoked exactly three times before returning.
 //   - The final successful response is returned to the caller.
-//   - The total elapsed time includes the initial delay plus one interval wait after each 404,
-//     i.e. iamPollInitialDelay + 2*iamPollInterval.
-func TestPollRequest_successAfter404Retries(t *testing.T) {
+//   - The total elapsed time includes the initial delay plus one interval wait after each
+//     retryable error, i.e. iamPollInitialDelay + 2*iamPollInterval.
+func TestPollRequest_successAfterRetryableErrors(t *testing.T) {
 	start := time.Now()
 	expected := map[string]interface{}{"id": "test-id"}
 	attempts := 0
 
 	resp, err := PollRequest(context.Background(), func() (interface{}, error) {
 		attempts++
-		if attempts < 3 {
+		switch attempts {
+		case 1:
 			return nil, golangsdk.ErrDefault404{}
+		case 2:
+			return nil, golangsdk.ErrDefault409{}
+		default:
+			return expected, nil
 		}
-		return expected, nil
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -73,20 +77,20 @@ func TestPollRequest_successAfter404Retries(t *testing.T) {
 		t.Fatalf("expected 3 attempts, got %d", attempts)
 	}
 
-	// Two 404 responses require two interval waits between the three request attempts.
+	// Two retryable responses require two interval waits between the three request attempts.
 	minElapsed := iamPollInitialDelay + 2*iamPollInterval
 	if elapsed := time.Since(start); elapsed < minElapsed {
 		t.Fatalf("expected elapsed time of at least %s, got %s", minElapsed, elapsed)
 	}
 }
 
-// TestPollRequest_non404Error verifies that PollRequest stops immediately when requestFunc returns
-// an error other than golangsdk.ErrDefault404.
+// TestPollRequest_nonRetryableError verifies that PollRequest stops immediately when requestFunc
+// returns an error other than golangsdk.ErrDefault404 or golangsdk.ErrDefault409.
 //
-// Non-404 errors (e.g. 403, 500, network failures) are considered non-retryable and should be
-// returned directly to the caller without entering the interval retry loop.
+// Non-retryable errors (e.g. 403, 500, network failures) should be returned directly to the caller
+// without entering the interval retry loop.
 // This test ensures that the original error is preserved and returned unchanged.
-func TestPollRequest_non404Error(t *testing.T) {
+func TestPollRequest_nonRetryableError(t *testing.T) {
 	expectedErr := errors.New("internal error")
 
 	_, err := PollRequest(context.Background(), func() (interface{}, error) {

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_group.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_group.go
@@ -84,6 +84,15 @@ func resourceV5GroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.SetId(userGroupId)
+
+	// After creation, the group may not be immediately queryable (usually 2-3s, up to 10s).
+	_, err = PollRequest(ctx, func() (interface{}, error) {
+		return GetV5GroupById(client, userGroupId)
+	})
+	if err != nil {
+		return diag.Errorf("error waiting for group (%s) to be created: %s", userGroupId, err)
+	}
+
 	return resourceV5GroupRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -42,10 +39,6 @@ func ResourceV5Policy() *schema.Resource {
 		DeleteContext: resourceV5PolicyDelete,
 
 		CustomizeDiff: config.FlexibleForceNew(v5PolicyNonUpdatableParams),
-
-		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(1 * time.Minute),
-		},
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -189,26 +182,18 @@ func resourceV5PolicyCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	d.SetId(policyId)
 
+	// After creation, the policy may not be immediately queryable (usually 2-3s, up to 10s).
+	_, err = PollRequest(ctx, func() (interface{}, error) {
+		return GetV5PolicyById(client, policyId)
+	})
+	if err != nil {
+		return diag.Errorf("error waiting for identity policy (%s) to be created: %s", policyId, err)
+	}
+
 	return resourceV5PolicyRead(ctx, d, meta)
 }
 
-func handlePolicyQueryError(err error) (bool, error) {
-	if err == nil {
-		return false, nil
-	}
-	if _, ok := err.(golangsdk.ErrDefault404); ok {
-		return true, err
-	}
-	if _, ok := err.(golangsdk.ErrDefault409); ok {
-		return true, err
-	}
-	return false, err
-}
-
-// isRetry is a optional parameter (defaults to false), if it is true, the function will retry the request when the
-// error is retryable (404 or 409).
-func GetV5PolicyById(ctx context.Context, client *golangsdk.ServiceClient, policyId string, timeout time.Duration,
-	isRetry ...bool) (interface{}, error) {
+func GetV5PolicyById(client *golangsdk.ServiceClient, policyId string) (interface{}, error) {
 	httpUrl := "v5/policies/{policy_id}"
 	getPath := client.Endpoint + httpUrl
 	getPath = strings.ReplaceAll(getPath, "{policy_id}", policyId)
@@ -216,24 +201,7 @@ func GetV5PolicyById(ctx context.Context, client *golangsdk.ServiceClient, polic
 		KeepResponseBody: true,
 	}
 
-	var (
-		requestResp *http.Response
-		requestErr  error
-	)
-
-	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
-		requestResp, requestErr = client.Request("GET", getPath, &getOpt)
-		retryable, err := handlePolicyQueryError(requestErr)
-		if retryable && (len(isRetry) > 0 && isRetry[0]) {
-			// lintignore:R018
-			time.Sleep(15 * time.Second)
-			return retry.RetryableError(err)
-		}
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-		return nil
-	})
+	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +258,7 @@ func listV5PolicyVersions(client *golangsdk.ServiceClient, policyId string) ([]i
 	return result, nil
 }
 
-func resourceV5PolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5PolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg      = meta.(*config.Config)
 		region   = cfg.GetRegion(d)
@@ -302,7 +270,7 @@ func resourceV5PolicyRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	policy, err := GetV5PolicyById(ctx, client, policyId, d.Timeout(schema.TimeoutRead), d.IsNewResource())
+	policy, err := GetV5PolicyById(client, policyId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving identity policy (%s)", policyId))
 	}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_user.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_user.go
@@ -122,6 +122,15 @@ func resourceV5UserCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	d.SetId(userId)
+
+	// After creation, the user may not be immediately queryable (usually 2-3s, up to 10s).
+	_, err = PollRequest(ctx, func() (interface{}, error) {
+		return GetV5UserById(client, userId)
+	})
+	if err != nil {
+		return diag.Errorf("error waiting for user (%s) to be created: %s", userId, err)
+	}
+
 	return resourceV5UserRead(ctx, d, meta)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For current V5 IAM resources, there are already have the same problems about 404 error returns after resource create completed.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. v5 resources support poll interval after create completed
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5Policy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5Policy_basic -timeout 360m -parallel 10
=== RUN   TestAccV5Policy_basic
=== PAUSE TestAccV5Policy_basic
=== CONT  TestAccV5Policy_basic
--- PASS: TestAccV5Policy_basic (67.29s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       67.481s coverage: 3.4% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
