### PR TITLE
fix(cciv2): fixed error caused by the automatic sorting of `TypeSet` parameters

### DIFF
--- a/huaweicloud/services/acceptance/cci/resource_huaweicloud_cciv2_pod_test.go
+++ b/huaweicloud/services/acceptance/cci/resource_huaweicloud_cciv2_pod_test.go
@@ -44,10 +44,26 @@ func TestAccV2Pod_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "containers.0.image", "nginx:stable-alpine-perl"),
 					resource.TestCheckResourceAttr(resourceName, "containers.0.name", "c1"),
+					resource.TestCheckResourceAttr(resourceName, "containers.0.command.0", "nginx"),
+					resource.TestCheckResourceAttr(resourceName, "containers.0.command.1", "-c"),
+					resource.TestCheckResourceAttr(resourceName, "containers.0.command.2", "/etc/nginx/nginx.conf"),
+					resource.TestCheckResourceAttr(resourceName, "containers.0.args.0", "-g"),
+					resource.TestCheckResourceAttr(resourceName, "containers.0.args.1", "daemon off;"),
+					resource.TestCheckResourceAttr(resourceName, "containers.0.startup_probe.0.exec.0.command.0", "sh"),
+					resource.TestCheckResourceAttr(resourceName, "containers.0.startup_probe.0.exec.0.command.1", "-c"),
+					resource.TestCheckResourceAttr(resourceName, "containers.0.startup_probe.0.exec.0.command.2", "exit 0"),
 					resource.TestCheckResourceAttr(resourceName, "containers.0.resources.0.limits.cpu", "2"),
 					resource.TestCheckResourceAttr(resourceName, "containers.0.resources.0.limits.memory", "2G"),
 					resource.TestCheckResourceAttr(resourceName, "containers.0.resources.0.requests.cpu", "2"),
 					resource.TestCheckResourceAttr(resourceName, "containers.0.resources.0.requests.memory", "2G"),
+					resource.TestCheckResourceAttr(resourceName, "init_containers.0.name", "init-first"),
+					resource.TestCheckResourceAttr(resourceName, "init_containers.0.command.0", "sh"),
+					resource.TestCheckResourceAttr(resourceName, "init_containers.0.command.1", "-c"),
+					resource.TestCheckResourceAttr(resourceName, "init_containers.0.command.2", "exit 0"),
+					resource.TestCheckResourceAttr(resourceName, "init_containers.1.name", "init-second"),
+					resource.TestCheckResourceAttr(resourceName, "init_containers.1.command.0", "sh"),
+					resource.TestCheckResourceAttr(resourceName, "init_containers.1.command.1", "-c"),
+					resource.TestCheckResourceAttr(resourceName, "init_containers.1.command.2", "exit 0"),
 					resource.TestCheckResourceAttr(resourceName, "image_pull_secrets.0.name", "imagepull-secret"),
 					resource.TestCheckResourceAttrSet(resourceName, "annotations.%"),
 				),
@@ -56,7 +72,7 @@ func TestAccV2Pod_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"annotations", "containers"},
+				ImportStateVerifyIgnore: []string{"annotations", "containers", "resource_version", "status"},
 				ImportStateIdFunc:       testAccV2PodImportStateFunc(resourceName),
 			},
 		},
@@ -77,6 +93,69 @@ func testAccV2PodImportStateFunc(name string) resource.ImportStateIdFunc {
 	}
 }
 
+func testAccV2Pod_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
+data "huaweicloud_vpcep_service_summary" "swr" {
+  endpoint_service_name = "com.myhuaweicloud.cn-north-4.swr"
+}
+
+data "huaweicloud_vpcep_service_summary" "obs" {
+  endpoint_service_name = "cn-north-4.com.myhuaweicloud.v4.obsv2.OBSCluster9"
+}
+
+resource "huaweicloud_vpcep_endpoint" "swr" {
+  service_id = data.huaweicloud_vpcep_service_summary.swr.id
+  vpc_id     = huaweicloud_vpc.test.id
+  network_id = huaweicloud_vpc_subnet.test.id
+  enable_dns = true
+}
+
+resource "huaweicloud_vpcep_endpoint" "obs" {
+  service_id = data.huaweicloud_vpcep_service_summary.obs.id
+  vpc_id     = huaweicloud_vpc.test.id
+  enable_dns = true
+}
+
+resource "huaweicloud_cciv2_namespace" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_cciv2_network" "test" {
+  namespace = huaweicloud_cciv2_namespace.test.name
+  name      = "%[1]s"
+
+  annotations = {
+    "yangtse.io/project-id"                 = huaweicloud_cciv2_namespace.test.annotations["tenant.kubernetes.io/project-id"],
+    "yangtse.io/domain-id"                  = huaweicloud_cciv2_namespace.test.annotations["tenant.kubernetes.io/domain-id"],
+    "yangtse.io/warm-pool-size"             = "10",
+    "yangtse.io/warm-pool-recycle-interval" = "2",
+  }
+
+  subnets {
+    subnet_id = huaweicloud_vpc_subnet.test.subnet_id
+  }
+
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+}
+`, rName)
+}
+
 func testAccV2Pod_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -94,8 +173,54 @@ resource "huaweicloud_cciv2_pod" "test" {
   }
 
   containers {
-    image = "nginx:stable-alpine-perl"
-    name  = "c1"
+    image   = "nginx:stable-alpine-perl"
+    name    = "c1"
+    command = ["nginx", "-c", "/etc/nginx/nginx.conf"]
+    args    = ["-g", "daemon off;"]
+
+    startup_probe {
+      exec {
+        command = ["sh", "-c", "exit 0"]
+      }
+
+      termination_grace_period_seconds = 30
+    }
+
+    resources {
+      limits = {
+        cpu    = 2
+        memory = "2G"
+      }
+
+      requests = {
+        cpu    = 2
+        memory = "2G"
+      }
+    }
+  }
+
+  init_containers {
+    image   = "nginx:stable-alpine-perl"
+    name    = "init-first"
+    command = ["sh", "-c", "exit 0"]
+
+    resources {
+      limits = {
+        cpu    = 2
+        memory = "2G"
+      }
+
+      requests = {
+        cpu    = 2
+        memory = "2G"
+      }
+    }
+  }
+
+  init_containers {
+    image   = "nginx:stable-alpine-perl"
+    name    = "init-second"
+    command = ["sh", "-c", "exit 0"]
 
     resources {
       limits = {
@@ -120,5 +245,5 @@ resource "huaweicloud_cciv2_pod" "test" {
     ]
   }
 }
-`, testAccV2Network_basic(rName), rName)
+`, testAccV2Pod_base(rName), rName)
 }

--- a/huaweicloud/services/cci/resource_huaweicloud_cciv2_pod.go
+++ b/huaweicloud/services/cci/resource_huaweicloud_cciv2_pod.go
@@ -174,7 +174,7 @@ func ResourceV2Pod() *schema.Resource {
 				},
 			},
 			"init_containers": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
 				Elem:        podContainersSchema(),
@@ -590,14 +590,14 @@ func podContainersSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"args": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `Specifies the arguments to the entrypoint of the container.`,
 			},
 			"command": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -1082,7 +1082,7 @@ func podContainersLifecycleHandlerExecSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"command": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -1361,7 +1361,7 @@ func buildCreateV2PodParams(d *schema.ResourceData) map[string]interface{} {
 			"hostAliases":                   buildV2PodHostAliasesParams(d.Get("host_aliases").(*schema.Set).List()),
 			"hostname":                      utils.ValueIgnoreEmpty(d.Get("hostname")),
 			"imagePullSecrets":              buildImagePullSecretsParams(d.Get("image_pull_secrets").(*schema.Set).List()),
-			"initContainers":                buildV2PodContainersParams(d.Get("init_containers").(*schema.Set).List()),
+			"initContainers":                buildV2PodContainersParams(d.Get("init_containers").([]interface{})),
 			"nodeName":                      utils.ValueIgnoreEmpty(d.Get("node_name")),
 			"overhead":                      utils.ValueIgnoreEmpty(d.Get("overhead")),
 			"readinessGates":                buildV2PodReadinessGatesParams(d.Get("readiness_gates").(*schema.Set).List()),
@@ -1665,8 +1665,8 @@ func buildV2PodContainersParams(containers []interface{}) []interface{} {
 	containersParams := make([]interface{}, len(containers))
 	for i, v := range containers {
 		container := utils.RemoveNil(map[string]interface{}{
-			"args":                     utils.ValueIgnoreEmpty(utils.PathSearch("args", v, &schema.Set{}).(*schema.Set).List()),
-			"command":                  utils.ValueIgnoreEmpty(utils.PathSearch("command", v, &schema.Set{}).(*schema.Set).List()),
+			"args":                     utils.ValueIgnoreEmpty(utils.PathSearch("args", v, make([]interface{}, 0)).([]interface{})),
+			"command":                  utils.ValueIgnoreEmpty(utils.PathSearch("command", v, make([]interface{}, 0)).([]interface{})),
 			"name":                     utils.ValueIgnoreEmpty(utils.PathSearch("name", v, nil)),
 			"image":                    utils.ValueIgnoreEmpty(utils.PathSearch("image", v, nil)),
 			"stdin":                    utils.ValueIgnoreEmpty(utils.PathSearch("stdin", v, nil)),
@@ -1831,7 +1831,7 @@ func buildPodContainersLifecycleHandlerExecParams(exec interface{}) map[string]i
 		return nil
 	}
 	return map[string]interface{}{
-		"command": utils.PathSearch("command", exec, &schema.Set{}).(*schema.Set).List(),
+		"command": utils.PathSearch("command", exec, make([]interface{}, 0)).([]interface{}),
 	}
 }
 
@@ -2594,10 +2594,12 @@ func resourceV2PodImportState(_ context.Context, d *schema.ResourceData,
 		return nil, fmt.Errorf("invalid format specified for import ID, want '<namespace>/<name>', but '%s'", importedId)
 	}
 
-	d.Set("namespace", parts[0])
-	d.Set("name", parts[1])
+	mErr := multierror.Append(nil,
+		d.Set("namespace", parts[0]),
+		d.Set("name", parts[1]),
+	)
 
-	return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }
 
 func GetV2Pod(client *golangsdk.ServiceClient, namespace, name string) (interface{}, error) {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Parameters `command` and `args` are currently of the `Set` type, when the API is called, the `Set` is automatically sorted, causing execution errors due to this reordering. As follows:
<img width="1048" height="647" alt="image" src="https://github.com/user-attachments/assets/127ea879-8723-4fa2-a73d-eb0abcf5746b" />


After the parameter type was changed from `Set` to `List`:
<img width="1487" height="671" alt="Snipaste_2026-09-07_11-52-28" src="https://github.com/user-attachments/assets/ef67b949-da98-49ce-b61c-0463e8f66504" />


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #10487

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

fixed error caused by the automatic sorting of `TypeSet` parameters

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccV2Pod_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccV2Pod_basic -timeout 360m -parallel 4
=== RUN   TestAccV2Pod_basic
=== PAUSE TestAccV2Pod_basic
=== CONT  TestAccV2Pod_basic
--- PASS: TestAccV2Pod_basic (143.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       143.127s


$ make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccDataSourceV2Pods_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccDataSourceV2Pods_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceV2Pods_basic
=== PAUSE TestAccDataSourceV2Pods_basic
=== CONT  TestAccDataSourceV2Pods_basic
--- PASS: TestAccDataSourceV2Pods_basic (145.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       145.503s

```
<img width="1320" height="755" alt="image" src="https://github.com/user-attachments/assets/1775afe2-9bbc-4ae3-ab9e-a583cb2639b1" />


* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
