### PR TITLE
feat(dcs): add new data source to query replications

### DIFF
--- a/docs/data-sources/dcs_replications.md
+++ b/docs/data-sources/dcs_replications.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Distributed Cache Service (DCS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dcs_replications"
+description: |-
+  Use this data source to query the replications information.
+---
+
+# huaweicloud_dcs_replications
+
+Use this data source to query the replications information.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_id" {}
+
+data "huaweicloud_dcs_replications" "test" {
+  instance_id = var.instance_id
+  group_id    = var.group_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the DCS instance.
+
+* `group_id` - (Required, String) Specifies the ID of the shard.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `replications` - Indicates the list of replication.
+  The [replications](#dcs_replications_replications_struct) structure is documented below.
+
+<a name="dcs_replications_replications_struct"></a>
+The `replications` block supports:
+
+* `id` - Indicates the ID of the replication.
+
+* `role` - Indicates the role of the replication.
+
+* `replication_ip` - Indicates the IP address of the replication.
+
+* `is_replication` - Whether the replica is newly added.
+
+* `node_id` - Indicates the ID of the node.
+
+* `status` - Indicates the status of the replication.
+
+* `az_code` - Indicates the availability zone where the replication located.
+
+* `dimensions` - Indicates the corresponding monitoring indicator dimension information of the replication.
+  The [dimensions](#dcs_replications_dimensions_struct) structure is documented below.
+
+<a name="dcs_replications_dimensions_struct"></a>
+The `dimensions` block supports:
+
+* `name` - Indicates the monitoring dimension name.
+
+* `value` - Indicates the dimension value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1218,6 +1218,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_center_tasks":                        dcs.DataSourceDcsCenterTasks(),
 			"huaweicloud_dcs_redis_log_download_link":             dcs.DataSourceDcsRedisLogDownloadLink(),
 			"huaweicloud_dcs_redis_run_logs":                      dcs.DataSourceDcsRedisRunLogs(),
+			"huaweicloud_dcs_replications":                        dcs.DataSourceReplications(),
 			"huaweicloud_dcs_secondary_dim_monitored_objects":     dcs.DataSourceDcsSecondaryDimMonitoredObjects(),
 			"huaweicloud_dcs_ssl_cert_download":                   dcs.DataSourceDcsSslCertDownload(),
 			"huaweicloud_dcs_instance_parameter_modify_records":   dcs.DataSourceInstanceParameterModifyRecords(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -820,6 +820,7 @@ var (
 	HW_DWS_OBS_AGENCY_NAMES = os.Getenv("HW_DWS_OBS_AGENCY_NAMES")
 
 	HW_DCS_INSTANCE_ID        = os.Getenv("HW_DCS_INSTANCE_ID")
+	HW_DCS_GROUP_ID           = os.Getenv("HW_DCS_GROUP_ID")
 	HW_DCS_BEGIN_TIME         = os.Getenv("HW_DCS_BEGIN_TIME")
 	HW_DCS_END_TIME           = os.Getenv("HW_DCS_END_TIME")
 	HW_DCS_OBS_BUCKET_NAME    = os.Getenv("HW_DCS_OBS_BUCKET_NAME")
@@ -4609,6 +4610,13 @@ func TestAccPreCheckDwsExtDataSourceAgencyNames(t *testing.T) {
 func TestAccPreCheckDCSInstanceID(t *testing.T) {
 	if HW_DCS_INSTANCE_ID == "" {
 		t.Skip("HW_DCS_INSTANCE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDcsGroupId(t *testing.T) {
+	if HW_DCS_GROUP_ID == "" {
+		t.Skip("HW_DCS_GROUP_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_replications_test.go
+++ b/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_replications_test.go
@@ -1,0 +1,49 @@
+package dcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceReplications_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_dcs_replications.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDCSInstanceID(t)
+			acceptance.TestAccPreCheckDcsGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceReplications_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replications.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replications.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replications.0.replication_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replications.0.is_replication"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replications.0.node_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replications.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceReplications_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dcs_replications" "test" {
+  instance_id = "%[1]s"
+  group_id    = "%[2]s"
+}
+`, acceptance.HW_DCS_INSTANCE_ID, acceptance.HW_DCS_GROUP_ID)
+}

--- a/huaweicloud/services/dcs/data_source_huaweicloud_dcs_replications.go
+++ b/huaweicloud/services/dcs/data_source_huaweicloud_dcs_replications.go
@@ -1,0 +1,194 @@
+package dcs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DCS GET /v2/{project_id}/instance/{instance_id}/groups/{group_id}/group-nodes-state
+func DataSourceReplications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceReplicationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the DCS instance.`,
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the shard.`,
+			},
+			"replications": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the list of replications.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the ID of the replication.`,
+						},
+						"role": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the role of the replication.`,
+						},
+						"replication_ip": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the IP address of the replication.`,
+						},
+						"is_replication": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the replica is newly added.`,
+						},
+						"node_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the ID of the node.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the status of the replication.`,
+						},
+						"az_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the availability zone where the replication located.`,
+						},
+						"dimensions": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `Indicates the corresponding monitoring indicator dimension information of the replication.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Indicates the monitoring dimension name.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Indicates the dimension value.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceReplicationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/instance/{instance_id}/groups/{group_id}/group-nodes-state"
+		instanceId = d.Get("instance_id").(string)
+		groupId    = d.Get("group_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dcs", region)
+	if err != nil {
+		return diag.Errorf("error creating DCS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{group_id}", groupId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the DCS instance replication state information: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("replications", flattenReplications(
+			utils.PathSearch("[*]", getRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenReplications(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("replication_id", v, nil),
+			"role":           utils.PathSearch("replication_role", v, nil),
+			"replication_ip": utils.PathSearch("replication_ip", v, nil),
+			"is_replication": utils.PathSearch("is_replication", v, nil),
+			"node_id":        utils.PathSearch("node_id", v, nil),
+			"status":         utils.PathSearch("status", v, nil),
+			"az_code":        utils.PathSearch("az_code", v, nil),
+			"dimensions":     flattenReplicationDimensions(utils.PathSearch("dimensions", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenReplicationDimensions(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("name", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query replications.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to  query replications.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o dcs -f TestAccDatasourceReplications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dcs" -v -coverprofile="./huaweicloud/services/acceptance/dcs/dcs_coverage.cov" -coverpkg="./huaweicloud/services/dcs" -run TestAccDatasourceReplications_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceReplications_basic
=== PAUSE TestAccDatasourceReplications_basic
=== CONT  TestAccDatasourceReplications_basic
--- PASS: TestAccDatasourceReplications_basic (11.36s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/dcs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       11.552s coverage: 3.4% of statements in ./huaweicloud/services/dcs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
