### PR TITLE
fix(dc): fix the logic error in `hostedConnectWaitingForStateCompleted`

### DIFF
--- a/huaweicloud/services/dc/resource_huaweicloud_dc_hosted_connect.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_hosted_connect.go
@@ -7,6 +7,7 @@ package dc
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -193,22 +194,23 @@ func hostedConnectWaitingForStateCompleted(ctx context.Context, client *golangsd
 			}
 			status := utils.PathSearch(`hosted_connect.status`, createHostedConnectWaitingRespBody, "").(string)
 
-			targetStatus := []string{
-				"BUILD",
+			successStatus := []string{
+				"ACTIVE",
 			}
-			if utils.StrSliceContains(targetStatus, status) {
+			if utils.StrSliceContains(successStatus, status) {
 				return createHostedConnectWaitingRespBody, "COMPLETED", nil
 			}
 
-			pendingStatus := []string{
-				"PENDING_CREATE",
-				"PENDING_UPDATE",
+			errorStatus := []string{
+				"DOWN",
+				"ERROR",
 			}
-			if utils.StrSliceContains(pendingStatus, status) {
-				return createHostedConnectWaitingRespBody, "PENDING", nil
+			if utils.StrSliceContains(errorStatus, status) {
+				return createHostedConnectWaitingRespBody, "ERROR",
+					fmt.Errorf("DC hosted connect is in (%s) status", status)
 			}
 
-			return createHostedConnectWaitingRespBody, status, nil
+			return createHostedConnectWaitingRespBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
@@ -397,20 +399,7 @@ func deleteHostedConnectWaitingForStateCompleted(ctx context.Context, client *go
 				return nil, "ERROR", err
 			}
 
-			deleteHostedConnectWaitingRespBody, err := utils.FlattenResponse(deleteHostedConnectWaitingResp)
-			if err != nil {
-				return nil, "ERROR", err
-			}
-			status := utils.PathSearch(`hosted_connect.status`, deleteHostedConnectWaitingRespBody, "").(string)
-
-			pendingStatus := []string{
-				"PENDING_DELETE",
-			}
-			if utils.StrSliceContains(pendingStatus, status) {
-				return deleteHostedConnectWaitingRespBody, "PENDING", nil
-			}
-
-			return deleteHostedConnectWaitingRespBody, status, nil
+			return deleteHostedConnectWaitingResp, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Cause of the error:
(Resource: huaweicloud_dc_hosted_connectProvider Version: >= 1.96.0Terraform Version: 1.15.8Region: la-south-2
The resource is successfully created and updated through the Direct Connect API, however the Terraform provider fails during the waiter phase because it expects the final state to be "COMPLETED" while the API returns "ACTIVE" as the final operational state.
Impact:- Successfully created resources are marked as tainted.- Every subsequent terraform plan attempts to replace the resource.- This creates a continuous create -> waiter failure -> tainted loop.- Resource lifecycle management becomes unreliable.- Manual intervention is required after every apply.
However, this prevents Terraform from properly managing updates and is not a sustainable solution.)


Remediation Plan:
I have confirmed with cloud service experts that both `BUILD` and `PENDING_CREATE` are intermediate states following the invocation of the creation API. The resource is only considered successfully created once it reaches the `ACTIVE` state. Both `DOWN` and `ERROR` indicate resource anomalies.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

fix the logic error in `hostedConnectWaitingForStateCompleted`

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
This resource needs other user's tenant_id and host_id, so test cases cannot be executed.
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
