### PR TITLE
feat(ModelArts): add new data source to query the available subnets

### DIFF
--- a/docs/data-sources/modelarts_network_available_subnets.md
+++ b/docs/data-sources/modelarts_network_available_subnets.md
@@ -1,0 +1,61 @@
+---
+subcategory: "ModelArts"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_network_available_subnets"
+description: |-
+  Use this data source to query the available subnets of a network within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_network_available_subnets
+
+Use this data source to query the available subnets of a network within HuaweiCloud.
+
+-> When other resources refer to this data source, any operations other than the creation operation  
+  should use `ignore_changes` to ignore the reference to the results of this data source.
+
+## Example Usage
+
+```hcl
+variable "network_name" {}
+variable "subnet_id" {}
+
+data "huaweicloud_modelarts_network_available_subnets" "test" {
+  network_name = var.network_name
+  subnet_id    = var.subnet_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.  
+  If omitted, the provider-level region will be used.
+
+* `network_name` - (Required, String) Specifies the network ID.
+
+* `subnet_id` - (Required, String) Specifies the subnet ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `name` - The subnet name.
+
+* `network_id` - The subnet ID.
+
+* `subnets` - The number of available network IP addresses of the subnet.  
+  The [subnets](#modelarts_network_available_subnets_struct) structure is documented below.
+
+<a name="modelarts_network_available_subnets_struct"></a>
+The `subnets` block supports:
+
+* `cidr` - The CIDR of the subnet.
+
+* `ip_version` - The IP address type.
+
+* `used_ips` - The number of used IP addresses.
+
+* `total_ips` - The total number of IP addresses in the subnet.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2204,6 +2204,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_devserver_plugins":              modelarts.DataSourceDevServerPlugins(),
 			"huaweicloud_modelarts_model_templates":                modelarts.DataSourceModelTemplates(),
 			"huaweicloud_modelarts_models":                         modelarts.DataSourceModels(),
+			"huaweicloud_modelarts_network_available_subnets":      modelarts.DataSourceNetworkAvailableSubnets(),
 			"huaweicloud_modelarts_networks":                       modelarts.DataSourceNetworks(),
 			"huaweicloud_modelarts_notebook_flavors":               modelarts.DataSourceNotebookFlavors(),
 			"huaweicloud_modelarts_notebook_images":                modelarts.DataSourceNotebookImages(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -646,6 +646,8 @@ var (
 	HW_MODELARTS_WORKFLOW_ID                                 = os.Getenv("HW_MODELARTS_WORKFLOW_ID")
 	HW_MODELARTS_WORKFLOW_SUBSCRIPTION_ID                    = os.Getenv("HW_MODELARTS_WORKFLOW_SUBSCRIPTION_ID")
 	HW_MODELARTS_WORKFLOW_ITEM_VERSION_ID                    = os.Getenv("HW_MODELARTS_WORKFLOW_ITEM_VERSION_ID")
+	HW_MODELARTS_NETWORK_NAME                                = os.Getenv("HW_MODELARTS_NETWORK_NAME")
+	HW_MODELARTS_SUBNET_ID                                   = os.Getenv("HW_MODELARTS_SUBNET_ID")
 
 	HW_AOM_ALARM_EVENT_SN                        = os.Getenv("HW_AOM_ALARM_EVENT_SN")
 	HW_AOM_INSTALLER_AGENT_ID                    = os.Getenv("HW_AOM_INSTALLER_AGENT_ID")
@@ -3748,6 +3750,13 @@ func TestAccPreCheckModelArtsTrainingJobPublicResourcePoolFlavorID(t *testing.T)
 func TestAccPreCheckModelArtsWorkflowSubscription(t *testing.T) {
 	if HW_MODELARTS_WORKFLOW_SUBSCRIPTION_ID == "" || HW_MODELARTS_WORKFLOW_ITEM_VERSION_ID == "" {
 		t.Skip("HW_MODELARTS_WORKFLOW_SUBSCRIPTION_ID and HW_MODELARTS_WORKFLOW_ITEM_VERSION_ID must be set for ModelArts Workflow acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckModelArtsNetworkAvailableSubnets(t *testing.T) {
+	if HW_MODELARTS_NETWORK_NAME == "" || HW_MODELARTS_SUBNET_ID == "" {
+		t.Skip("HW_MODELARTS_NETWORK_NAME and HW_MODELARTS_SUBNET_ID must be set for ModelArts the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_network_available_subnets_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_network_available_subnets_test.go
@@ -1,0 +1,50 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataNetworkAvailableSubnets_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_modelarts_network_available_subnets.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsNetworkAvailableSubnets(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataNetworkAvailableSubnets_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "name"),
+					resource.TestCheckResourceAttrSet(dataSource, "network_id"),
+					resource.TestMatchResourceAttr(dataSource, "subnets.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(dataSource, "subnets.0.cidr"),
+					resource.TestCheckResourceAttrSet(dataSource, "subnets.0.ip_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "subnets.0.used_ips"),
+					resource.TestCheckResourceAttrSet(dataSource, "subnets.0.total_ips"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataNetworkAvailableSubnets_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelarts_network_available_subnets" "test" {
+  network_name = "%[1]s"
+  subnet_id    = "%[2]s"
+}
+`, acceptance.HW_MODELARTS_NETWORK_NAME, acceptance.HW_MODELARTS_SUBNET_ID)
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_network_available_subnets.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_network_available_subnets.go
@@ -1,0 +1,179 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v1/{project_id}/networks/{network_name}/network-ip-availabilities
+func DataSourceNetworkAvailableSubnets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNetworkAvailableSubnetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"network_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the network ID.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the subnet ID.`,
+			},
+
+			// Attributes.
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subnet name.`,
+			},
+			"network_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subnet ID.`,
+			},
+			"subnets": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The number of available network IP addresses of the subnet.`,
+				Elem:        networkAvailableSubnetsSchema(),
+			},
+		},
+	}
+}
+
+func networkAvailableSubnetsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cidr": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cidr of the subnet.`,
+			},
+			"ip_version": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The IP address type.`,
+			},
+			"used_ips": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of used IP addresses.`,
+			},
+			"total_ips": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of IP addresses in the subnet.`,
+			},
+		},
+	}
+}
+
+func buildNetworkAvailableSubnetsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("subnet_id"); ok {
+		res = fmt.Sprintf("%s?network_id=%v", res, v)
+	}
+
+	return res
+}
+
+func listNetworkAvailableSubnets(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, string, string, error) {
+	httpUrl := "v1/{project_id}/networks/{network_name}/network-ip-availabilities"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{network_name}", d.Get("network_name").(string))
+	listPath += buildNetworkAvailableSubnetsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	subnetName := utils.PathSearch("name", respBody, "").(string)
+	subnetId := utils.PathSearch("networkId", respBody, "").(string)
+	ipAddresses := utils.PathSearch("subnetIpAvailability", respBody, make([]interface{}, 0)).([]interface{})
+
+	return ipAddresses, subnetName, subnetId, nil
+}
+
+func dataSourceNetworkAvailableSubnetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	ipAddresses, subnetName, subnetId, err := listNetworkAvailableSubnets(client, d)
+	if err != nil {
+		return diag.Errorf("error querying network available subnets: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", subnetName),
+		d.Set("network_id", subnetId),
+		d.Set("subnets", flattenNetworkAvailableSubnets(ipAddresses)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenNetworkAvailableSubnets(ipAddresses []interface{}) []map[string]interface{} {
+	if len(ipAddresses) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(ipAddresses))
+	for _, v := range ipAddresses {
+		result = append(result, map[string]interface{}{
+			"cidr":       utils.PathSearch("cidr", v, nil),
+			"ip_version": utils.PathSearch("ipVersion", v, nil),
+			"used_ips":   utils.PathSearch("usedIps", v, nil),
+			"total_ips":  utils.PathSearch("totalIps", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query the available subnets.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to query the available subnets.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o modelarts -f TestAccDataNetworkAvailableSubnets_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataNetworkAvailableSubnets_basic -timeout 360m -parallel 10
=== RUN   TestAccDataNetworkAvailableSubnets_basic
=== PAUSE TestAccDataNetworkAvailableSubnets_basic
=== CONT  TestAccDataNetworkAvailableSubnets_basic
--- PASS: TestAccDataNetworkAvailableSubnets_basic (7.06s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 7.268s  coverage: 5.4% of statements in ./huaweicloud/services/modelarts
```
<img width="1040" height="17" alt="image" src="https://github.com/user-attachments/assets/75e6f01d-f898-45c3-9b0d-a339daea1897" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
