### PR TITLE
feat(waf): support `waf_vulnerability_rules` data source

### DIFF
--- a/docs/data-sources/waf_vulnerability_rules.md
+++ b/docs/data-sources/waf_vulnerability_rules.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_vulnerability_rules"
+description: |-
+  Use this data source to get the list of WAF vulnerability rules within HuaweiCloud.
+---
+
+# huaweicloud_waf_vulnerability_rules
+
+Use this data source to get the list of WAF vulnerability rules within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_waf_vulnerability_rules" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID used for filtering.
+  If you need to query the resources bound to all enterprise projects of the current user, set this parameter to
+  **all_granted_eps**. The default value is **0**, indicating the default enterprise project.
+
+* `from` - (Optional, Int) Specifies the start time used for filtering, in 13-digit millisecond timestamp.
+  This parameter must be used together with `to`.
+
+* `to` - (Optional, Int) Specifies the end time used for filtering, in 13-digit millisecond timestamp.
+  This parameter must be used together with `from`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The vulnerability rule list.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `vulnerability_id` - The vulnerability ID.
+
+* `description` - The vulnerability description.
+
+* `rule_ids` - The list of protectable rule IDs.
+
+* `create_time` - The creation time of the vulnerability intelligence, in milliseconds.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2915,6 +2915,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_source_ips":                           waf.DataSourceWafSourceIps(),
 			"huaweicloud_waf_tag_antileakage_map":                  waf.DataSourceTagAntileakageMap(),
 			"huaweicloud_waf_tag_ip_reputation_map":                waf.DataSourceTagIpReputationMap(),
+			"huaweicloud_waf_vulnerability_rules":                  waf.DataSourceVulnerabilityRules(),
 			"huaweicloud_waf_web_basic_protection_rules":           waf.DataSourceWafWebBasicProtectionRules(),
 			"huaweicloud_waf_security_report_sending_records":      waf.DataSourceWafSecurityReportSendingRecords(),
 			"huaweicloud_waf_protectable_resources":                waf.DataSourceWafProtectables(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_vulnerability_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_vulnerability_rules_test.go
@@ -1,0 +1,69 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVulnerabilityRules_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_waf_vulnerability_rules.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceVulnerabilityRules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "items.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.vulnerability_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.rule_ids.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.create_time"),
+					resource.TestCheckOutput("time_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceVulnerabilityRules_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_waf_vulnerability_rules" "test" {
+  enterprise_project_id = "%[1]s"
+}
+
+# Filter by from and to.
+locals {
+  create_time = data.huaweicloud_waf_vulnerability_rules.test.items[0].create_time
+}
+
+data "huaweicloud_waf_vulnerability_rules" "filter_by_time" {
+  enterprise_project_id = "%[1]s"
+  from                  = local.create_time
+  to                    = local.create_time
+}
+
+locals {
+  time_filter_result = [
+    for v in data.huaweicloud_waf_vulnerability_rules.filter_by_time.items[*].create_time : v == local.create_time
+  ]
+}
+
+output "time_filter_is_useful" {
+  value = alltrue(local.time_filter_result) && length(local.time_filter_result) > 0
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_vulnerability_rules.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_vulnerability_rules.go
@@ -1,0 +1,183 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/vulnerability/notification
+func DataSourceVulnerabilityRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVulnerabilityRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"from": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"to": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     vulnerabilityRuleItemSchema(),
+			},
+		},
+	}
+}
+
+func vulnerabilityRuleItemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"vulnerability_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rule_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildVulnerabilityRulesQueryParams(d *schema.ResourceData, cfg *config.Config, limit, offset int) string {
+	queryParams := fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+
+	epsId := cfg.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	if v, ok := d.GetOk("from"); ok {
+		queryParams = fmt.Sprintf("%s&from=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("to"); ok {
+		queryParams = fmt.Sprintf("%s&to=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceVulnerabilityRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/vulnerability/notification"
+		product = "waf"
+		limit   = 1000
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	for {
+		currentPath := requestPath + buildVulnerabilityRulesQueryParams(d, cfg, limit, offset)
+		resp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving WAF vulnerability rules: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		items := flattenVulnerabilityRulesRespBody(respBody)
+		if len(items) == 0 {
+			break
+		}
+
+		result = append(result, items...)
+		if len(items) < limit {
+			break
+		}
+
+		offset += limit
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", flattenVulnerabilityRulesItems(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenVulnerabilityRulesRespBody(respBody interface{}) []interface{} {
+	if items, ok := respBody.([]interface{}); ok {
+		return items
+	}
+
+	return make([]interface{}, 0)
+}
+
+func flattenVulnerabilityRulesItems(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"vulnerability_id": utils.PathSearch("vulnerability_id", v, nil),
+			"description":      utils.PathSearch("description", v, nil),
+			"rule_ids": utils.ExpandToStringList(
+				utils.PathSearch("rule_ids", v, make([]interface{}, 0)).([]interface{})),
+			"create_time": utils.PathSearch("create_time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_vulnerability_rules` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_vulnerability_rules` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o waf -f TestAccDataSourceVulnerabilityRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceVulnerabilityRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceVulnerabilityRules_basic
=== PAUSE TestAccDataSourceVulnerabilityRules_basic
=== CONT  TestAccDataSourceVulnerabilityRules_basic
--- PASS: TestAccDataSourceVulnerabilityRules_basic (9.34s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       9.466s  coverage: 4.2% of statements in ./huaweicloud/services/waf

```
<img width="904" height="38" alt="image" src="https://github.com/user-attachments/assets/167a2967-e719-4001-9cea-327001f09d2d" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
