### PR TITLE
feat(waf): add new data source to query all rules

### DIFF
--- a/docs/data-sources/waf_rules.md
+++ b/docs/data-sources/waf_rules.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_rules"
+description: |-
+  Use this data source to query protection rules of a specified type in all policies.
+---
+
+# huaweicloud_waf_rules
+
+Use this data source to query protection rules of a specified type in all policies.
+
+## Example Usage
+
+```hcl
+variable "rule_type" {}
+
+data "huaweicloud_waf_rules" "test" {
+  rule_type = var.rule_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the rules.
+  If omitted, the provider-level region will be used.
+
+* `rule_type` - (Required, String) Specifies the type of the rules to be queried.
+  The valid values are as follows:
+  + **cc**: Indicates CC attack protection.
+  + **custom**: Indicates precise protection rules.
+  + **whiteblackip**: Indicates blacklist and whitelist.
+  + **geoip**: Indicates geolocation-based protection.
+  + **ip-reputation**: Indicates threat intelligence.
+  + **antitamper**: Indicates anti-tamper events.
+  + **antileakage**: Indicates sensitive information leakage prevention.
+  + **ignore**: Indicates global protection whitelist.
+  + **privacy**: Indicates privacy masking.
+
+* `policy_ids` - (Optional, String) Specifies the ID list of the policies to be queried.
+  Multiple policy IDs are separated by commas (,).
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the rules belong.
+  If you want to query resources under all enterprise projects, set this parameter to **all_granted_eps**.
+  Defaults to **0**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - All rules that matched the filter parameters.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2867,6 +2867,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_all_ip_reputation_policy_rules":       waf.DataSourceAllIpReputationPolicyRules(),
 			"huaweicloud_waf_all_domains":                          waf.DataSourceWafAllDomains(),
 			"huaweicloud_waf_all_precise_protection_rules":         waf.DataSourceAllPreciseProtectionRules(),
+			"huaweicloud_waf_rules":                                waf.DataSourceRules(),
 			"huaweicloud_waf_all_web_antitamper_rules":             waf.DataSourceAllWebAntitamperRules(),
 			"huaweicloud_waf_all_whiteblackip_rules":               waf.DataSourceAllWhiteblackipRules(),
 			"huaweicloud_waf_bundle":                               waf.DataSourceUserBundle(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_rules_test.go
@@ -1,0 +1,77 @@
+package waf
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// If you want query the rules outside of the default enterprise project,
+// please configuration the corresponding enterprise project ID.
+func TestAccDataSourceRules_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "rules.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+
+					resource.TestCheckOutput("policy_ids_filter_is_useful", "true"),
+					resource.TestCheckOutput("eps_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRules_basic() string {
+	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%s"
+}
+
+data "huaweicloud_waf_rules" "test" {
+  rule_type = "cc"
+}
+
+data "huaweicloud_waf_all_policy_cc_rules" "test" {}
+
+locals {
+  policy_id = data.huaweicloud_waf_all_policy_cc_rules.test.items[0].policyid
+}
+
+data "huaweicloud_waf_rules" "filter_by_policy_ids" {
+  rule_type  = "cc"
+  policy_ids = local.policy_id
+}
+
+output "policy_ids_filter_is_useful" {
+  value = length(data.huaweicloud_waf_rules.filter_by_policy_ids.rules) > 0
+}
+
+data "huaweicloud_waf_rules" "filter_by_eps" {
+  rule_type             = "cc"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : "0"
+}
+
+output "eps_filter_is_useful" {
+  value = length(data.huaweicloud_waf_rules.filter_by_eps.rules) > 0
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_rules.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_rules.go
@@ -1,0 +1,151 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/policy/{rule_type}/rules
+func DataSourceRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the rules.`,
+			},
+			"rule_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the type of the rules to be queried.`,
+			},
+			"policy_ids": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID list of the policies to be queried.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the enterprise project ID to which the rules belong.`,
+			},
+			"rules": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `All rules that matched the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildListRulesQueryParams(policyIds, epsId string) string {
+	res := "?pagesize=1000"
+	if policyIds != "" {
+		res = fmt.Sprintf("%s&policyids=%v", res, policyIds)
+	}
+	if epsId != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsId)
+	}
+
+	return res
+}
+
+func listRules(client *golangsdk.ServiceClient, ruleType, policyIds, epsId string) ([]interface{}, error) {
+	var (
+		allRules    []interface{}
+		currentPage = 1
+	)
+
+	httpUrl := "v1/{project_id}/waf/policy/{rule_type}/rules"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{rule_type}", ruleType)
+	listPath += buildListRulesQueryParams(policyIds, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithPage := fmt.Sprintf("%s&page=%d", listPath, currentPage)
+		resp, err := client.Request("GET", requestPathWithPage, &requestOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		rulesResp := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(rulesResp) == 0 {
+			break
+		}
+
+		allRules = append(allRules, rulesResp...)
+		currentPage++
+	}
+
+	return allRules, nil
+}
+
+func dataSourceRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		epsId     = cfg.GetEnterpriseProjectID(d)
+		ruleType  = d.Get("rule_type").(string)
+		policyIds = d.Get("policy_ids").(string)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	allRules, err := listRules(client, ruleType, policyIds, epsId)
+	if err != nil {
+		return diag.Errorf("error retrieving WAF protection rules: %s", err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rules", flattenRules(allRules)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRules(rules []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(rules))
+	for _, v := range rules {
+		rst = append(rst, utils.JsonToString(v))
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query WAF all rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
<img width="883" height="446" alt="image" src="https://github.com/user-attachments/assets/25dec487-689c-40a0-b0f3-1adeb27d5d81" />
<img width="868" height="628" alt="image" src="https://github.com/user-attachments/assets/1c1fee4f-2247-45b5-a7af-3e819880a370" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to query WAF all rules.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o waf -f TestAccDataSourceRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceRules_basic
=== PAUSE TestAccDataSourceRules_basic
=== CONT  TestAccDataSourceRules_basic
--- PASS: TestAccDataSourceRules_basic (12.44s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.756s coverage: 4.9% of statements in ./huaweicloud/services/waf
```
<img width="988" height="19" alt="image" src="https://github.com/user-attachments/assets/f5cc221d-80ee-451a-a0ef-6d4a9aa0ec1d" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
